### PR TITLE
Fixes #454 now any exception thrown from a native method is converted…

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ExceptionTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ExceptionTestCase.xtend
@@ -328,4 +328,19 @@ class ExceptionTestCase extends AbstractWollokInterpreterTestCase {
 		'''.interpretPropagatingErrors
 	}
 	
+	@Test
+	def void testExceptionFromNativeMethodGetsWrappedIntoAWollokException() {
+		'''
+			program p {
+				try {
+					console.println(2 / 0)
+				}
+				catch e : Exception {
+					// OK !
+					e.printStackTrace()
+				}
+			}
+		'''.interpretPropagatingErrors
+	}
+	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/TestTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/TestTestCase.xtend
@@ -33,7 +33,6 @@ class TestTestCase extends AbstractWollokInterpreterTestCase {
 
 	@Test
 	def void testWithAssertEqualsWithErrors() {
-		try{
 			'''
 				object pepita {
 					var energia = 0
@@ -46,15 +45,15 @@ class TestTestCase extends AbstractWollokInterpreterTestCase {
 				}
 
 				test "pepita" {
-					assert.equals(7, pepita.energia())	
+					try {
+						assert.equals(7, pepita.energia())
+						assert.fail("should have failed")
+					}
+					catch e {
+						assert.equals("Expected [7] but found [0]", e.getMessage())
+					} 	
 				}
 			'''.interpretPropagatingErrors
-
-			fail()
-		} catch(Exception e){
-			e.assertIsException(AssertionException)
-			assertEquals("Expected [7] but found [0]",getMessageOf(e,AssertionException))
-		}
 	}
 
 	@Test(expected = AssertionError)

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/nativeobj/WollokJavaConversions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/nativeobj/WollokJavaConversions.xtend
@@ -89,6 +89,9 @@ class WollokJavaConversions {
 		throw new UnsupportedOperationException('''Unsupported convertion from java «o» («o.class.name») to wollok''')
 	}
 	
+	def static newWollokException(String message) {
+		evaluator.newInstance(EXCEPTION, message)
+	}
 	
 	def static getEvaluator() { (WollokInterpreter.getInstance.evaluator as WollokInterpreterEvaluator) }
 	

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/operation/WollokDeclarativeNativeBasicOperations.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/operation/WollokDeclarativeNativeBasicOperations.xtend
@@ -35,7 +35,10 @@ class WollokDeclarativeNativeBasicOperations implements WollokBasicBinaryOperati
 					op.invoke(this, a, b)
 				}
 				catch(InvocationTargetException e) {
-					throw new WollokRuntimeException('''Error while resolving «a» «operationSymbol» «b»''', e.cause)
+					if (e.cause instanceof WollokProgramExceptionWrapper)
+						throw e.cause
+					else
+						throw new WollokRuntimeException('''Error while resolving «a» «operationSymbol» «b»''', e.cause)
 				}
 			]
 		}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/sdk/WollokDSK.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/sdk/WollokDSK.xtend
@@ -28,6 +28,8 @@ class WollokDSK {
 	public static val LIST = "wollok.lang.List"
 	public static val SET = "wollok.lang.Set"
 	
+	public static val EXCEPTION = "wollok.lang.Exception"
+	
 	public static val MESSAGE_NOT_UNDERSTOOD_EXCEPTION = "wollok.lang.MessageNotUnderstoodException"
 	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/ui/utils/XTendUtilExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/ui/utils/XTendUtilExtensions.xtend
@@ -16,6 +16,8 @@ import org.uqbar.project.wollok.interpreter.core.WollokProgramExceptionWrapper
 import static org.uqbar.project.wollok.sdk.WollokDSK.*
 
 import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions.*
+import java.lang.reflect.InvocationTargetException
+import org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions
 
 /**
  * Utilities for xtend code
@@ -138,6 +140,9 @@ class XTendUtilExtensions {
 		try {
 			val returnVal = m.invoke(o, converted.toArray)
 			javaToWollok(returnVal)
+		}
+		catch (InvocationTargetException e) {
+			throw new WollokProgramExceptionWrapper(WollokJavaConversions.newWollokException(e.cause.message))
 		}
 		catch (IllegalArgumentException e) {
 			throw new WollokRuntimeException("Error while calling java method " + m + " with parameters: " + converted, e)


### PR DESCRIPTION
… to wollok.lang.Exception and thrown in wollok itself, which allows wollok programs to handle native exceptions