### PR TITLE
Fix #588 removing collision listeners

### DIFF
--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/VisualComponent.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/VisualComponent.xtend
@@ -19,14 +19,6 @@ abstract class VisualComponent {
 	def abstract Image getImage()
 	def abstract Position getPosition()
 	def abstract void setPosition(Position image)
-	
-	def say(String aText) {
-		balloonMessages.add(new BalloonMessage(aText, Color.BLACK))
-	}
-	
-	def scream(String aText) {
-		balloonMessages.add(new BalloonMessage(aText, Color.RED))
-	}
 
 	def void draw(Window window) {
 		window => [
@@ -50,6 +42,26 @@ abstract class VisualComponent {
 	def drawBallonIfNecesary(Window window) {
 		if (hasMessages)
 			currentMessage.draw(window, this)
+	}
+
+	def say(String aText) {
+		addMessage(aText, Color.BLACK)
+	}
+	
+	def scream(String aText) {
+		addMessage(aText, Color.RED)
+	}
+	
+	def addMessage(String message, Color color) {
+		if (message.length > 50) {
+			var beginning = message.substring(0, 45) + ".."
+			var end = ".." + message.substring(46, message.length)
+			this.addMessage(beginning, color)
+			this.addMessage(end, color)
+			return 
+		}
+		
+		balloonMessages.add(new BalloonMessage(message, color))
 	}
 
 	def isInMyZone(){

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
@@ -119,6 +119,7 @@ class Gameboard {
 	
 	def remove(VisualComponent component) {
 		components.remove(component)
+		listeners.removeIf[it.isObserving(component)]
 	}
 	
 }

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
@@ -46,10 +46,9 @@ class Gameboard {
 	
 	def void draw(Window window) {
 		// NO UTILIZAR FOREACH PORQUE HAY UN PROBLEMA DE CONCURRENCIA AL MOMENTO DE VACIAR LA LISTA
-		for (var i=0; i < this.listeners.size(); i++){
-			try {
-				this.listeners.get(i).notify(this);
-			} 
+		for (var i=0; i < listeners.size(); i++) {
+			try 
+				listeners.get(i).notify(this)
 			catch (WollokProgramExceptionWrapper e) {
 				var Object message = e.wollokMessage
 				if (message == null)
@@ -62,9 +61,8 @@ class Gameboard {
 			} 
 		}
 
-		this.cells.forEach[ it.draw(window) ]
-
-		this.getComponents().forEach[ it.draw(window) ]		
+		cells.forEach[ it.draw(window) ]
+		components.forEach[it.draw(window)]
 	}
 
 	def createCells(String groundImage) {

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
@@ -37,9 +37,11 @@ class Gameboard {
 
 	def void start() {
 		new WollokGDXApplication(new GameboardRendering(this), new GameboardConfiguration(this))
-		Runtime.runtime.addShutdownHook(new Thread([
-			Gdx.app.exit
-		]))
+		Runtime.runtime.addShutdownHook(new Thread[stop])
+	}
+	
+	def stop() {
+		Gdx.app.exit
 	}
 	
 	def void draw(Window window) {

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
@@ -41,15 +41,11 @@ class Window {
 	def drawBallon(String text, Position position, Color color) {		
 		val baseWidth = 75
 		var newText = text
-		
-		if (text.length > 50)
-			newText = text.substring(0,49) + "..."
-		
 		var plusWidth = 0	
 		glyphLayout.reset
 		this.setText(newText, baseWidth, color)
 		
-		while(glyphLayout.height > 29){
+		while(glyphLayout.height > 29) {
 			glyphLayout.reset
 			plusWidth += 10
 			this.setText(newText, baseWidth + plusWidth, color)

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/ArrowListener.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/ArrowListener.xtend
@@ -21,4 +21,8 @@ class ArrowListener implements GameboardListener {
 	override notify(Gameboard gameboard) {
 		listeners.forEach[it.notify(gameboard)]
 	}
+	
+	override isObserving(VisualComponent component) {
+		listeners.exists[it.isObserving(component)]
+	}
 }

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/CollisionListener.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/CollisionListener.xtend
@@ -22,4 +22,9 @@ class CollisionListener implements GameboardListener {
 				block.apply(it)
 			]
 	}
+	
+	override isObserving(VisualComponent otherComponent) {
+		component.equals(otherComponent)
+	}
+	
 }

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/GameboardListener.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/GameboardListener.xtend
@@ -1,9 +1,12 @@
 package org.uqbar.project.wollok.game.listeners
 
 import org.uqbar.project.wollok.game.gameboard.Gameboard
+import org.uqbar.project.wollok.game.VisualComponent
 
 interface GameboardListener {
 	
 	def void notify(Gameboard gameboard)
+	
+	def boolean isObserving(VisualComponent component)
 	
 }

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/KeyboardListener.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/KeyboardListener.xtend
@@ -2,14 +2,15 @@ package org.uqbar.project.wollok.game.listeners
 
 import org.uqbar.project.wollok.game.gameboard.Gameboard
 import org.uqbar.project.wollok.game.helpers.Keyboard
+import org.uqbar.project.wollok.game.VisualComponent
 
 class KeyboardListener implements GameboardListener {
-	
+
 	var keyboard = Keyboard.instance
 	int key
 	Runnable gameAction
 
-	new (int key, Runnable gameAction) {
+	new(int key, Runnable gameAction) {
 		this.key = key;
 		this.gameAction = gameAction;
 	}
@@ -17,5 +18,9 @@ class KeyboardListener implements GameboardListener {
 	override notify(Gameboard gameboard) {
 		if (keyboard.isKeyPressed(this.key))
 			gameAction.run();
+	}
+
+	override isObserving(VisualComponent component) {
+		false
 	}
 }

--- a/org.uqbar.project.wollok.lib/src/wollok.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok.wlk
@@ -676,6 +676,10 @@ package lib {
 		
 		method clone() = new Position(x, y)
 
+		method clear() {
+			this.allElements().forEach{it => wgame.removeVisual(it)}
+		}
+		
 		method getX() = x
 		method setX(_x) { x = _x }
 		method getY() = y

--- a/org.uqbar.project.wollok.lib/src/wollok.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok.wlk
@@ -643,6 +643,7 @@ package lib {
 		method getObjectsIn(position) native
 		method clear() native
 		method start() native
+		method stop() native
 		
 		method setTitle(title) native
 		method getTitle() native

--- a/org.uqbar.project.wollok.lib/src/wollok.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok.wlk
@@ -641,6 +641,7 @@ package lib {
 		method whenKeyPressedSay(key, function) native
 		method whenCollideDo(element, action) native
 		method getObjectsIn(position) native
+		method say(element, message) native
 		method clear() native
 		method start() native
 		method stop() native
@@ -673,6 +674,7 @@ package lib {
 		method drawElement(element) { wgame.addVisualIn(element, this) }
 		method drawCharacter(element) { wgame.addVisualCharacterIn(element, this) }		
 		method deleteElement(element) { wgame.removeVisual(element) }
+		method say(element, message) { wgame.say(element, message) }
 		method allElements() = wgame.getObjectsIn(this)
 		
 		method clone() = new Position(x, y)

--- a/org.uqbar.project.wollok.lib/src/wollok/lib/WgameObject.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib/WgameObject.xtend
@@ -67,6 +67,10 @@ class WgameObject {
 		.toList.javaToWollok
 	}
 	
+	def say(WollokObject visual, WollokObject message) {
+		board.findVisual(visual).say(message.asString)
+	}
+	
 	def clear() { board.clear }
 	
 	def start() { board.start }

--- a/org.uqbar.project.wollok.lib/src/wollok/lib/WgameObject.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib/WgameObject.xtend
@@ -71,6 +71,9 @@ class WgameObject {
 	
 	def start() { board.start }
 	
+	def stop() { board.stop }
+	
+	
 	def board() { Gameboard.getInstance }
 	
 	def addListener(GameboardListener listener) {

--- a/org.uqbar.project.wollok.lib/src/wollok/lib/WgameObject.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib/WgameObject.xtend
@@ -78,9 +78,9 @@ class WgameObject {
 	}
 	
 	def findVisual(Gameboard it, WollokObject visual) {
-		it.components
+		components
 		.map[it as WVisual]
-		.findFirst[ it.wObject.equals(visual)]
+		.findFirst[ wObject.equals(visual)]
 	}
 	
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/CollisionListenerTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/CollisionListenerTest.xtend
@@ -11,12 +11,13 @@ import org.uqbar.project.wollok.game.gameboard.Gameboard
 import org.uqbar.project.wollok.game.listeners.CollisionListener
 
 import static org.mockito.Mockito.*
+import org.junit.Assert
 
 /**
  * @author ? 
  */
 class CollisionListenerTest {
-	CollisionListener collisionListener
+	CollisionListener listener
 	Gameboard gameboard
 	VisualComponent mario
 	VisualComponent aCoin
@@ -35,18 +36,18 @@ class CollisionListenerTest {
 		gameboard.addComponents(newArrayList(mario, aCoin, otherCoin))
 		
 		block = mock(Function1)
-		collisionListener = new CollisionListener(mario, block)
+		listener = new CollisionListener(mario, block)
 	}
 	
 	@Test
 	def void nothing_happens_when_components_dont_collide_with_itself(){
-		collisionListener.notify(gameboard)
+		listener.notify(gameboard)
 		verify(block, never).apply(mario)
 	}
 	
 	@Test
 	def void when_no_components_are_colliding_with_mario_then_nothing_happens(){
-		collisionListener.notify(gameboard)
+		listener.notify(gameboard)
 		verify(block, never).apply(aCoin)
 		verify(block, never).apply(otherCoin)
 	}
@@ -56,7 +57,7 @@ class CollisionListenerTest {
 		aCoin.position = mario.position
 		otherCoin.position = mario.position
 		
-		collisionListener.notify(gameboard)
+		listener.notify(gameboard)
 		
 		verify(block).apply(aCoin)
 		verify(block).apply(otherCoin)
@@ -66,8 +67,20 @@ class CollisionListenerTest {
 	def void when_components_are_colliding_but_anyone_is_mario_then_nothing_happens(){
 		aCoin.position = otherCoin.position
 		
-		collisionListener.notify(gameboard)
+		listener.notify(gameboard)
 		
 		verifyZeroInteractions(block)
+	}
+	
+	@Test
+	def void should_remove_listener_from_board_when_mario_is_removed(){
+		gameboard.addListener(listener)
+		Assert.assertTrue(containsListener)
+		gameboard.remove(mario)
+		Assert.assertFalse(containsListener)
+	}
+	
+	def containsListener() {
+		gameboard.listeners.contains(listener)
 	}
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/CollisionListenerTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/CollisionListenerTest.xtend
@@ -11,7 +11,7 @@ import org.uqbar.project.wollok.game.gameboard.Gameboard
 import org.uqbar.project.wollok.game.listeners.CollisionListener
 
 import static org.mockito.Mockito.*
-import org.junit.Assert
+import static org.junit.Assert.*
 
 /**
  * @author ? 
@@ -75,9 +75,9 @@ class CollisionListenerTest {
 	@Test
 	def void should_remove_listener_from_board_when_mario_is_removed(){
 		gameboard.addListener(listener)
-		Assert.assertTrue(containsListener)
+		assertTrue(containsListener)
 		gameboard.remove(mario)
-		Assert.assertFalse(containsListener)
+		assertFalse(containsListener)
 	}
 	
 	def containsListener() {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/PositionTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/PositionTest.xtend
@@ -146,4 +146,21 @@ class PositionTest extends AbstractWollokParameterizedInterpreterTest {
 		
 		assertEquals(1, gameboard.components.size)
 	}
+	
+	@Test
+	def void sayShouldAddBallonMessageToVisualObject() {
+		var message = "A message"
+		'''
+		object visual {
+			method getImage() = "image.png"
+		}
+		
+		program p {
+			var position = new Position(0,0)
+			position.drawCharacter(visual)
+			position.say(visual, "«message»")
+		}'''.interpretPropagatingErrors
+		
+		assertEquals(message, gameboard.character.balloonMessages.head.text)
+	}
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/PositionTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/PositionTest.xtend
@@ -125,4 +125,25 @@ class PositionTest extends AbstractWollokParameterizedInterpreterTest {
 			assert.equals(expected, visual)
 		}'''.interpretPropagatingErrors
 	}
+	
+	@Test
+	def void whenClearShouldRemoveAllVisualsInIt() {
+		'''
+		class Visual {
+			method getImage() = "image.png"
+		}
+		
+		program p {
+			2.times{ new Position(0,0).drawElement(new Visual()) }
+			new Position(1,1).drawElement(new Visual())
+		}'''.interpretPropagatingErrors
+		
+		assertEquals(3, gameboard.components.size)
+		'''
+		program p {
+			new Position(0,0).clear()
+		}'''.interpretPropagatingErrors
+		
+		assertEquals(1, gameboard.components.size)
+	}
 }


### PR DESCRIPTION
- Collision Listeners are removed when remove its visual
- Positions can remove all visuals in itself
- wgame.stop() finish the game
- Any visual can talk (https://github.com/uqbar-project/wollok/issues/488) and large balloon messages are splitted in many shorters
