### PR TITLE
Set jvm params configuration for maven surefire plugin.

### DIFF
--- a/org.uqbar.project.wollok.tests/pom.xml
+++ b/org.uqbar.project.wollok.tests/pom.xml
@@ -117,7 +117,7 @@
 							<forkMode>once</forkMode>
 							<reportFormat>xml</reportFormat>
 							<testClassesDirectory>target/classes</testClassesDirectory>
-							<argLine>-Dfile.encoding=UTF-8</argLine>
+							<argLine>-Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US -Dnl=en</argLine>
 						</configuration>
 						<goals>
 							<goal>test</goal>


### PR DESCRIPTION
When `mvn tests` runs no US location and English language **org.uqbar.project.wollok.tests** fails. So set these arguments in **pom.xml**.