### PR TITLE
Adding support for named objects to inherit from a class

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/namedobjects/NamedObjectInheritanceTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/namedobjects/NamedObjectInheritanceTest.xtend
@@ -1,0 +1,80 @@
+package org.uqbar.project.wollok.tests.interpreter.namedobjects
+
+import org.uqbar.project.wollok.tests.interpreter.AbstractWollokInterpreterTestCase
+import org.junit.Test
+
+/**
+ * Tests named objecst inheriting from a class
+ * 
+ * @author jfernandes
+ */
+class NamedObjectInheritanceTest extends AbstractWollokInterpreterTestCase {
+	
+	@Test
+	def void noExplicitParentMeansObjectSuperclass() {
+		'''
+			object myObject {
+				method something() = "abc"
+			}
+			
+			program p {
+				assert.equals("abc", myObject.something())
+				assert.equals(myObject, (myObject->"42").getX())
+			}
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void objectInheritFromCustomClass() {
+		'''
+			class MyClass {
+				method myMethod() = "1234"
+			}
+			object myObject extends MyClass {
+				method something() = "abc"
+			}
+			
+			program p {
+				assert.equals("abc", myObject.something())
+				assert.equals("1234", myObject.myMethod())
+			}
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void objectInheritFromCustomClassAndOverridesMethod() {
+		'''
+			class MyClass {
+				method myMethod() = "1234"
+			}
+			object myObject extends MyClass {
+				method something() = "abc"
+				override method myMethod() = "5678"
+			}
+			
+			program p {
+				assert.equals("abc", myObject.something())
+				assert.equals("5678", myObject.myMethod())
+			}
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void objectInheritFromCustomClassAndOverridesMethodCallingSuper() {
+		'''
+			class MyClass {
+				method myMethod() = "1234"
+			}
+			object myObject extends MyClass {
+				method something() = "abc"
+				override method myMethod() = super() + "5678"
+			}
+			
+			program p {
+				assert.equals("abc", myObject.something())
+				assert.equals("12345678", myObject.myMethod())
+			}
+		'''.interpretPropagatingErrors
+	}
+	
+}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/formatter/WollokFormatterTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/formatter/WollokFormatterTestCase.xtend
@@ -235,7 +235,9 @@ class Direccion {
 }
 class Client {
 	method blah() {
-		val a = "" val b = 2 val c = new Direccion(a, b, "blah", #[ 1, 2, 3 ])
+		val a = ""
+		val b = 2
+		val c = new Direccion(a, b, "blah", #[ 1, 2, 3 ])
 	}
 }''')
     }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
@@ -311,7 +311,7 @@ WSetLiteral returns WCollectionLiteral:
 	{WSetLiteral} '#' '{' (elements+=WExpression (',' elements+=WExpression )*)? '}';
 
 WNamedObject:
-	'object' name=ID '{'
+	'object' name=ID ('extends' parent=[WClass|QualifiedName])?'{'
 		(members+=WVariableDeclaration ';'?)*
 		(members+=WMethodDeclaration ';'?)*
 	'}'

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting/WollokDslFormatter.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting/WollokDslFormatter.xtend
@@ -22,6 +22,7 @@ import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WTryElements
 import org.eclipse.xtext.service.AbstractElementFinder.AbstractParserRuleElementFinder
 import static extension org.uqbar.project.wollok.utils.StringUtils.firstUpper
 import org.eclipse.xtext.util.ReflectionUtil
+import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WSuperInvocationElements
 
 /**
  * This class contains custom formatting description.
@@ -214,27 +215,27 @@ class WollokDslFormatter extends AbstractDeclarativeFormatter {
 		// wrap before
 		setLinewrap(1, 2, 2).before(objectKeyword_0)
 		
-		setLinewrap.after(leftCurlyBracketKeyword_2)
-		setLinewrap.after(rightCurlyBracketKeyword_5)
+		setLinewrap.after(leftCurlyBracketKeyword_3)
+		setLinewrap.after(rightCurlyBracketKeyword_6)
 		setLinewrap(1, 2, 2).after(group_4)
 		
 		// wrap after var, and method
-		setLinewrap(1, 1, 2).after(getMembersWVariableDeclarationParserRuleCall_3_0_0)
+		setLinewrap(1, 1, 2).after(membersWVariableDeclarationParserRuleCall_4_0_0)
 		setLinewrap(1, 1, 2).after(membersAssignment_4_0)
-		setLinewrap(1, 2, 2).after(membersWMethodDeclarationParserRuleCall_4_0_0)
+		setLinewrap(1, 2, 2).after(membersWMethodDeclarationParserRuleCall_5_0_0)
 		
 		// after all variables
-		setLinewrap(1, 2, 2).after(group_3)
-		
-		// after all methods
 		setLinewrap(1, 2, 2).after(group_4)
 		
+		// after all methods
+		setLinewrap(1, 2, 2).after(group_5)
+		
 		// increase indentation of content
-		setIndentation(leftCurlyBracketKeyword_2, rightCurlyBracketKeyword_5)
+		setIndentation(leftCurlyBracketKeyword_3, rightCurlyBracketKeyword_6)
 		
 		// wrap before and after close bracket
-		setLinewrap(1, 1, 1).before(rightCurlyBracketKeyword_5)
-		setLinewrap(1, 1, 1).after(rightCurlyBracketKeyword_5)
+		setLinewrap(1, 1, 1).before(rightCurlyBracketKeyword_6)
+		setLinewrap(1, 1, 1).after(rightCurlyBracketKeyword_6)
 	}
 	
 	def dispatch formatting(FormattingConfig it, extension WListLiteralElements l) {
@@ -264,6 +265,12 @@ class WollokDslFormatter extends AbstractDeclarativeFormatter {
 		setSpace(' ').after(catchKeyword_0)
 		setLinewrap(1,1,1).before(catchKeyword_0)
 		setLinewrap(1,1,1).around(expressionAssignment_4)
+	}
+	
+	def dispatch formatting(FormattingConfig it, extension WSuperInvocationElements i) {
+		setNoSpace.after(leftParenthesisKeyword_2_0)
+		setNoSpace.before(rightParenthesisKeyword_2_2)
+		setNoSpace.after(superKeyword_1)
 	}
 	
 	// default

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting/WollokDslFormatter.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting/WollokDslFormatter.xtend
@@ -257,6 +257,7 @@ class WollokDslFormatter extends AbstractDeclarativeFormatter {
 	}
 	
 	def dispatch formatting(FormattingConfig it, extension WTryElements i) {
+		setLinewrap(1, 1, 2).before(group)
 		setLinewrap(1, 1, 1).after(tryKeyword_0)
 		setLinewrap(1, 1, 1).after(catchBlocksAssignment_2)
 		

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting/WollokDslFormatter.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting/WollokDslFormatter.xtend
@@ -23,6 +23,8 @@ import org.eclipse.xtext.service.AbstractElementFinder.AbstractParserRuleElement
 import static extension org.uqbar.project.wollok.utils.StringUtils.firstUpper
 import org.eclipse.xtext.util.ReflectionUtil
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WSuperInvocationElements
+import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
+import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WVariableDeclarationElements
 
 /**
  * This class contains custom formatting description.
@@ -65,7 +67,7 @@ class WollokDslFormatter extends AbstractDeclarativeFormatter {
 	}
 	
 	def dispatch formatting(FormattingConfig it, extension WMethodDeclarationElements e) {
-		setLinewrap(1, 1, 2).before(methodKeyword_1)
+		setLinewrap(1, 1, 2).before(group)
 		setLinewrap(1, 1, 1).after(expressionAssignment_7_0)
 		
 		setNoSpace.after(nameAssignment_2)
@@ -271,6 +273,10 @@ class WollokDslFormatter extends AbstractDeclarativeFormatter {
 		setNoSpace.after(leftParenthesisKeyword_2_0)
 		setNoSpace.before(rightParenthesisKeyword_2_2)
 		setNoSpace.after(superKeyword_1)
+	}
+	
+	def dispatch formatting(FormattingConfig it, extension WVariableDeclarationElements i) {
+		setLinewrap(1, 1, 2).after(group)
 	}
 	
 	// default

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/AbstractWollokCallable.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/AbstractWollokCallable.xtend
@@ -90,8 +90,9 @@ abstract class AbstractWollokCallable implements WCallable {
 		declaration.parameters.map[name].createEvaluationContext(values)
 	}
 
-	def dispatch isVoid(Object nativeObject, String message, Object... parameters){
-		var method = this.class.methods.findFirst[name == message] // TODO Por qué busca el método a mano en la clase en lugar de usar los mecanismos que ya tenemos?
+	def dispatch isVoid(Object nativeObject, String message, Object... parameters) {
+		// TODO Por qué busca el método a mano en la clase en lugar de usar los mecanismos que ya tenemos?
+		var method = this.class.methods.findFirst[name == message]
 		
 		if(method == null) false 
 		else method.returnType == Void.TYPE

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -91,7 +91,7 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 	def static dispatch WClass parent(WMethodContainer c) { throw new UnsupportedOperationException("shouldn't happen")  }
 	def static dispatch WClass parent(WClass c) { c.parent }
 	def static dispatch WClass parent(WObjectLiteral c) { null } // For now, object literals do not allow superclasses
-	def static dispatch WClass parent(WNamedObject c) { null } // For now, object literals do not allow superclasses
+	def static dispatch WClass parent(WNamedObject c) { c.parent } // For now, object literals do not allow superclasses
 
 	def static dispatch members(WMethodContainer c) { throw new UnsupportedOperationException("shouldn't happen")  }
 	def static dispatch members(WClass c) { c.members }
@@ -103,10 +103,8 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 	def static dispatch contextName(WObjectLiteral c) { "<anonymousObject>" }
 	def static dispatch contextName(WNamedObject c) { c.fqn }
 	
-	def static dispatch boolean inheritsMethod(WMethodContainer c, String name) { throw new UnsupportedOperationException("shouldn't happen") }
+	def static dispatch boolean inheritsMethod(WMethodContainer c, String name) { c.parent != null && c.parent.hasOrInheritMethod(name) }
 	def static dispatch boolean inheritsMethod(WClass c, String name) { c.parent != null && c.parent.hasOrInheritMethod(name) }
-	def static dispatch boolean inheritsMethod(WObjectLiteral c, String name) { false }
-	def static dispatch boolean inheritsMethod(WNamedObject c, String name) { false }
 	
 	def static boolean hasOrInheritMethod(WClass c, String mname) { 
 		c != null && (c.methods.exists[name == mname] || c.parent.hasOrInheritMethod(mname))

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -261,13 +261,12 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def superInvocationOnlyInValidMethod(WSuperInvocation sup) {
-		val body = sup.method.expression as WBlockExpression
 		if (sup.method.declaringContext instanceof WObjectLiteral)
-			report(WollokDslValidator_SUPER_ONLY_IN_CLASSES, body, WBLOCK_EXPRESSION__EXPRESSIONS, body.expressions.indexOf(sup))
+			report(WollokDslValidator_SUPER_ONLY_IN_CLASSES, sup)
 		else if (!sup.method.overrides)
-			report(WollokDslValidator_SUPER_ONLY_OVERRIDING_METHOD, body, WBLOCK_EXPRESSION__EXPRESSIONS, body.expressions.indexOf(sup))
+			report(WollokDslValidator_SUPER_ONLY_OVERRIDING_METHOD, sup)
 		else if (sup.memberCallArguments.size != sup.method.parameters.size)
-			report('''«WollokDslValidator_SUPER_INCORRECT_ARGS» «sup.method.parameters.size»: «sup.method.overridenMethod.parameters.map[name].join(", ")»''', body, WBLOCK_EXPRESSION__EXPRESSIONS, body.expressions.indexOf(sup))
+			report('''«WollokDslValidator_SUPER_INCORRECT_ARGS» «sup.method.parameters.size»: «sup.method.overridenMethod.parameters.map[name].join(", ")»''', sup)
 	}
 	
 	// ***********************


### PR DESCRIPTION
Not yet implemented for object literals. Not sure about the syntax.

This fixes #159  at least for named objects.
Also fixes #127 