### PR TITLE
Feature unified block syntax

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok.wlk
@@ -34,9 +34,9 @@ package lang {
 			printer.println(preffix +  this.className() + (if (message != null) (": " + message.toString()) else "")
 			
 			// TODO: eventually we will need a stringbuffer or something to avoid memory consumption
-			this.getStackTrace().forEach[e|
+			this.getStackTrace().forEach { e =>
 				printer.println("\tat " + e.contextDescription() + " [" + e.location() + "]")
-			]
+			}
 			
 			if (cause != null)
 				cause.printStackTraceWithPreffix("Caused by: ", printer)
@@ -110,19 +110,19 @@ package lang {
 		
 		method equals(other) = this == other
 		
+		method randomBetween(start, end) native
+		
 		method ->(other) {
 			return new Pair(this, other)
 		}
-		
-		method randomBetween(start, end) native
-		
+
 		method toString() {
 			// TODO: should be a set
 			// return this.toSmartString(#{})
-			return this.toSmartString(#[])
+			return this.toSmartString([])
 		}
 		method toSmartString(alreadyShown) {
-			if (alreadyShown.exists[e| e.identity() == this.identity()] ) { 
+			if (alreadyShown.exists { e => e.identity() == this.identity() } ) { 
 				return this.kindName() 
 			}
 			else {
@@ -132,9 +132,9 @@ package lang {
 		} 
 		method internalToSmartString(alreadyShown) {
 			return this.kindName() + "[" 
-				+ this.instanceVariables().map[v| 
+				+ this.instanceVariables().map { v => 
 					v.name() + "=" + v.valueToSmartString(alreadyShown)
-				].join(', ') 
+				}.join(', ') 
 			+ "]"
 		}
 		
@@ -145,7 +145,7 @@ package lang {
 					 	this.kindName()
 			message += " does not understand " + name
 			if (parameters.size() > 0)
-				message += "(" + (0..(parameters.size()-1)).map[i| "p" + i].join(',') + ")"
+				message += "(" + (0..(parameters.size()-1)).map { i => "p" + i }.join(',') + ")"
 			else
 				message += "()"
 			throw new MessageNotUnderstoodException(message)
@@ -178,21 +178,21 @@ package lang {
 		  * The criteria is given by a closure that receives a single element as input (one of the element)
 		  * The closure must return a comparable value (something that understands the >, >= messages).
 		  * Example:
-		  *       #["a", "ab", "abc", "d" ].max[e| e.length() ]    ->  returns "abc"		 
+		  *       ["a", "ab", "abc", "d" ].max { e => e.length() }    =>  returns "abc"		 
 		  */
-		method max(closure) = this.absolute(closure, [a,b | a > b])
+		method max(closure) = this.absolute(closure, { a, b => a > b })
 		
 		/**
 		  * Returns the element that is considered to be/have the minimum value.
 		  * The criteria is given by a closure that receives a single element as input (one of the element)
 		  * The closure must return a comparable value (something that understands the >, >= messages).
 		  * Example:
-		  *       #["ab", "abc", "hello", "wollok world"].max[e| e.length() ]    ->  returns "wollok world"		 
+		  *       ["ab", "abc", "hello", "wollok world"].max { e => e.length() }    =>  returns "wollok world"		 
 		  */
-		method min(closure) = this.absolute(closure, [a,b | a < b])
+		method min(closure) = this.absolute(closure, { a, b => a < b} )
 		
 		method absolute(closure, criteria) {
-			val result = this.fold(null, [acc, e|
+			val result = this.fold(null, { acc, e =>
 				val n = closure.apply(e) 
 				if (acc == null)
 					new Pair(e, n)
@@ -202,7 +202,7 @@ package lang {
 					else
 						acc
 				}
-			])
+			})
 			return if (result == null) null else result.getX()
 		}
 		 
@@ -211,7 +211,7 @@ package lang {
 		/**
 		  * Adds all elements from the given collection parameter to this collection
 		  */
-		method addAll(elements) { elements.forEach[e| this.add(e) ] }
+		method addAll(elements) { elements.forEach { e => this.add(e) } }
 		
 		/** Tells whether this collection has no elements */
 		method isEmpty() = this.size() == 0
@@ -221,57 +221,57 @@ package lang {
 		 * The logic to execute is passed as a closure that takes a single parameter.
 		 * @returns nothing
 		 * Example:
-		 *      plants.forEach[ plant |   plant.takeSomeWater() ]
+		 *      plants.forEach { plant => plant.takeSomeWater() }
 		 */
-		method forEach(closure) { this.fold(null, [ acc, e | closure.apply(e) ]) }
+		method forEach(closure) { this.fold(null, { acc, e => closure.apply(e) }) }
 		
 		/**
 		 * Tells whether all the elements of this collection satisfy a given condition
 		 * The condition is a closure argument that takes a single element and returns a boolean value.
 		 * @returns true/false
 		 * Example:
-		 *      plants.forAll[ plant | plant.hasFlowers() ]
+		 *      plants.forAll { plant => plant.hasFlowers() }
 		 */
-		method forAll(predicate) = this.fold(true, [ acc, e | if (!acc) acc else predicate.apply(e) ])
+		method forAll(predicate) = this.fold(true, { acc, e => if (!acc) acc else predicate.apply(e) })
 		/**
 		 * Tells whether at least one element of this collection satisfy a given condition
 		 * The condition is a closure argument that takes a single element and returns a boolean value.
 		 * @returns true/false
 		 * Example:
-		 *      plants.exists[ plant | plant.hasFlowers() ]
+		 *      plants.exists { plant => plant.hasFlowers() }
 		 */
-		method exists(predicate) = this.fold(false, [ acc, e | if (acc) acc else predicate.apply(e) ])
+		method exists(predicate) = this.fold(false, { acc, e => if (acc) acc else predicate.apply(e) })
 		/**
 		 * Returns the element of this collection that satisfy a given condition.
 		 * If more than one element satisfies the condition then it depends on the specific collection class which element
 		 * will be returned
 		 * @returns the element that complies the condition
 		 * Example:
-		 *      users.detect[ user | user.name() == "Cosme Fulanito" ]
+		 *      users.detect { user => user.name() == "Cosme Fulanito" }
 		 */
-		method detect(predicate) = this.fold(null, [ acc, e |
+		method detect(predicate) = this.fold(null, { acc, e =>
 			 if (acc != null)
 			 	acc
 			 else
 			 	if (predicate.apply(e)) e else null
-		])
+		})
 		/**
 		 * Counts all elements of this collection that satisfy a given condition
 		 * The condition is a closure argument that takes a single element and returns a number.
 		 * @returns an integer number
 		 * Example:
-		 *      plants.count[ plant | plant.hasFlowers() ]
+		 *      plants.count { plant => plant.hasFlowers() }
 		 */
-		method count(predicate) = this.fold(0, [ acc, e | if (predicate.apply(e)) acc++ else acc  ])
+		method count(predicate) = this.fold(0, { acc, e => if (predicate.apply(e)) acc++ else acc  })
 		/**
 		 * Collects the sum of each value for all e
-		 * This is similar to call a map[] to transform each element into a number object and then adding all those numbers.
+		 * This is similar to call a map {} to transform each element into a number object and then adding all those numbers.
 		 * The condition is a closure argument that takes a single element and returns a boolean value.
 		 * @returns an integer
 		 * Example:
-		 *      val totalNumberOfFlowers = plants.sum[ plant | plant.numberOfFlowers() ]
+		 *      val totalNumberOfFlowers = plants.sum{ plant => plant.numberOfFlowers() }
 		 */
-		method sum(closure) = this.fold(0, [ acc, e | acc + closure.apply(e) ])
+		method sum(closure) = this.fold(0, { acc, e => acc + closure.apply(e) })
 		
 		/**
 		 * Returns a new collection that contains the result of transforming each of this collection's elements
@@ -279,29 +279,29 @@ package lang {
 		 * The condition is a closure argument that takes a single element and returns an object.
 		 * @returns another collection (same type as this one)
 		 * Example:
-		 *      val ages = users.map[ user | user.age() ]
+		 *      val ages = users.map{ user => user.age() }
 		 */
-		method map(closure) = this.fold(this.newInstance(), [ acc, e |
+		method map(closure) = this.fold(this.newInstance(), { acc, e =>
 			 acc.add(closure.apply(e))
 			 acc
-		])
+		})
 		
-		method flatMap(closure) = this.fold(this.newInstance(), [ acc, e |
+		method flatMap(closure) = this.fold(this.newInstance(), { acc, e =>
 			acc.addAll(closure.apply(e))
 			acc
-		])
+		})
 
-		method filter(closure) = this.fold(this.newInstance(), [ acc, e |
+		method filter(closure) = this.fold(this.newInstance(), { acc, e =>
 			 if (closure.apply(e))
 			 	acc.add(e)
 			 acc
-		])
+		})
 
-		method contains(e) = this.exists[one | e == one ]
-		method flatten() = this.flatMap[ e | e ]
+		method contains(e) = this.exists{one => e == one }
+		method flatten() = this.flatMap{ e => e }
 		
 		override method internalToSmartString(alreadyShown) {
-			return this.toStringPrefix() + this.map[e| e.toSmartString(alreadyShown) ].join(', ') + this.toStringSufix()
+			return this.toStringPrefix() + this.map{e=> e.toSmartString(alreadyShown) }.join(', ') + this.toStringSufix()
 		}
 		
 		method toStringPrefix()
@@ -318,13 +318,16 @@ package lang {
 	 * @since 1.3
 	 */	
 	class Set inherits Collection {
-	
+		new(elements ...) {
+			this.addAll(elements)
+		}
+		
 		override method newInstance() = #{}
 		override method toStringPrefix() = "#{"
 		override method toStringSufix() = "}"
 		
 		override method asList() { 
-			val result = #[]
+			val result = []
 			result.addAll(this)
 			return result
 		}
@@ -354,7 +357,7 @@ package lang {
 
 		method get(index) native
 		
-		override method newInstance() = #[]
+		override method newInstance() = []
 		
 		method any() {
 			if (this.isEmpty()) 
@@ -366,7 +369,7 @@ package lang {
 		method first() = this.head()
 		method head() = this.get(0)
 		
-		override method toStringPrefix() = "#["
+		override method toStringPrefix() = "["
 		override method toStringSufix() = "]"
 
 		override method asList() = this
@@ -377,29 +380,29 @@ package lang {
 			return result
 		}
 		
-		method subList(start,end) = {
+		method subList(start,end) {
 			if(this.isEmpty)
 				return this.newInstance()
 			val newList = this.newInstance()
 			val _start = start.limitBetween(0,this.size()-1)
 			val _end = end.limitBetween(0,this.size()-1)
-			(_start.._end).forEach[i| newList.add(this.get(i))]
+			(_start.._end).forEach { i => newList.add(this.get(i)) }
 			return newList
 		}
 		
-		method take(n) = {
-		if(n <= 0)
-			this.newInstance()
-		else
-			this.subList(0,n-1)
-		}
+		method take(n) =
+			if(n <= 0)
+				this.newInstance()
+			else
+				this.subList(0,n-1)
+			
 		
-		method drop(n) =  {
-		if(n >= this.size())
-			this.newInstance()
-		else
-			this.subList(n,this.size()-1)
-		}	
+		method drop(n) = 
+			if(n >= this.size())
+				this.newInstance()
+			else
+				this.subList(n,this.size()-1)
+			
 		
 		method reverse() = this.subList(this.size()-1,0)
 	
@@ -547,8 +550,8 @@ package lang {
 		method forEach(closure) native
 		
 		method map(closure) {
-			val l = #[]
-			this.forEach[e| l.add(closure.apply(e)) ]
+			val l = []
+			this.forEach{e=> l.add(closure.apply(e)) }
 			return l
 		}
 		

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ClosureTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ClosureTestCase.xtend
@@ -8,20 +8,10 @@ import org.junit.Test
 class ClosureTestCase extends AbstractWollokInterpreterTestCase {
 	
 	@Test
-	def void applyNoArgsClosure() {
-		'''
-		program p {
-			val helloWorld = [ "helloWorld" ]
-			val response = helloWorld.apply()		
-			assert.equals("helloWorld", response)
-		}'''.interpretPropagatingErrors
-	}
-	
-	@Test
 	def void applyClosureWithOneArgument() {
 		'''
 		program p {
-			val helloWorld = [to | "hello " + to ]
+			val helloWorld = {to => "hello " + to }
 			val response = helloWorld.apply("world")		
 			assert.equals("hello world", response)
 		}'''.interpretPropagatingErrors
@@ -32,7 +22,7 @@ class ClosureTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			var to = "world"
-			val helloWorld = ["hello " + to ]
+			val helloWorld = {=>"hello " + to }
 			
 			assert.equals("hello world", helloWorld.apply())
 			
@@ -45,9 +35,9 @@ class ClosureTestCase extends AbstractWollokInterpreterTestCase {
 	def void closureAsParamToClosure() {
 		'''
 		program p {
-			val twice = [ block | block.apply() + block.apply() ]
+			val twice = { block => block.apply() + block.apply() }
 			
-			assert.equals(4, twice.apply [| 2 ])
+			assert.equals(4, twice.apply {=> 2 })
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -55,11 +45,11 @@ class ClosureTestCase extends AbstractWollokInterpreterTestCase {
 	def void nestedClosure() {
 		'''
 		program p {
-			val sum =  [a, b | a + b]
+			val sum =  {a, b => a + b}
 			
-			val curried = [ a |
-				[ b | sum.apply(a, b) ] 
-			]
+			val curried = { a =>
+				{ b => sum.apply(a, b) } 
+			}
 			
 			val curriedSum = curried.apply(2)
 			
@@ -71,13 +61,13 @@ class ClosureTestCase extends AbstractWollokInterpreterTestCase {
 	def void foldingClosures() {
 		'''
 		program p {
-			val sum2 = [ a | a + 2];
-			val by3 = [ b | b * 3];
-			val pow = [ c | c ** 2];
+			val sum2 = { a => a + 2};
+			val by3 = { b => b * 3};
+			val pow = { c => c ** 2};
 			
-			val op = #[sum2, by3, pow]
+			val op = [sum2, by3, pow]
 			
-			val result = op.fold(0, [acc, o |  o.apply(acc) ])
+			val result = op.fold(0, {acc, o =>  o.apply(acc) })
 			
 			assert.equals(36, result)
 		}'''.interpretPropagatingErrors

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ClosureTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ClosureTestCase.xtend
@@ -8,6 +8,16 @@ import org.junit.Test
 class ClosureTestCase extends AbstractWollokInterpreterTestCase {
 	
 	@Test
+	def void applyNoArgsClosure() {
+		'''
+		program p {
+			val helloWorld = { "helloWorld" }
+			val response = helloWorld.apply()
+			assert.equals("helloWorld", response)
+		}'''.interpretPropagatingErrors
+	}
+
+	@Test
 	def void applyClosureWithOneArgument() {
 		'''
 		program p {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/CollectionTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/CollectionTestCase.xtend
@@ -6,11 +6,11 @@ import org.uqbar.project.wollok.interpreter.core.WollokProgramExceptionWrapper
 class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 	
 	def instantiateCollectionAsNumbersVariable() {
-		"val numbers = #[22, 2, 10]"
+		"val numbers = [22, 2, 10]"
 	}
 	
 	def instantiateStrings() {
-		"val strings = #['hello', 'hola', 'bonjour', 'ciao', 'hi']"
+		"val strings = ['hello', 'hola', 'bonjour', 'ciao', 'hi']"
 	}
 	
 	@Test
@@ -18,7 +18,7 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateStrings»		
-			assert.equals('hi', strings.min[e| e.length() ])
+			assert.equals('hi', strings.min{e=> e.length() })
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -28,8 +28,8 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateStrings»
-			val r = strings.max[e| e.length() ]	
-			assert.equals('bonjour', strings.max[e| e.length() ])
+			val r = strings.max{e=> e.length() }	
+			assert.equals('bonjour', strings.max{e=> e.length() })
 		}'''.interpretPropagatingErrors
 		catch (WollokProgramExceptionWrapper e)
 					fail(e.message)
@@ -60,9 +60,9 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.that(numbers.exists[e| e > 20])
-			assert.that(numbers.exists[e| e > 0])
-			assert.notThat(numbers.exists[e| e < 0])
+			assert.that(numbers.exists{e=> e > 20})
+			assert.that(numbers.exists{e=> e > 0})
+			assert.notThat(numbers.exists{e=> e < 0})
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -102,7 +102,7 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 			«instantiateCollectionAsNumbersVariable»
 			
 			var sum = 0
-			numbers.forEach([n | sum += n])
+			numbers.forEach({n => sum += n})
 			
 			assert.equals(34, sum)
 		}'''.interpretPropagatingErrors
@@ -113,8 +113,8 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.that(numbers.forAll([n | n > 0]))
-			assert.notThat(numbers.forAll([n | n > 5]))
+			assert.that(numbers.forAll({n => n > 0}))
+			assert.notThat(numbers.forAll({n => n > 5}))
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -123,7 +123,7 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			var greaterThanFiveElements = numbers.filter([n | n > 5])
+			var greaterThanFiveElements = numbers.filter({n => n > 5})
 			assert.that(greaterThanFiveElements.size() == 2)
 		}'''.interpretPropagatingErrors
 	}
@@ -133,7 +133,7 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			var halfs = numbers.map([n | n / 2])
+			var halfs = numbers.map({n => n / 2})
 
 			assert.equals(3, halfs.size())
 			assert.that(halfs.contains(11))
@@ -147,7 +147,7 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			var greaterThanFiveElements = numbers.filter[n | n > 5]
+			var greaterThanFiveElements = numbers.filter{n => n > 5}
 			assert.that(greaterThanFiveElements.size() == 2)
 		}'''.interpretPropagatingErrors
 	}
@@ -166,8 +166,8 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 	def void equalsWithMethodName() {
 		'''
 		program p {
-			val a = #[23, 2, 1]
-			val b = #[23, 2, 1]
+			val a = [23, 2, 1]
+			val b = [23, 2, 1]
 			assert.that(a.equals(b))
 		}'''.interpretPropagatingErrors
 	}
@@ -176,8 +176,8 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 	def void equalsWithEqualsEquals() {
 		'''
 		program p {
-			val a = #[23, 2, 1]
-			val b = #[23, 2, 1]
+			val a = [23, 2, 1]
+			val b = [23, 2, 1]
 			assert.that(a == b)
 		}'''.interpretPropagatingErrors
 	}
@@ -187,7 +187,7 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals("#[22, 2, 10]", numbers.toString())
+			assert.equals("[22, 2, 10]", numbers.toString())
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -198,8 +198,8 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 			method internalToSmartString(alreadyShown) = "My Object"
 		}
 		program p {
-			val a = #[23, 2, 1, myObject]
-			assert.equals("#[23, 2, 1, My Object]", a.toString())
+			val a = [23, 2, 1, myObject]
+			assert.equals("[23, 2, 1, My Object]", a.toString())
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -208,8 +208,8 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals(22, numbers.detect[e| e > 20])
-			assert.equals(null, numbers.detect[e| e > 1000])
+			assert.equals(22, numbers.detect{e=> e > 20})
+			assert.equals(null, numbers.detect{e=> e > 1000})
 		}
 		'''.interpretPropagatingErrors
 	}
@@ -219,9 +219,9 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals(1, numbers.count[e| e > 20])
-			assert.equals(3, numbers.count[e| e > 0])
-			assert.equals(0, numbers.count[e| e < 0])
+			assert.equals(1, numbers.count{e=> e > 20})
+			assert.equals(3, numbers.count{e=> e > 0})
+			assert.equals(0, numbers.count{e=> e < 0})
 		}
 		'''.interpretPropagatingErrors
 	}
@@ -232,7 +232,7 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 		program p {
 			«instantiateCollectionAsNumbersVariable»
 			
-			assert.equals(34, numbers.sum([n | n]))
+			assert.equals(34, numbers.sum {n => n})
 		}'''.interpretPropagatingErrors
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
@@ -13,10 +13,10 @@ class ListTestCase extends CollectionTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals(#[22,2], numbers.subList(0,1))
-			assert.equals(#[22,2,10], numbers.subList(0,2))
-			assert.equals(#[2,10], numbers.subList(1,2))
-			assert.equals(#[2], numbers.subList(1,1))
+			assert.equals([22,2], numbers.subList(0,1))
+			assert.equals([22,2,10], numbers.subList(0,2))
+			assert.equals([2,10], numbers.subList(1,2))
+			assert.equals([2], numbers.subList(1,1))
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -25,10 +25,10 @@ class ListTestCase extends CollectionTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals(#[2,22], numbers.subList(1,0))
-			assert.equals(#[22,2,10], numbers.subList(0,25))
-			assert.equals(#[2,10], numbers.subList(1,2))
-			assert.equals(#[2], numbers.subList(1,1))
+			assert.equals([2,22], numbers.subList(1,0))
+			assert.equals([22,2,10], numbers.subList(0,25))
+			assert.equals([2,10], numbers.subList(1,2))
+			assert.equals([2], numbers.subList(1,1))
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -37,13 +37,13 @@ class ListTestCase extends CollectionTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals(#[], numbers.take(-1))
-			assert.equals(#[], numbers.take(0))
-			assert.equals(#[22], numbers.take(1))
-			assert.equals(#[22,2], numbers.take(2))
-			assert.equals(#[22,2,10], numbers.take(3))
-			assert.equals(#[22,2,10], numbers.take(4))
-			assert.equals(#[22,2,10], numbers)
+			assert.equals([], numbers.take(-1))
+			assert.equals([], numbers.take(0))
+			assert.equals([22], numbers.take(1))
+			assert.equals([22,2], numbers.take(2))
+			assert.equals([22,2,10], numbers.take(3))
+			assert.equals([22,2,10], numbers.take(4))
+			assert.equals([22,2,10], numbers)
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -52,10 +52,10 @@ class ListTestCase extends CollectionTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals(#[], #[].take(-1))
-			assert.equals(#[], #[].take(0))
-			assert.equals(#[], #[].take(1))
-			assert.equals(#[], #[].take(2))
+			assert.equals([], [].take(-1))
+			assert.equals([], [].take(0))
+			assert.equals([], [].take(1))
+			assert.equals([], [].take(2))
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -64,13 +64,13 @@ class ListTestCase extends CollectionTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals(#[22,2,10], numbers.drop(-1))
-			assert.equals(#[22,2,10], numbers.drop(0))
-			assert.equals(#[2,10], numbers.drop(1))			
-			assert.equals(#[10], numbers.drop(2))
-			assert.equals(#[], numbers.drop(3))
-			assert.equals(#[], numbers.drop(4))
-			assert.equals(#[22,2,10], numbers)
+			assert.equals([22,2,10], numbers.drop(-1))
+			assert.equals([22,2,10], numbers.drop(0))
+			assert.equals([2,10], numbers.drop(1))			
+			assert.equals([10], numbers.drop(2))
+			assert.equals([], numbers.drop(3))
+			assert.equals([], numbers.drop(4))
+			assert.equals([22,2,10], numbers)
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -79,10 +79,10 @@ class ListTestCase extends CollectionTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals(#[], #[].drop(-1))
-			assert.equals(#[], #[].drop(0))
-			assert.equals(#[], #[].drop(1))
-			assert.equals(#[], #[].drop(2))
+			assert.equals([], [].drop(-1))
+			assert.equals([], [].drop(0))
+			assert.equals([], [].drop(1))
+			assert.equals([], [].drop(2))
 		}'''.interpretPropagatingErrors
 	}	
 	
@@ -91,9 +91,9 @@ class ListTestCase extends CollectionTestCase {
 		'''
 		program p {
 			«instantiateCollectionAsNumbersVariable»
-			assert.equals(#[10,2,22], numbers.reverse())
-			assert.equals(#[], #[].reverse())
-			assert.equals(#[2], #[2].reverse())			
+			assert.equals([10,2,22], numbers.reverse())
+			assert.equals([], [].reverse())
+			assert.equals([2], [2].reverse())			
 		}'''.interpretPropagatingErrors
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NamedObjectsTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NamedObjectsTestCase.xtend
@@ -58,7 +58,7 @@ class NamedObjectsTestCase extends AbstractWollokInterpreterTestCase {
 	def void referencingObject() {
 		'''
 			object pp {
-			    val ps = #[pepita]
+			    val ps = [pepita]
 			    
 			    method unMethod(){
 			        var x = pepita

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RangeTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RangeTestCase.xtend
@@ -19,7 +19,7 @@ class RangeTestCase extends AbstractWollokInterpreterTestCase {
 			
 			assert.that(range != null)
 			
-			range.forEach [ i | sum += i ]
+			range.forEach { i => sum += i }
 			
 			assert.equals(55, sum)
 		}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RecursiveToStringTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RecursiveToStringTestCase.xtend
@@ -20,7 +20,7 @@ class RecursiveToStringTestCase extends AbstractWollokInterpreterTestCase {
 			}
 			
 			object obj1 {
-				var x = #[]
+				var x = []
 				method addX(anObject){
 					x.add(anObject)
 				}
@@ -35,7 +35,7 @@ class RecursiveToStringTestCase extends AbstractWollokInterpreterTestCase {
 				obj2.setY(obj1)
 				obj1.addX(new Prb())
 				
-				assert.equals('obj2[y=obj1[x=#[obj2, a Prb[]]]]', obj2.toString())
+				assert.equals('obj2[y=obj1[x=[obj2, a Prb[]]]]', obj2.toString())
 			}
 		'''.interpretPropagatingErrors
 	}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/WollokParseHelper.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/WollokParseHelper.xtend
@@ -16,7 +16,7 @@ import org.eclipse.core.runtime.NullProgressMonitor
 class WollokParseHelper extends ParseHelper<WFile>{
 	
 	/**
-	 * file is a pair fileName -> content
+	 * file is a pair fileName => content
 	 */
 	def WFile parse(Pair<String,String> file, ResourceSet resourceSetToUse) throws Exception {
 		parse(file, resourceSetToUse, false)

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/classes/MethodTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/classes/MethodTest.xtend
@@ -29,9 +29,9 @@ class MethodTest extends AbstractWollokInterpreterTestCase {
 		class Sample {
 			method preffix(preffix, numbers...) {
 				if (numbers.size() > 0)
-					return numbers.map[n| preffix + n]
+					return numbers.map{n=> preffix + n}
 				else
-					return #[]
+					return []
 			}
 		}
 		test "Var args method must automatically box params as a list" {
@@ -55,7 +55,7 @@ class MethodTest extends AbstractWollokInterpreterTestCase {
 		class Sample {
 			var result
 			new(preffix, numbers...) {
-				result = if (numbers.size() > 0) numbers.map[n| preffix + n] else #[]
+				result = if (numbers.size() > 0) numbers.map{n=> preffix + n} else []
 			}
 			method getResult() = result
 		}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/classes/ObjectTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/classes/ObjectTest.xtend
@@ -20,19 +20,4 @@ class ObjectTest extends AbstractWollokInterpreterTestCase {
 			assert.that(myObject.identity() != null)
 		}'''.interpretPropagatingErrors
 	}
-	
-	@Test
-	def void testInheritedMethodForPairLiterals() {
-		'''
-		class MyClass {
-		}
-		program p {
-			val myObject = new MyClass()
-			val pair = myObject -> 23
-			
-			assert.equals(myObject, pair.getX())
-			assert.equals(23, pair.getY())
-		}'''.interpretPropagatingErrors
-	}
-	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/imports/ImportsTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/imports/ImportsTest.xtend
@@ -55,7 +55,7 @@ class ImportsTest extends AbstractWollokInterpreterTestCase {
 			
 			object mostaza {
 				method entrenar() {
-					return #[pepita, pepona].map[p| p.getNombre()].join(',')
+					return [pepita, pepona].map{p => p.getNombre()}.join(',')
 				} 
 			}
 		''',
@@ -83,7 +83,7 @@ class ImportsTest extends AbstractWollokInterpreterTestCase {
 		'programa' -> '''
 			import aves.*
 			program a {
-				assert.equals('pepita,pepona', #[pepita, pepona].map[p| p.getNombre()].join())
+				assert.equals('pepita,pepona', [pepita, pepona].map{p => p.getNombre()}.join())
 			}
 		'''
 		].interpretAsFilesPropagatingErrors

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/namedobjects/NamedObjectTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/namedobjects/NamedObjectTestCase.xtend
@@ -12,7 +12,7 @@ class NamedObjectTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void testMultipleReferencesToSameObjectCreatesJustOneInstance() { '''
 		object pp {
-		    var ps = #[pepita]
+		    var ps = [pepita]
 		    method unMethod(){
 		        var x = pepita
 		        return x

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/numbers/CollectionsMinMaxTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/numbers/CollectionsMinMaxTest.xtend
@@ -19,7 +19,7 @@ class CollectionsMinMaxTest extends AbstractWollokInterpreterTestCase {
 				}				
 
 				program a {
-					assert.equals(x1, #[x1, x2, x3].min[ o | o.value()])
+					assert.equals(x1, [x1, x2, x3].min{ o => o.value()})
 				}
 			'''
 		.interpretPropagatingErrors
@@ -39,7 +39,7 @@ class CollectionsMinMaxTest extends AbstractWollokInterpreterTestCase {
 				}
 
 				program a {
-					assert.equals(x3, #[x1, x2, x3].max[ o | o.value()])
+					assert.equals(x3, [x1, x2, x3].max{ o => o.value()})
 				}
 			'''
 		.interpretPropagatingErrors

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/parser/UnusedVariableTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/parser/UnusedVariableTest.xtend
@@ -25,13 +25,13 @@ class ScopeTest extends AbstractWollokInterpreterTestCase {
 	def void shadowing() {
 		val model = '''
 			class Tren {
-			    val vagones = #[]
+			    val vagones = []
 			
 			    method agregarVagon(v) {
 			        vagones.add(v)
 			    }
 			    method getCantidadPasajeros() {
-			        vagones.fold(0, [v| v.getCantidadPasajeros()])
+			        vagones.fold(0, {v=> v.getCantidadPasajeros()})
 			    }
 			}
 			

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/regression/RegressionTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/regression/RegressionTestCase.xtend
@@ -12,7 +12,7 @@ class RegressionTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void bug_38() {
 			'''object pajarera {
-		    var pajaros = #[pepita,pepe,pepona]
+		    var pajaros = [pepita,pepe,pepona]
 		
 		    method agregarA(pajaro){
 		        pajaros.add(pajaro)
@@ -31,46 +31,46 @@ class RegressionTestCase extends AbstractWollokInterpreterTestCase {
 		    }
 		
 		    method alimentarATodosCon(comida){
-		        pajaros.forEach[p|p.comer(comida)]
+		        pajaros.forEach{p=>p.comer(comida)}
 		    }
 		
 		    method hacerVolarATodas20M(metros){
-		        pajaros.forEach[p|p.volar(metros)]
+		        pajaros.forEach{p=>p.volar(metros)}
 		    }
 		
 		    method cualEstaSaludable(){
-		        return pajaros.filter[p|p.energia() > 100]
+		        return pajaros.filter{p=>p.energia() > 100}
 		    }
 		
 		    method retornaEnergias(energiaMinima){
-		        return  pajaros.filter[p|p.energia() < energiaMinima]
+		        return  pajaros.filter{p=>p.energia() < energiaMinima}
 		    }
 		
 		    method el(){
-		        var filtro1 = #[]
-		        var filtro2 = #[]
-		        var filtro3 = #[]
+		        var filtro1 = []
+		        var filtro2 = []
+		        var filtro3 = []
 		
-		        filtro1 = pajaros.filter[p|p.energia() <= pepita.energia()]
-		        filtro2 = filtro1.filter[pp|pp.energia() <= pepona.energia()]
-		        filtro3 = filtro2.filter[ppp|ppp.energia() <= pepe.energia()]
+		        filtro1 = pajaros.filter{p=>p.energia() <= pepita.energia()}
+		        filtro2 = filtro1.filter{pp=>pp.energia() <= pepona.energia()}
+		        filtro3 = filtro2.filter{ppp=>ppp.energia() <= pepe.energia()}
 		
 		
-		        //var filtro2 = filtro1.filter[pp|pp.energia() > pepe.energia()]
-		        //return filtro2.filter[ppp|[ppp.energia() > pepona.energia()]]
+		        //var filtro2 = filtro1.filter{pp=>pp.energia() > pepe.energia()}
+		        //return filtro2.filter{ppp=>ppp.energia() > pepona.energia()}
 		
 		        return this.comparaEnergia(filtro3)
 		    }
 		
 		    method alimentaBajaEnergia(filtro3){
-		        filtro3.forEach[pppp|pppp.com()]
+		        filtro3.forEach{pppp=>pppp.com()}
 		        //pepe.com()
 		        this.comparaEnergia(filtro3)
 		    }
 		
 		    method comparaEnergia(filtro3){
-		        var filtro4 = #[]
-		        filtro4 = filtro3.filter[p|p.energia() >= 30]
+		        var filtro4 = []
+		        filtro4 = filtro3.filter{p=>p.energia() >= 30}
 		
 		        if (filtro4.size() == 0) {    
 		            this.alimentaBajaEnergia(filtro3)
@@ -85,11 +85,11 @@ class RegressionTestCase extends AbstractWollokInterpreterTestCase {
 		    }
 		
 		    method getEnergias(){
-		        return pajaros.map[p|p.energia()]
+		        return pajaros.map{p=>p.energia()}
 		    }
 		
 		    method estanTodosVivos(){
-		        return pajaros.forAll[p|p.energia() > 0]
+		        return pajaros.forAll{p=>p.energia() > 0}
 		    }
 		}
 		object pepita {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
@@ -13,7 +13,7 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void testCollectionAsInstanceVariable() { #['''
 		object pajarera{
-			val pajaros = #[]
+			val pajaros = []
 			method agregar(unPajaro){
 				pajaros.add(unPajaro)
 			}
@@ -41,9 +41,9 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 		'''
 		object pajarera {
 		    var energiaMenor = 100 
-		    var pajaros = #[pepita, pepe]
+		    var pajaros = [pepita, pepe]
 		    method menorValor(){
-		        pajaros.forEach[a | a.sosMenor(energiaMenor)]
+		        pajaros.forEach{a => a.sosMenor(energiaMenor)}
 		        return energiaMenor
 		    }      
 		
@@ -74,10 +74,10 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 	def void testAddAll() { 
 		'''
 		program p {
-			val unos = #[1,2,3,4]
-			val otros = #[5,6,7,8]
+			val unos = [1,2,3,4]
+			val otros = [5,6,7,8]
 			
-			val todos = #[]
+			val todos = []
 			todos.addAll(unos)
 			todos.addAll(otros)			
 			assert.equals(8, todos.size())
@@ -88,10 +88,10 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 	def void testFlatMap() {
 		'''
 		program p {
-			assert.equals(#[1,2,3,4], #[#[1,2], #[3,4]].flatten())
-			assert.equals(#[1,2,3,4], #[#[1,2], #[], #[3,4]].flatten())
-			assert.equals(#[], #[].flatten())
-			assert.equals(#[], #[#[]].flatten())
+			assert.equals([1,2,3,4], [[1,2], [3,4]].flatten())
+			assert.equals([1,2,3,4], [[1,2], [], [3,4]].flatten())
+			assert.equals([], [].flatten())
+			assert.equals([], [[]].flatten())
 		}'''.interpretPropagatingErrors
 	}
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -18,7 +18,7 @@ class ListTest extends ListTestCase {
 	}
 	
 	override instantiateStrings() {
-		"val strings = new List(); \n #['hello', 'hola', 'bonjour', 'ciao', 'hi'].forEach[e| strings.add(e) ]"
+		"val strings = new List(); \n ['hello', 'hola', 'bonjour', 'ciao', 'hi'].forEach{e=> strings.add(e) }"
 	}
 	
 	@Test
@@ -26,7 +26,7 @@ class ListTest extends ListTestCase {
 		'''
 		program p {
 			val numbers = new List()
-			assert.equals("#[]", numbers.toString())
+			assert.equals("[]", numbers.toString())
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -36,7 +36,7 @@ class ListTest extends ListTestCase {
 		program p {
 			«instantiateCollectionAsNumbersVariable»
 			
-			val strings = numbers.map[e| e.toString()]
+			val strings = numbers.map{e=> e.toString()}
 			
 			assert.notEquals(numbers.identity(), strings.identity())
 			
@@ -53,7 +53,7 @@ class ListTest extends ListTestCase {
 		object o2 {}
 			
 		program p {
-			val list = #[o1, o2]
+			val list = [o1, o2]
 			
 			assert.that(list.contains(o1))
 			assert.that(list.contains(o2))
@@ -61,13 +61,25 @@ class ListTest extends ListTestCase {
 	}
 	
 	@Test
-	def void testConversions() {
+	def void testAsListConversion() {
 		'''
 		program p {
-			val list = #[1,2,3]
+			val list = [1,2,3]
 			
-			assert.equals(#[1,2,3], list.asList())
-			assert.equals(#{1,2,3}, list.asSet())
+			assert.equals([1,2,3], list.asList())
+		}'''.interpretPropagatingErrors
+	}
+	
+		@Test
+	def void testAsSetConversion() {
+		'''
+		program p {
+			val set = #{}
+			set.add(1)
+			set.add(2)
+			set.add(3)
+		
+			assert.equals(set, set.asSet())
 		}'''.interpretPropagatingErrors
 	}
 	
@@ -75,7 +87,7 @@ class ListTest extends ListTestCase {
 	def void testFirstAndHead() {
 		'''
 		program p {
-			val list = #[1,2,3]
+			val list = [1,2,3]
 			
 			assert.equals(1, list.first())
 			assert.equals(1, list.head())

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ObjectTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ObjectTest.xtend
@@ -75,10 +75,10 @@ class ObjectTest extends AbstractWollokInterpreterTestCase {
 				val instVars = perro.instanceVariables()
 				assert.equals(2, instVars.size())
 				
-				val nombreInstVar = instVars.detect[e| e.name() == "nombre"]
+				val nombreInstVar = instVars.detect{e=> e.name() == "nombre"}
 				assert.equals("Colita", nombreInstVar.value())
 				
-				val edadInstVar = instVars.detect[e| e.name() == "edad"]
+				val edadInstVar = instVars.detect{e=> e.name() == "edad"}
 				assert.equals(7, edadInstVar.value())
 				
 «««				assert.equals("#[edad=7, nombre=Colita]",instVars.toString())

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -77,7 +77,7 @@ class SetTest extends CollectionTestCase {
 			
 			val list = set.asList()
 			assert.equals(3, list.size())
-			#[1,2,3].forEach[i|assert.equals(list.contains(i))]
+			[1,2,3].forEach{i=>assert.equals(list.contains(i))}
 		}'''.interpretPropagatingErrors
 	}
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/AbstractClassesAndMethods.wlk.xt.fails
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/AbstractClassesAndMethods.wlk.xt.fails
@@ -24,7 +24,7 @@ val b = new B()
 class C extends B {
 	override foo() { 42 }
 }
-// XPECT warnings --> "Unused variable" at "c"
+// XPECT warnings -=> "Unused variable" at "c"
 val c = new C()
 
 
@@ -45,5 +45,5 @@ class E extends D {
 	override bar() { 'bar' }
 }
 
-// XPECT warnings --> "Unused variable" at "e"
+// XPECT warnings -=> "Unused variable" at "e"
 val e = new E()

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/AssignmentToTheSameVariable.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/AssignmentToTheSameVariable.wlk.xt
@@ -9,10 +9,10 @@ class Golondrina {
 	}
 	
 	method comer(alimento) {
-		alimento.sum[ x | 
+		alimento.sum { x =>
 			// XPECT errors --> "Cannot assign a variable to itself. It does not have any effect" at "energia"
 			energia = energia 
-		]
+		}
 		
 		// XPECT errors --> "Cannot assign a variable to itself. It does not have any effect" at "y"
 		var y = y 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CannotModifyValues.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CannotModifyValues.wlk.xt
@@ -9,10 +9,10 @@ class A {
 	}
 	
 	method s() {
-		val aBlock = [a |
+		val aBlock = {a =>
 			// XPECT errors --> "Cannot modify values" at "a"
 			a = 23
-		]
+		}
 		// XPECT errors --> "Cannot modify values" at "aBlock"
 		aBlock = null
 	}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckOnNameStyles.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckOnNameStyles.wlk.xt
@@ -24,11 +24,11 @@
 			
 			var aBlock =
 			// XPECT errors --> "Referenciable name must start with lowercase" at "A" 
-			[A 
-				| A > 23
-			]
+			{A 
+				=> A > 23
+			}
 			
-			return #[car, Lota, aBlock]
+			return [car, Lota, aBlock]
 		}
 		
 	}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/DuplicatedChecksTestCase.wlk.xt.failing
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/DuplicatedChecksTestCase.wlk.xt.failing
@@ -13,27 +13,27 @@ class Person {
 		 ---
 	*/
 	var name = "asdd"
-	// XPECT warnings --> "Unused variable" at "toBeHidden"
+	// XPECT warnings -=> "Unused variable" at "toBeHidden"
 	var toBeHidden = 23
 	
 	new(
-		// XPECT errors --> "Duplicated name" at "a"
+		// XPECT errors -=> "Duplicated name" at "a"
 		a, 
-		// XPECT errors --> "Duplicated name" at "a"
+		// XPECT errors -=> "Duplicated name" at "a"
 		a
 	) {}
 	
 	
 	method repeatedParameters(
-		// XPECT errors --> "Duplicated name" at "p1"
+		// XPECT errors -=> "Duplicated name" at "p1"
 		p1,
-		// XPECT errors --> "Duplicated name" at "p1"
+		// XPECT errors -=> "Duplicated name" at "p1"
 		p1
 	) {}  
 	
 	
 	method hidingFieldWithParameter(
-		// XPECT errors --> "Duplicated name" at "toBeHidden"
+		// XPECT errors -=> "Duplicated name" at "toBeHidden"
 		toBeHidden
 	) {}
 	
@@ -60,14 +60,14 @@ class Person {
 		   "Unused variable" at "c"
 		   ---
 		 */
-		var c = [p1 | true ]
+		var c = {p1 => true }
 	}
 	
-	// XPECT errors --> "Duplicated method" at "dupMethod"
+	// XPECT errors -=> "Duplicated method" at "dupMethod"
 	method dupMethod() {}
-	// XPECT errors --> "Duplicated method" at "dupMethod"
+	// XPECT errors -=> "Duplicated method" at "dupMethod"
 	method dupMethod() {}
-	// XPECT errors --> "Duplicated method" at "dupMethod"
+	// XPECT errors -=> "Duplicated method" at "dupMethod"
 	method dupMethod(withParam) {}
 	
 }
@@ -89,11 +89,11 @@ class DuplicatedChecksTest {
 		val u = 566
 		
 		// dup closures params
-		// XPECT warnings --> "Unused variable" at "closure"
+		// XPECT warnings -=> "Unused variable" at "closure"
 		val closure = [
-			// XPECT errors --> "Duplicated name" at "y"
+			// XPECT errors -=> "Duplicated name" at "y"
 			y,
-			// XPECT errors --> "Duplicated name" at "y"
+			// XPECT errors -=> "Duplicated name" at "y"
 			y |
 			y.blah()
 		]
@@ -106,28 +106,28 @@ class DuplicatedChecksTest {
 			---
 		*/
 		
-		val cl = [u | u.blah() ]
-		// XPECT warnings --> "Unused variable" at "inner"
+		val cl = {u => u.blah() }
+		// XPECT warnings -=> "Unused variable" at "inner"
 		val inner = [a |
-			// XPECT errors --> "Duplicated name" at "a"
-			[a | true]
+			// XPECT errors -=> "Duplicated name" at "a"
+			{a => true}
 		]
 	}
 }
 
 
 package myPackage {
-	// XPECT errors --> "Duplicated class name in package myPackage" at "A"
+	// XPECT errors -=> "Duplicated class name in package myPackage" at "A"
 	class A {}
-	// XPECT errors --> "Duplicated class name in package myPackage" at "A"
+	// XPECT errors -=> "Duplicated class name in package myPackage" at "A"
 	class A {}
 }
 
-// XPECT errors --> "Duplicated package name otherPackage" at "otherPackage"
+// XPECT errors -=> "Duplicated package name otherPackage" at "otherPackage"
 package otherPackage {
 	class A {} // this one is ok, it's in another package
 }
 
-// XPECT errors --> "Duplicated package name otherPackage" at "otherPackage"
+// XPECT errors -=> "Duplicated package name otherPackage" at "otherPackage"
 package otherPackage {}
 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MethodNotReturningValue.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MethodNotReturningValue.wlk.xt
@@ -31,5 +31,6 @@ object sarasita {
 	}
 	
 	method returningAValue() { return 2 }
+	method returningWithShortSyntax() = 2
 	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MethodNotReturningValue.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MethodNotReturningValue.wlk.xt
@@ -15,9 +15,9 @@ object sarasita {
 		false
 	}
 	
-	// XPECT warnings --> "Method produces a value but you are not returning it. Did you forget the return ?" at "{ #[1, 2, 3] }"
+	// XPECT warnings --> "Method produces a value but you are not returning it. Did you forget the return ?" at "{ [1, 2, 3] }"
 	method collectionLiteral() {
-		#[1, 2, 3]
+		[1, 2, 3]
 	}
 	
 	// XPECT warnings --> "Method produces a value but you are not returning it. Did you forget the return ?" at "{ 1 + 2 }"

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MethodReturnOnAllFlows.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MethodReturnOnAllFlows.wlk.xt
@@ -98,10 +98,10 @@ class A {
 	}
 	
 	method cargar() {
-		#["hola", "chau"]
-			.map[ p |
+		["hola", "chau"]
+			.map{ p =>
 				return p
-			]
+			}
 	}
 
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MultiOpsOperations.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MultiOpsOperations.wlk.xt
@@ -2,7 +2,7 @@
 
 class MultiOpsOperations {
 	
-	method run() = {
+	method run() {
 		var n = 1
 		n++  // OK
 		
@@ -14,7 +14,7 @@ class MultiOpsOperations {
 		
 		val edad = 10
 		// XPECT errors --> "++ can only be applied to variable references" at "edad"
-		edad++
+		return edad++
 	}	
 }
 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NoExpressionAfterReturn.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NoExpressionAfterReturn.wlk.xt
@@ -3,11 +3,11 @@
 class A {
 	// XPECT errors --> "Must return a value on every possible flow" at "inABlock"
 	method inABlock() {
-		val aBlock = [a |
+		val aBlock = {a =>
 			return a
 			// XPECT errors --> "Unexpected expression after return" at "a > 23"
 			a > 23
-		]
+		}
 		return aBlock
 		
 		// XPECT errors --> "Unexpected expression after return" at "val b = '23'"

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NoExpressionAfterThrow.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NoExpressionAfterThrow.wlk.xt
@@ -2,11 +2,11 @@
 
 class A {
 	method inABlock() {
-		val aBlock = [a |
+		val aBlock = {a =>
 			throw new Exception()
 			// XPECT errors --> "Unexpected expression after throw" at "a > 23"
 			a > 23
-		]
+		}
 		aBlock.apply(23)
 		throw new Exception()
 		

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/PostFixOperations.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/PostFixOperations.wlk.xt
@@ -1,7 +1,7 @@
 /* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
 
 class PostFixOperations {
-	method run() = {
+	method run() {
 		val n = 1
 		
 		// XPECT errors --> "++ can only be applied to variable references" at "n"
@@ -11,7 +11,7 @@ class PostFixOperations {
 		(n == 1)++
 		
 		// XPECT errors --> "++ can only be applied to variable references" at "new Pepita()"
-		new Pepita()++
+		return new Pepita()++
 	}
 }
 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/TestWithVariables.wtest.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/TestWithVariables.wtest.xt
@@ -4,24 +4,24 @@ import wollok.lib.assert
 test "testX" {
 
 	// 1 param
-	val incrementClosure = [param | param + 1]
+	val incrementClosure = {param => param + 1}
 	assert.that(incrementClosure.apply(2) == 3)
 	
 	// 2 params
-	val addition = [a, b | a + b]
+	val addition = {a, b => a + b}
 	assert.that(addition.apply(10, 15) == 25)
 	
 	
 	// using outside context VALUE
 	val n1 = 2
-	val multiplyByN1 = [i| i * n1]
+	val multiplyByN1 = {i=> i * n1}
 	
 	assert.that(multiplyByN1.apply(3) == 6)
 	
 	
 	// using outside context VARIABLE (mutating)
 	var n2 = 2
-	val multiplyByN2 = [i| i * n2]
+	val multiplyByN2 = {i=> i * n2}
 	n2 = 10
 	
 	assert.equals(30,multiplyByN2.apply(3))

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/UnusedVariable.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/UnusedVariable.wlk.xt
@@ -13,9 +13,9 @@ class WithUnusedVariables {
 	
 	val usedOnlyWithUnary = ""
 	
-	var equipos = #[]
+	var equipos = []
 	
-	method doSomething() = {
+	method doSomething() {
 		a = a + 1 + c + x
 		d = 123
 		//XPECT errors --> "Cannot modify values" at "z"
@@ -53,10 +53,10 @@ class UnusedVariables {
 			}
 			method peso() = peso
 		}
-		val vacas = #[vaca1, vaca2]
+		val vacas = [vaca1, vaca2]
 		
-		vacas.forEach([v | v.engordar(2)])
-		return vacas.forAll([v | v.peso() == 1002])
+		vacas.forEach({v => v.engordar(2)})
+		return vacas.forAll({v => v.peso() == 1002})
 	}
 	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/VarArgs.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/VarArgs.wlk.xt
@@ -3,7 +3,7 @@
 class A {
 
 	method preffix(preffix, numbers...) {
-		return numbers.map[n| preffix + n]
+		return numbers.map{n=> preffix + n}
 	}
 	
 	// XPECT errors --> "Only the last parameter can be a vararg" at "..."	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/VoidMethodsUsage.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/VoidMethodsUsage.wlk.xt
@@ -51,8 +51,8 @@ class MethodsCalledOnWellKnowObjects inherits A {
 			30	
 	}
 	
-	method asABinaryOperatorArgument() = {
-		#[
+	method asABinaryOperatorArgument() {
+		return [
 			// XPECT errors --> "This message call produces no value" at "eat" 
 			10 + pepita.eat(10),
 			// XPECT errors --> "This message call produces no value" at "eat" 
@@ -69,9 +69,9 @@ class MethodsCalledOnWellKnowObjects inherits A {
 		pepita.eat(10).cantina() 
 	}
 	
-	method asListLiteralElement() = {
+	method asListLiteralElement() {
 		// XPECT errors --> "This message call produces no value" at "eat"
-		#[1, 2, 3, pepita.eat(10)] 
+		return [1, 2, 3, pepita.eat(10)] 
 	}
 	
 	override method toBeOverriden(a) {
@@ -79,9 +79,9 @@ class MethodsCalledOnWellKnowObjects inherits A {
 		super(pepita.eat(10))
 	}
 	
-	method asConstructorArg() = {
+	method asConstructorArg() {
 		// XPECT errors --> "This message call produces no value" at "eat"
-		new B(pepita.eat(10)) 
+		return new B(pepita.eat(10)) 
 	}
 	
 	// XPECT errors --> "This message call produces no value" at "eat"

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/formatter/WollokFormatterTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/formatter/WollokFormatterTestCase.xtend
@@ -222,7 +222,7 @@ class WollokFormatterTestCase extends AbstractXtextTests {
 		method blah() {
 			val a = ""
 			val b = 2
-			val c = new    Direccion  (  a   ,  b   ,  "blah"   ,   #[1,2,3]    )
+			val c = new    Direccion  (  a   ,  b   ,  "blah"   ,   [1,2,3]    )
 		}
 	}''',
         '''
@@ -237,7 +237,7 @@ class Client {
 	method blah() {
 		val a = ""
 		val b = 2
-		val c = new Direccion(a, b, "blah", #[ 1, 2, 3 ])
+		val c = new Direccion(a, b, "blah", [ 1, 2, 3 ])
 	}
 }''')
     }

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/Messages.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/Messages.java
@@ -58,8 +58,8 @@ public class Messages extends NLS {
 	public static String WollokTemplateProposalProvider_WIfExpression_name;
 	public static String WollokTemplateProposalProvider_WIfExpression_description;
 	
-	public static String WollokTemplateProposalProvider_WListLiteral_name;
-	public static String WollokTemplateProposalProvider_WListLiteral_description;
+	public static String WollokTemplateProposalProvider_WCollectionLiteral_name;
+	public static String WollokTemplateProposalProvider_WCollectionLiteral_description;
 	
 	public static String WollokTemplateProposalProvider_WSetLiteral_name;
 	public static String WollokTemplateProposalProvider_WSetLiteral_description;

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/BasicTypeResolver.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/BasicTypeResolver.xtend
@@ -1,19 +1,18 @@
 package org.uqbar.project.wollok.ui.contentassist
 
-import com.google.inject.Inject
 import org.eclipse.emf.ecore.EObject
 import org.uqbar.project.wollok.interpreter.WollokClassFinder
 import org.uqbar.project.wollok.wollokDsl.WBooleanLiteral
+import org.uqbar.project.wollok.wollokDsl.WConstructorCall
 import org.uqbar.project.wollok.wollokDsl.WListLiteral
 import org.uqbar.project.wollok.wollokDsl.WMethodContainer
 import org.uqbar.project.wollok.wollokDsl.WNumberLiteral
 import org.uqbar.project.wollok.wollokDsl.WSetLiteral
 import org.uqbar.project.wollok.wollokDsl.WStringLiteral
 import org.uqbar.project.wollok.wollokDsl.WVariable
+import org.uqbar.project.wollok.wollokDsl.WVariableReference
 
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
-import org.uqbar.project.wollok.wollokDsl.WVariableReference
-import org.uqbar.project.wollok.wollokDsl.WConstructorCall
 
 /**
  * Really basic impl while we don't have the type system.

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/editor/templates/WollokTemplateProposalProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/editor/templates/WollokTemplateProposalProvider.xtend
@@ -14,20 +14,20 @@ import org.eclipse.xtext.ui.editor.templates.ContextTypeIdHelper
 import org.eclipse.xtext.ui.editor.templates.DefaultTemplateProposalProvider
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess
 import org.uqbar.project.wollok.wollokDsl.WClass
-import org.uqbar.project.wollok.wollokDsl.WNamedObject
-import org.uqbar.project.wollok.wollokDsl.WObjectLiteral
-import org.uqbar.project.wollok.wollokDsl.WProgram
-import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
-
-import static org.uqbar.project.wollok.ui.Messages.*
-import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
+import org.uqbar.project.wollok.wollokDsl.WClosure
 import org.uqbar.project.wollok.wollokDsl.WConstructorCall
 import org.uqbar.project.wollok.wollokDsl.WIfExpression
 import org.uqbar.project.wollok.wollokDsl.WListLiteral
+import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
+import org.uqbar.project.wollok.wollokDsl.WNamedObject
+import org.uqbar.project.wollok.wollokDsl.WObjectLiteral
+import org.uqbar.project.wollok.wollokDsl.WProgram
 import org.uqbar.project.wollok.wollokDsl.WSetLiteral
-import org.uqbar.project.wollok.wollokDsl.WClosure
 import org.uqbar.project.wollok.wollokDsl.WTest
 import org.uqbar.project.wollok.wollokDsl.WTry
+import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
+
+import static org.uqbar.project.wollok.ui.Messages.*
 
 /**
  * Provides code templates for the editor.

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages.properties
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages.properties
@@ -112,8 +112,8 @@ WollokTemplateProposalProvider_WConstructorCall_description = Add a Constructor 
 WollokTemplateProposalProvider_WIfExpression_name = If expression
 WollokTemplateProposalProvider_WIfExpression_description = Add if expression
 	
-WollokTemplateProposalProvider_WListLiteral_name = List
-WollokTemplateProposalProvider_WListLiteral_description = Add a list 
+WollokTemplateProposalProvider_WCollectionLiteral_name = List
+WollokTemplateProposalProvider_WCollectionLiteral_description = Add a list 
 	
 WollokTemplateProposalProvider_WSetLiteral_name = Set
 WollokTemplateProposalProvider_WSetLiteral_description = Add a set 

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages_es.properties
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages_es.properties
@@ -108,8 +108,8 @@ WollokTemplateProposalProvider_WConstructorCall_description = Agregar llamada a 
 WollokTemplateProposalProvider_WIfExpression_name = If
 WollokTemplateProposalProvider_WIfExpression_description = Agregar una expresion if
 	
-WollokTemplateProposalProvider_WListLiteral_name = Lista
-WollokTemplateProposalProvider_WListLiteral_description = Agregar una lista 
+WollokTemplateProposalProvider_WCollectionLiteral_name = Lista
+WollokTemplateProposalProvider_WCollectionLiteral_description = Agregar una lista 
 	
 WollokTemplateProposalProvider_WSetLiteral_name = Conjunto
 WollokTemplateProposalProvider_WSetLiteral_description = Agregar un conjunto 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
@@ -295,7 +295,7 @@ WClosure returns WExpression:
 		expression=WBlockInClosure 
 	'}';
 
-WBlockInClosure: 
+WBlockInClosure returns WExpression: 
 	{WBlockExpression}
 	(expressions+=WExpressionOrVarDeclaration ';'?)*;
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
@@ -251,8 +251,7 @@ WVariableReference:
 ;
 
 WBlockOrExpression returns WExpression:
-	WExpression | WBlockExpression
-;
+	(=> WBlockExpression) | WExpression;
 
 WIfExpression:
 	'if' '(' condition=WExpression ')' 
@@ -292,7 +291,7 @@ WNumberLiteral returns WExpression :
 WClosure returns WExpression:
 	=>({WClosure} 
 	'{') 
-		=>(parameters+=WParameter (',' parameters+=WParameter)*)? '=>'
+		=>((parameters+=WParameter (',' parameters+=WParameter)*)? '=>')?
 		expression=WBlockInClosure 
 	'}';
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
@@ -155,11 +155,10 @@ WOtherOperatorExpression returns WExpression:
 	rightOperand=WAdditiveExpression)*;
 
 OpOther:
-	  '->' 
-	| '..<'
+	  '..<'
 	| '>' '..'
 	| '..'
-	| '=>' 
+	| '->' 
 	| '>' (=>('>' '>') | '>') 
 	| '<' (=>('<' '<') | '<' | '=>')
 	| '<>'
@@ -214,7 +213,6 @@ WThis returns WExpression:
 ;
 
 WPrimaryExpression returns WExpression:
-	WBlockExpression |
 	WVariableReference |
 	WLiteral |
 	WConstructorCall |
@@ -252,11 +250,15 @@ WVariableReference:
 	{WVariableReference} ref=[WReferenciable]
 ;
 
+WBlockOrExpression returns WExpression:
+	WExpression | WBlockExpression
+;
+
 WIfExpression:
 	'if' '(' condition=WExpression ')' 
-		then=WExpression
+		then=WBlockOrExpression
 	(=>'else'
-		else=WExpression
+		else=WBlockOrExpression
 	)?
 ;
 
@@ -289,27 +291,26 @@ WNumberLiteral returns WExpression :
 
 WClosure returns WExpression:
 	=>({WClosure} 
-	'[') 
-		=>((parameters+=WParameter (',' parameters+=WParameter)*)? explicitSyntax?='|')? 
-		expression=WExpressionInClosure 
-	']';
+	'{') 
+		=>(parameters+=WParameter (',' parameters+=WParameter)*)? '=>'
+		expression=WBlockInClosure 
+	'}';
 
-WExpressionInClosure returns WExpression: 
+WBlockInClosure: 
 	{WBlockExpression}
 	(expressions+=WExpressionOrVarDeclaration ';'?)*;
 
 // COLLECTIONS
 
 WCollectionLiteral:
-	WListLiteral | WSetLiteral
-;
+	WListLiteral | WSetLiteral;
 
-WListLiteral returns WCollectionLiteral:
-	{WListLiteral} '#' '[' (elements+=WExpression (',' elements+=WExpression )*)? ']';
+WListLiteral:
+	{WListLiteral} '[' (elements+=WExpression (',' elements+=WExpression )*)? ']';
+
+WSetLiteral:
+	{WSetLiteral} '#{' (elements+=WExpression (',' elements+=WExpression )*)? '}';
 	
-WSetLiteral returns WCollectionLiteral:
-	{WSetLiteral} '#' '{' (elements+=WExpression (',' elements+=WExpression )*)? '}';
-
 WNamedObject:
 	'object' name=ID ('inherits' parent=[WClass|QualifiedName] ('(' parentParameters+=WExpression (',' parentParameters+=WExpression)* ')')? )?'{'
 		(members+=WVariableDeclaration ';'?)*
@@ -365,14 +366,14 @@ WConstructorCall:
 
 WTry:
 	'try'
-		expression=WExpression
+		expression=WBlockOrExpression
 	(catchBlocks+=WCatch)*
-	(=>'then always' alwaysExpression=WExpression)?
+	(=>'then always' alwaysExpression=WBlockOrExpression)?
 ;
 
 WCatch:
 	=>'catch' exceptionVarName=WVariable (':' exceptionType=[WClass|QualifiedName])?
-		expression=WExpression 
+		expression=WBlockOrExpression 
 ;
 
 WReturnExpression:

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting/WollokDslFormatter.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting/WollokDslFormatter.xtend
@@ -5,7 +5,6 @@ import org.eclipse.xtext.formatting.impl.AbstractDeclarativeFormatter
 import org.eclipse.xtext.formatting.impl.FormattingConfig
 import org.eclipse.xtext.service.AbstractElementFinder.AbstractParserRuleElementFinder
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess
-import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WBlockExpressionElements
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WCatchElements
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WClassElements
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WConstructorCallElements
@@ -19,12 +18,14 @@ import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WNamedObjectElem
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WObjectLiteralElements
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WPackageElements
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WProgramElements
+import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WSetLiteralElements
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WSuperInvocationElements
+import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WTestElements
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WTryElements
 import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WVariableDeclarationElements
 
 import static extension org.uqbar.project.wollok.utils.StringUtils.firstUpper
-import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WTestElements
+import org.uqbar.project.wollok.services.WollokDslGrammarAccess.WBlockExpressionElements
 
 /**
  * This class contains custom formatting description.
@@ -254,14 +255,18 @@ class WollokDslFormatter extends AbstractDeclarativeFormatter {
 		setLinewrap(1, 1, 1).after(rightCurlyBracketKeyword_6)
 	}
 	
-	def dispatch formatting(FormattingConfig it, extension WListLiteralElements l) {
-		// #[  together
-		setNoSpace.after(numberSignKeyword_1)
-		
+	def dispatch formatting(FormattingConfig it, extension WSetLiteralElements l) {
 		// nospace ',' then space 
-		setNoSpace.before(commaKeyword_3_1_0)
-		setSpace(' ').after(commaKeyword_3_1_0)
+		setNoSpace.before(commaKeyword_2_1_0)
+		setSpace(' ').after(commaKeyword_2_1_0)
 	}
+	
+	def dispatch formatting(FormattingConfig it, extension WListLiteralElements l) {
+		// nospace ',' then space 
+		setNoSpace.before(commaKeyword_2_1_0)
+		setSpace(' ').after(commaKeyword_2_1_0)
+	}
+	
 	
 	def dispatch formatting(FormattingConfig it, extension WIfExpressionElements i) {
 		setNoSpace.after(leftParenthesisKeyword_1)

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -22,7 +22,6 @@ import org.uqbar.project.wollok.interpreter.stack.ReturnValueException
 import org.uqbar.project.wollok.scoping.WollokQualifiedNameProvider
 import org.uqbar.project.wollok.wollokDsl.WAssignment
 import org.uqbar.project.wollok.wollokDsl.WBinaryOperation
-import org.uqbar.project.wollok.wollokDsl.WBlockExpression
 import org.uqbar.project.wollok.wollokDsl.WBooleanLiteral
 import org.uqbar.project.wollok.wollokDsl.WCatch
 import org.uqbar.project.wollok.wollokDsl.WClass
@@ -61,6 +60,7 @@ import static extension org.uqbar.project.wollok.interpreter.context.EvaluationC
 import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions.*
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
+import org.uqbar.project.wollok.wollokDsl.WBlockExpression
 
 /**
  * It's the real "interpreter".

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WBlockExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WBlockExtensions.xtend
@@ -1,11 +1,11 @@
 package org.uqbar.project.wollok.model
 
 import java.util.List
-import org.uqbar.project.wollok.wollokDsl.WBlockExpression
 import org.uqbar.project.wollok.wollokDsl.WExpression
+import org.uqbar.project.wollok.wollokDsl.WBlockExpression
 
 /**
- * Extension methods for WBlockExpressions
+ * Extension methods for WBlocks
  * 
  * @author jfernandes
  */

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -9,6 +9,7 @@ import org.uqbar.project.wollok.interpreter.WollokRuntimeException
 import org.uqbar.project.wollok.wollokDsl.WBlockExpression
 import org.uqbar.project.wollok.wollokDsl.WBooleanLiteral
 import org.uqbar.project.wollok.wollokDsl.WClass
+import org.uqbar.project.wollok.wollokDsl.WClosure
 import org.uqbar.project.wollok.wollokDsl.WConstructor
 import org.uqbar.project.wollok.wollokDsl.WExpression
 import org.uqbar.project.wollok.wollokDsl.WFeatureCall
@@ -30,10 +31,9 @@ import org.uqbar.project.wollok.wollokDsl.WVariable
 import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
 import org.uqbar.project.wollok.wollokDsl.WVariableReference
 
+import static extension org.eclipse.xtext.EcoreUtil2.*
 import static extension org.uqbar.project.wollok.interpreter.WollokInterpreterEvaluator.*
 import static extension org.uqbar.project.wollok.ui.utils.XTendUtilExtensions.*
-import static extension org.eclipse.xtext.EcoreUtil2.*
-import org.uqbar.project.wollok.wollokDsl.WClosure
 
 /**
  * Extension methods for WMethodContainers.

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
@@ -1,3 +1,4 @@
+
 package org.uqbar.project.wollok.model
 
 import java.util.List
@@ -14,14 +15,15 @@ import org.uqbar.project.wollok.wollokDsl.WAssignment
 import org.uqbar.project.wollok.wollokDsl.WBinaryOperation
 import org.uqbar.project.wollok.wollokDsl.WBlockExpression
 import org.uqbar.project.wollok.wollokDsl.WBooleanLiteral
+import org.uqbar.project.wollok.wollokDsl.WCatch
 import org.uqbar.project.wollok.wollokDsl.WClass
 import org.uqbar.project.wollok.wollokDsl.WClosure
-import org.uqbar.project.wollok.wollokDsl.WCollectionLiteral
 import org.uqbar.project.wollok.wollokDsl.WConstructor
 import org.uqbar.project.wollok.wollokDsl.WConstructorCall
 import org.uqbar.project.wollok.wollokDsl.WExpression
 import org.uqbar.project.wollok.wollokDsl.WFile
 import org.uqbar.project.wollok.wollokDsl.WIfExpression
+import org.uqbar.project.wollok.wollokDsl.WCollectionLiteral
 import org.uqbar.project.wollok.wollokDsl.WMemberFeatureCall
 import org.uqbar.project.wollok.wollokDsl.WMethodContainer
 import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
@@ -33,9 +35,11 @@ import org.uqbar.project.wollok.wollokDsl.WPackage
 import org.uqbar.project.wollok.wollokDsl.WParameter
 import org.uqbar.project.wollok.wollokDsl.WProgram
 import org.uqbar.project.wollok.wollokDsl.WReferenciable
+import org.uqbar.project.wollok.wollokDsl.WReturnExpression
 import org.uqbar.project.wollok.wollokDsl.WStringLiteral
 import org.uqbar.project.wollok.wollokDsl.WTest
 import org.uqbar.project.wollok.wollokDsl.WThis
+import org.uqbar.project.wollok.wollokDsl.WThrow
 import org.uqbar.project.wollok.wollokDsl.WTry
 import org.uqbar.project.wollok.wollokDsl.WVariable
 import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
@@ -44,9 +48,7 @@ import wollok.lang.Exception
 
 import static extension org.uqbar.project.wollok.interpreter.WollokInterpreterEvaluator.hookObjectInHierarhcy
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
-import org.uqbar.project.wollok.wollokDsl.WReturnExpression
-import org.uqbar.project.wollok.wollokDsl.WThrow
-import org.uqbar.project.wollok.wollokDsl.WCatch
+import org.uqbar.project.wollok.wollokDsl.WBlockExpression
 
 /**
  * Extension methods to Wollok semantic model.

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/visitors/AbstractVisitor.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/visitors/AbstractVisitor.xtend
@@ -8,7 +8,6 @@ import org.uqbar.project.wollok.wollokDsl.WBooleanLiteral
 import org.uqbar.project.wollok.wollokDsl.WCatch
 import org.uqbar.project.wollok.wollokDsl.WClass
 import org.uqbar.project.wollok.wollokDsl.WClosure
-import org.uqbar.project.wollok.wollokDsl.WCollectionLiteral
 import org.uqbar.project.wollok.wollokDsl.WConstructor
 import org.uqbar.project.wollok.wollokDsl.WConstructorCall
 import org.uqbar.project.wollok.wollokDsl.WIfExpression
@@ -33,6 +32,7 @@ import org.uqbar.project.wollok.wollokDsl.WTry
 import org.uqbar.project.wollok.wollokDsl.WUnaryOperation
 import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
 import org.uqbar.project.wollok.wollokDsl.WVariableReference
+import org.uqbar.project.wollok.wollokDsl.WCollectionLiteral
 
 /**
  * Implements an abstract visitor for the AST

--- a/org.uqbar.project.xinterpreter/.project
+++ b/org.uqbar.project.xinterpreter/.project
@@ -16,17 +16,17 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.pde.ManifestBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
 			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/org.uqbar.project.xinterpreter/.project
+++ b/org.uqbar.project.xinterpreter/.project
@@ -16,17 +16,17 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.pde.ManifestBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
 			<name>org.eclipse.pde.SchemaBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/wollok-tests/src/10_collection_literals.wpgm
+++ b/wollok-tests/src/10_collection_literals.wpgm
@@ -1,6 +1,6 @@
 program collections {
 
-val numbers = #[2, 23, 25]
+val numbers = [2, 23, 25]
 
 this.println(numbers)
 
@@ -8,7 +8,7 @@ val y = 23
 val z = 2.2
 
 val x = "Hola"
-val bag = #[x,y,z]
+val bag = [x,y,z]
 this.println(bag)
 
 // ***************************
@@ -21,8 +21,8 @@ assert.that(numbers.contains(23))
 this.assertFalse(numbers.contains(1))
 
 // forAll
-assert.that(#[20, 22, 34].forAll([n | n > 18]))
-this.assertFalse(#[20, 22, 34].forAll([n | n > 30]))
+assert.that([20, 22, 34].forAll({n => n > 18}))
+this.assertFalse([20, 22, 34].forAll({n => n > 30}))
 
 // forEach
 val vaca1 = object {
@@ -40,18 +40,18 @@ val vaca2 = object {
 	}
 	method peso() = peso
 }
-val vacas = #[vaca1, vaca2]
+val vacas = [vaca1, vaca2]
 
-vacas.forEach[v | v.engordar(2)]
-assert.that(vacas.forAll[v | v.peso() == 1002])
+vacas.forEach{v => v.engordar(2)}
+assert.that(vacas.forAll{v => v.peso() == 1002})
 
 // map
-val mapped = vacas.map[v | v.peso()]
-assert.that(mapped.forAll[p | p == 1002])
+val mapped = vacas.map{v => v.peso()}
+assert.that(mapped.forAll{p => p == 1002})
 
 
 // filter
-val r = #[10, 20, 30, 40, 50].filter[n| n > 30]
+val r = [10, 20, 30, 40, 50].filter{n=> n > 30}
 assert.that(r.size() == 2)
 assert.that(r.contains(40))
 assert.that(r.contains(50))

--- a/wollok-tests/src/9_closures.wpgm
+++ b/wollok-tests/src/9_closures.wpgm
@@ -1,23 +1,23 @@
 program closures {
 // 1 param
-val incrementClosure = [param | param + 1]
+val incrementClosure = {param => param + 1}
 assert.that(incrementClosure.apply(2) == 3)
 
 // 2 params
-val addition = [a, b | a + b]
+val addition = {a, b => a + b}
 assert.that(addition.apply(10, 15) == 25)
 
 
 // using outside context VALUE
 val n1 = 2
-val multiplyByN1 = [i| i * n1]
+val multiplyByN1 = {i=> i * n1}
 
 assert.that(multiplyByN1.apply(3) == 6)
 
 
 // using outside context VARIABLE (mutating)
 var n2 = 2
-val multiplyByN2 = [i| i * n2]
+val multiplyByN2 = {i=> i * n2}
 n2 = 10
 
 assert.equals(30,multiplyByN2.apply(3))

--- a/wollok-tests/src/bugs/b40.wlk
+++ b/wollok-tests/src/bugs/b40.wlk
@@ -1,8 +1,8 @@
 object pajarera {
     var energiaMenor = 100 
-    var pajaros = #[pepita, pepe]
+    var pajaros = [pepita, pepe]
     method menorValor(){
-        pajaros.forEach[a|a.sosMenor(energiaMenor)]
+        pajaros.forEach{a=>a.sosMenor(energiaMenor)}
         return energiaMenor
     }      
 
@@ -26,9 +26,9 @@ object pepita {
 
 class Arturo {
 	var energiaMenor = 100 
-    var pajaros = #[pepita, pepe]
+    var pajaros = [pepita, pepe]
     method menorValor(){
-        pajaros.forEach[a | a.sosMenor(energiaMenor)]
+        pajaros.forEach{a => a.sosMenor(energiaMenor)}
         return energiaMenor
     }      
 

--- a/wollok-tests/src/bugs/b44.wtest
+++ b/wollok-tests/src/bugs/b44.wtest
@@ -1,6 +1,6 @@
 
 test "Testing regretion of Bug #44" {
-	val aList = #[ 1, 2, 3, 4]
+	val aList = [ 1, 2, 3, 4]
 	val clone = aList.clone()
 	
 	assert.equals(aList.getClass(), clone.getClass())

--- a/wollok-tests/src/bugs/recursiveToString.wpgm
+++ b/wollok-tests/src/bugs/recursiveToString.wpgm
@@ -6,7 +6,7 @@ object obj2 {
 }
 
 object obj1 {
-	var x = #[]
+	var x = []
 	method addX(anObject){
 		x.add(anObject)
 	}
@@ -21,5 +21,5 @@ program a {
 	obj2.setY(obj1)
 	obj1.addX(new Prb())
 	
-	assert.equals('obj2[y=obj1[x=#[anObject,aPrb]]]', obj2.toString())
+	assert.equals('obj2[y=obj1[x=[anObject,aPrb]]]', obj2.toString())
 }

--- a/wollok-tests/src/wollok/classes/autocomplete.wpgm
+++ b/wollok-tests/src/wollok/classes/autocomplete.wpgm
@@ -35,9 +35,9 @@ program autocomplete {
 	// *************
 	// closures
 	
-	var aBlock = [auto |
+	var aBlock = {auto =>
 		// ufa, no anda acá.
-	]
+	}
 
-	var otro = [auto | auto.arrancar() ]
+	var otro = {auto => auto.arrancar() }
 }

--- a/wollok-tests/src/wollok/classes/zuper.wlk
+++ b/wollok-tests/src/wollok/classes/zuper.wlk
@@ -11,7 +11,7 @@ class Golondrina {
 	
 	method gastoParaVolar(kms) = kms
 	
-	method blah(a) = {
+	method blah(a) {
 		this.gastoParaVolar(a)
 		// super(a) // FAIL OK !
 	}

--- a/wollok-tests/src/wollok/examples/guia2/clases_ej3_camiones.wlk
+++ b/wollok-tests/src/wollok/examples/guia2/clases_ej3_camiones.wlk
@@ -1,15 +1,15 @@
 class Deposito {
-	var camiones = #[]
+	var camiones = []
 	
-	method cargaEnViaje() = camiones.sum[camion | camion.capacidadDisponible()]
+	method cargaEnViaje() = camiones.sum{camion => camion.capacidadDisponible()}
 	
-	method camionesQueCargan(unContenido) = camiones.filter[camion | camion.estaCargando(unContenido)]
+	method camionesQueCargan(unContenido) = camiones.filter{camion => camion.estaCargando(unContenido)}
 	
-	method camionConMayorCantidadDeCosos() = camiones.max[camion | camion.getCosos().size()]
+	method camionConMayorCantidadDeCosos() = camiones.max{camion => camion.getCosos().size()}
 }
 
 class Camion {
-	var cosos = #[]
+	var cosos = []
 	var cargaMaxima
 	var estado = disponible
 	
@@ -17,7 +17,7 @@ class Camion {
 
 	method getCosos() = cosos
 
-	method cargaActual() =this.getCosos().sum[bulto | bulto.peso()]
+	method cargaActual() =this.getCosos().sum{bulto => bulto.peso()}
 
 	method puedeCargar(unCoso) = this.tieneLugarPara(unCoso) && estado.sePuedeCargar()
 	
@@ -35,25 +35,25 @@ class Camion {
 	
 	method getCargaMaxima() = cargaMaxima
 	
-	method estaCargando(unContenido) = this.tieneLugar() && this.getCosos().exists[coso | coso.getContenido() == unContenido]
+	method estaCargando(unContenido) = this.tieneLugar() && this.getCosos().exists{coso => coso.getContenido() == unContenido}
 	
-	method cosoMasLiviano() = this.getCosos().min[coso | coso.peso()]
+	method cosoMasLiviano() = this.getCosos().min{coso => coso.peso()}
 	
-	method elementosEnComunCon(otroCamion) = this.getCosos().filter[coso | otroCamion.getCosos().contains(coso)] 
+	method elementosEnComunCon(otroCamion) = this.getCosos().filter{coso => otroCamion.getCosos().contains(coso)} 
 }
 
 class CamionReutilizable inherits Camion {
-	var destinos = #[]
+	var destinos = []
 	
 	new(cargaMaximaPosible) = super(cargaMaximaPosible)
 	
-	override method getCosos() = destinos.map[destino | destino.getCosos()].flatten() 
+	override method getCosos() = destinos.map{destino => destino.getCosos()}.flatten() 
 	
-	method descargarCamionEn(unLugar) { destino.remove(destinos.detect[destino | destino.getLugar() == unLugar]) }
+	method descargarCamionEn(unLugar) { destino.remove(destinos.detect{destino => destino.getLugar() == unLugar}) }
 	
 	method cargarUnCosoEnDestino(unCoso, unLugar) {
 		if(this.puedeCargar(unCoso)) {
-			var destino = destinos.detect[destino | destino.getLugar() == unLugar]
+			var destino = destinos.detect{destino => destino.getLugar() == unLugar}
 			if (destino == null) {
 				var nuevoDestino = new Destino(unLugar)
 				nuevoDestino.getCosos().add(unCoso)
@@ -67,7 +67,7 @@ class CamionReutilizable inherits Camion {
 
 class Destino {
 	var lugar
-	var cosos = #[]
+	var cosos = []
 	
 	new(unLugar) { lugar = unLugar }
 	method getLugar() = lugar 

--- a/wollok-tests/src/wollok/examples/guia2/objetos_ej1_pajarera.wlk
+++ b/wollok-tests/src/wollok/examples/guia2/objetos_ej1_pajarera.wlk
@@ -77,7 +77,7 @@ object golondrina1 {
 
 object pajarera {
 	
-	val pajaros = #[pepita, pepona, otraPepita]
+	val pajaros = [pepita, pepona, otraPepita]
 	
 	method cuantosHay() {
 		return pajaros.size()
@@ -92,16 +92,16 @@ object pajarera {
 	}
 
 	method alimentarATodosCon(alpiste) {
-		pajaros.forEach[p | p.comer(alpiste)]
+		pajaros.forEach{p => p.comer(alpiste)}
 	}
  	
  	method sonTodosSaludables() {
- 		var suma = pajaros.sum[p | p.energia()]
+ 		var suma = pajaros.sum{p => p.energia()}
  		return suma
  	}
  	
  	method alimentarALaPeor() {
- 		return pajaros.min[p | p.energia()]
+ 		return pajaros.min{p => p.energia()}
  	
  	}
 }

--- a/wollok-tests/src/wollok/examples/guia2/objetos_ej2_deliveryEmpanadas.wlk
+++ b/wollok-tests/src/wollok/examples/guia2/objetos_ej2_deliveryEmpanadas.wlk
@@ -85,22 +85,22 @@ object jose {
 }
 
 object delivery {
-	val transportes = #[ biciVieja, biciNueva, motoGrande, motoChica, jose ]
+	val transportes = [ biciVieja, biciNueva, motoGrande, motoChica, jose ]
 
 	method cantidadTotalQueSePuedeTransportar() {
-		return transportes.sum[ t | t.capacidad() ]
+		return transportes.sum{ t => t.capacidad() }
 	}
 
 	method transportesQuePuedenLlevar(pedido, distancia) {
-		return transportes.filter[ t | t.puedeLlevar(pedido, distancia) ]
+		return transportes.filter{ t => t.puedeLlevar(pedido, distancia) }
 	}
 
 	method esPosibleHacerPedido(pedido, distancia) {
-		return transportes.exists[ t | t.puedeLlevar(pedido, distancia) ] ;
+		return transportes.exists{ t => t.puedeLlevar(pedido, distancia) } ;
 	}
 
 	method transporteQuePuedeLlevar(pedido, distancia) {
-		return transportes.detect[ t | t.puedeLlevar(pedido, distancia) ]
+		return transportes.detect{ t => t.puedeLlevar(pedido, distancia) }
 	}
 
 	method desperdicio(transporte, pedido, distancia) {
@@ -122,27 +122,27 @@ object delivery {
 	method mejorTransporteParaLlevar(pedido, distancia) {
 		var desperdicio = 1000
 		var mejorTransporte = null
-		this.transportesQuePuedenLlevar(pedido, distancia).forEach[ t | if
+		this.transportesQuePuedenLlevar(pedido, distancia).forEach { t => if
 		(this.desperdicio(t, pedido, distancia) < desperdicio) {
 			mejorTransporte = t
-		} ] return mejorTransporte
+		} } return mejorTransporte
 	}
 
 	method transportesQueNecesitoParaLlevar(pedido, distancia) {
-		var pendiente = pedido var transportesNecesarios = #[ ] 
-		transportes.forEach[t | 
+		var pendiente = pedido var transportesNecesarios = [ ] 
+		transportes.forEach { t => 
 			if (pedido > 0) {
 				if (t.puedeLlevar(pedido - t.capacidad(), distancia)) {
 					transportesNecesarios.add(t) pendiente -= t.capacidad()
 				}
 			}
-		]
+		}
 		return transportesNecesarios
 	}
 
 	method cantidadDesperdiciadaPorLlevar(pedido, distancia) {
 		var transportesQueSalen = this.transportesQueNecesitoParaLlevar(pedido, distancia) 
-		return transportesQueSalen.sum[ t | t.capacidad() ] - pedido
+		return transportesQueSalen.sum{ t => t.capacidad() } - pedido
 	}
 
 	method pedidosTotalesVidaUtil() {}
@@ -151,14 +151,14 @@ object delivery {
 		var desperdicio = 1000
 		var menorSobrante = 1000
 		var mejorTransporte = null
-		transportes.forEach[ t | 
+		transportes.forEach { t =>
 			if (this.desperdicio(t, pedido, distancia) >= 0 &&  this.desperdicio(t, pedido, distancia) < desperdicio) {
 				desperdicio = this.desperdicio(t, pedido, distancia) mejorTransporte = t
 			} else if (this.sobrante(t, pedido) >= 0 && this.sobrante(t, pedido) < menorSobrante) {
 				menorSobrante = this.sobrante(t, pedido) mejorTransporte = t
 			} 
 			console.println(mejorTransporte)
-		] 
+		} 
 		return mejorTransporte
 	}
 
@@ -176,7 +176,7 @@ object delivery {
 	}
 
 	method transportesOptimosPara(pedido) {
-		var todosLosTransportes = transportes var mejoresTransportes = #[ ] return
+		var todosLosTransportes = transportes var mejoresTransportes = [ ] return
 		this.transportesOptimos(pedido, mejoresTransportes, todosLosTransportes)
 	}
 }

--- a/wollok-tests/src/wollok/examples/guia3/ej1_piratas.wlk
+++ b/wollok-tests/src/wollok/examples/guia3/ej1_piratas.wlk
@@ -1,5 +1,5 @@
 class Pirata {
-	var items = #[]
+	var items = []
 	var dinero
 	var nivelEbriedad
 	
@@ -48,7 +48,7 @@ object saquear {
 
 object main {
 	
-	var p = new Pirata(#["brujula", "cuchillo", "cuchillo"])	
+	var p = new Pirata(["brujula", "cuchillo", "cuchillo"])	
 	//var barco = new Barco()
 	
 	method getP() {

--- a/wollok-tests/src/wollok/examples/monstersinc/asustables.wlk
+++ b/wollok-tests/src/wollok/examples/monstersinc/asustables.wlk
@@ -14,12 +14,12 @@ class Ninio inherits Asustable {
 }
 
 class Piyamada inherits Asustable {
-	var ninios = #[]
+	var ninios = []
 	method agregarNinio(n) { ninios.add(n) }
 	override method teVaAAsustar(asustador) {
-		return ninios.fold(0, [a, n| 
+		return ninios.fold(0, {a, n=> 
 			a + asustador.asustar(n)
-		])
+		})
 	}
 }
 

--- a/wollok-tests/src/wollok/examples/monstersinc/modelo.wlk
+++ b/wollok-tests/src/wollok/examples/monstersinc/modelo.wlk
@@ -1,13 +1,13 @@
 object monstersInc {
-	var equipos = #[]
-	var puertas = #[]
+	var equipos = []
+	var puertas = []
 
 	method getEquipos() = equipos	
 	method agregarPuerta(p) { puertas.add(p) }
 	method agregarEquipo(e) { equipos.add(e) }
 	method removerEquipo(e) { equipos.remove(e) }
 	method getEnergiaTotalGenerada() {
-		return equipos.sum([e| e.getEnergiaGenerada()])
+		return equipos.sum({e=> e.getEnergiaGenerada()})
 	}
 	
 	method cualquierPuerta() {
@@ -17,11 +17,11 @@ object monstersInc {
 	}
 	
 	method diaLaboral() {
-		equipos.forEach([e| e.visitar(this.cualquierPuerta())])
+		equipos.forEach({e=> e.visitar(this.cualquierPuerta())})
 	}
 	
 	method equipoMasAsustador() {
-		return equipos.max([e| e.getEnergiaGenerada()])
+		return equipos.max({e=> e.getEnergiaGenerada()})
 	} 
 }
 

--- a/wollok-tests/src/wollok/examples/trenes/trenes.wlk
+++ b/wollok-tests/src/wollok/examples/trenes/trenes.wlk
@@ -1,29 +1,29 @@
 class Deposito {
-	val formaciones = #[]
+	val formaciones = []
 	
 	method agregarFormacion(unTren) { formaciones.add(unTren) }
-	method vagonesMasPesados() { formaciones.map([t| t.vagonMasPesado()]).flatten() }
+	method vagonesMasPesados() { formaciones.map({t=> t.vagonMasPesado()}).flatten() }
 }
 
 class Tren {
-	val vagones = #[]
-	val locomotoras = #[]
+	val vagones = []
+	val locomotoras = []
 	
 	method agregarVagon(v) { vagones.add(v) }
-	method getCantidadPasajeros() = vagones.sum[v| v.getCantidadPasajeros()] 
-	method getCantidadVagonesLivianos() = vagones.count[v| v.esLiviano()]
-	method getVelocidadMaxima() = locomotoras.min[l| l.getVelocidadMaxima() ].getVelocidadMaxima()
+	method getCantidadPasajeros() = vagones.sum{v=> v.getCantidadPasajeros()}
+	method getCantidadVagonesLivianos() = vagones.count{v=> v.esLiviano()}
+	method getVelocidadMaxima() = locomotoras.min{l=> l.getVelocidadMaxima() }.getVelocidadMaxima()
 	method agregarLocomotora(loco) { locomotoras.add(loco)	}
-	method esEficiente() = locomotoras.forAll[l| l.esEficiente()]
+	method esEficiente() = locomotoras.forAll{l=> l.esEficiente()}
 	method puedeMoverse() = this.arrastreUtilTotalLocomotoras() >= this.pesoMaximoTotalDeVagones()
-	method arrastreUtilTotalLocomotoras() = locomotoras.sum[l| l.arrastreUtil()]
-	method pesoMaximoTotalDeVagones() = vagones.sum[v| v.getPesoMaximo()]
+	method arrastreUtilTotalLocomotoras() = locomotoras.sum{l=> l.arrastreUtil()}
+	method pesoMaximoTotalDeVagones() = vagones.sum{v=> v.getPesoMaximo()}
 	method getKilosEmpujeFaltantes() =
 		if (this.puedeMoverse())
 			0
 		else
 			this.pesoMaximoTotalDeVagones() - this.arrastreUtilTotalLocomotoras()
-	method vagonMasPesado() = vagones.max([v| v.getPesoMaximo() ])
+	method vagonMasPesado() = vagones.max({v=> v.getPesoMaximo() })
 }
 
 class Locomotora {

--- a/wollok-tests/src/wollok/parciales/objetos/piratas.wlk
+++ b/wollok-tests/src/wollok/parciales/objetos/piratas.wlk
@@ -27,7 +27,7 @@ object barcoPirata2 {
 
 
 object barbanegra {
-	var items = #["brujula", "cuchillo", "cuchillo", "dienteDeOro", "grodXD", "grodXD", "grodXD"]
+	var items = ["brujula", "cuchillo", "cuchillo", "dienteDeOro", "grodXD", "grodXD", "grodXD"]
 	var dinero = 10
 	
 	method esUtilParaUnaMision(mision) {
@@ -44,7 +44,7 @@ object barbanegra {
 }
 
 object jack {
-	var items = #["brujula", "cuchillo", "cuchillo", "dienteDeOro", "grodXD", "grodXD", "grodXD"]
+	var items = ["brujula", "cuchillo", "cuchillo", "dienteDeOro", "grodXD", "grodXD", "grodXD"]
 	var dinero = 2
 	
 	method esUtilParaUnaMision(mision) {


### PR DESCRIPTION
This PR introduces some important changes to syntax: 

* It unifies the code block syntax - only braces. This applies to block expressions, closures, etc
   * In particular, it changes the XTend syntax to `{ arg1,...argn => body }`, which resembles or is identical to Haskell's, Groovy, Scala, JS, etc
   * <del>It removes the optional arrow - now arrow is mandatory, to avoid ambiguities </del>
* It changes the list syntax to just `[1, 2, 3]`, to be compatible with the list syntax present in most modern languages 
* <del>It removes the Set literal syntax. But</del> it adds a `new Set(1, 2, 3)` constructor. 
* It removes the block as a top level expression. So it means you will not be able to do things like `var x = {2}`, only you will be able to use it in if/try expressions. 
* Due to ambiguites, now the scala-like method assignment syntax will only work for one liners. For example, instead of writing: 
* <del>`->` was removed from object. It is seldom used alongside the codebase, and it clashed with the arrow syntax for closures. If we really need tuples, perhaps we should add a better, more generic syntax.</del> 

```
method foo(x) = {
     y.z()
     4
}
```

You will have to write it this way:

```
method foo(x) {
     y.z()
     return 4
}
```

Which I think is actually a feature too, since it is very easy to ignore the equals sign between the parenthesis and brace.

You can still write this: 

```
method foo(x) = x
```

Fixes  #415