### PR TITLE
#603 Fix for variable scope of NamedObject

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/mixins/MixinsTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/mixins/MixinsTestCase.xtend
@@ -303,6 +303,31 @@ class MixinsTestCase extends AbstractWollokInterpreterTestCase {
 	}
 	
 	@Test
+	def void mixinVariablesAreInScopeOnAWKO() {
+		'''
+		mixin Flies {
+			var times = 0
+			method fly() {
+				times = 1
+			}
+			method times() = times
+		}
+		
+		object pepita mixed with Flies {
+			method rest() {
+				times = 0
+			}
+		}
+		
+		program t {
+			pepita.fly()
+			assert.equals(1, pepita.times())
+			pepita.rest()
+			assert.equals(0, pepita.times())
+		} 
+		'''.interpretPropagatingErrors
+	}
+	@Test
 	def void mixinOnAWKOOverridingAMethod() {
 		'''
 		mixin Flies {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/namedobjects/NamedObjectInheritanceTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/namedobjects/NamedObjectInheritanceTest.xtend
@@ -42,6 +42,29 @@ class NamedObjectInheritanceTest extends AbstractWollokInterpreterTestCase {
 	}
 	
 	@Test
+	def void objectInheritFromCustomClassWithInstanceVariable() {
+		'''
+			class MyClass {
+				var inheritedVariable = "1234"
+			}
+			object myObject inherits MyClass {
+				method something() {
+					return inheritedVariable
+				}
+				method setInheritedVariable(aValue){
+					inheritedVariable = aValue
+				}
+			}
+			
+			program p {
+				assert.equals("1234", myObject.something())
+				myObject.setInheritedVariable("abc")
+				assert.equals("abc", myObject.something())
+			}
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
 	def void objectInheritFromCustomClassAndOverridesMethod() {
 		'''
 			class MyClass {

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokDslScopeProvider.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokDslScopeProvider.xtend
@@ -67,7 +67,10 @@ class WollokDslScopeProvider extends AbstractDeclarativeScopeProvider {
 	def dispatch IScope scope(WMixin it) { declaredVariables.asScope }
 
 	def dispatch IScope scope(WNamedObject namedObject) {
-		namedObject.parent.scope + namedObject.declaredVariables
+		val scope = namedObject.parent.scope + namedObject.declaredVariables
+		namedObject.mixins.fold(scope) [s, mixin|
+			s + mixin.declaredVariables
+		]
 	}
 	
 	// containers which declares elements

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokDslScopeProvider.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokDslScopeProvider.xtend
@@ -67,7 +67,7 @@ class WollokDslScopeProvider extends AbstractDeclarativeScopeProvider {
 	def dispatch IScope scope(WMixin it) { declaredVariables.asScope }
 
 	def dispatch IScope scope(WNamedObject namedObject) {
-		namedObject.declaredVariables.asScope
+		namedObject.parent.scope + namedObject.declaredVariables
 	}
 	
 	// containers which declares elements


### PR DESCRIPTION
For the moment, I only changed scope(WNamedObject namedObject) to consider the parent's scope as well. I didn't include mixins because I wasn't sure about what was expected on that aspect (not sure if NamedObjects will be expected to be mixed in in the future).

All preexistent test cases pass and the additioned objectInheritFromCustomClassWithInstanceVariable test case in NamedObjectInheritanceTest is also green after the fix.

In an unrelated topic, after I made the change I noticed that the following files were also updated and git prompted me to include them in the commit, but I think they just need to be ignored and not commited (they are listed in .gitignore files under org.uqbar.project.wollok.typeSystem.xsemantics\xsemantics-gen\org\uqbar\project\wollok\semantics):
/.WollokDslTypeSystem.java._trace
/.WollokDslTypeSystemValidator.java._trace

Please advice in case I need to do something about that.