### PR TITLE
Fix #507 Double-clicking on a test raises a Java null pointer exception

### DIFF
--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestState.java
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestState.java
@@ -24,6 +24,7 @@ public enum WollokTestState {
 		public URI getURI(WollokTestResult result) {
 			return result.getTestResource();
 		}
+
 		@Override
 		public String getOutputText(WollokTestResult result) {
 			return getText();
@@ -63,9 +64,12 @@ public enum WollokTestState {
 
 		@Override
 		public URI getURI(WollokTestResult result) {
-			return result.getErrorResource();
+			// Temporarily not linking to error resource because its URI is not available.
+			// return result.getErrorResource();
+
+			 return result.getTestResource();
 		}
-		
+
 		@Override
 		public String getOutputText(WollokTestResult result) {
 			return result.getErrorOutput();
@@ -107,7 +111,11 @@ public enum WollokTestState {
 
 		@Override
 		public URI getURI(WollokTestResult result) {
-			return result.getErrorResource();
+			// Temporarily not linking to error resource because its URI is not
+			// available.
+			// return result.getErrorResource();
+
+			return result.getTestResource();
 		}
 
 		@Override
@@ -126,7 +134,6 @@ public enum WollokTestState {
 	public abstract String getOutputText(WollokTestResult result);
 
 	public Image getImage() {
-		return Activator.getDefault().getImageDescriptor(this.getImageName())
-				.createImage();
+		return Activator.getDefault().getImageDescriptor(this.getImageName()).createImage();
 	}
 }


### PR DESCRIPTION
Temporarily disable linking to the URI of the error source, since it is not available.
Until that is fixed I provide a link to test header.