### PR TITLE
Fixes #622 bug on shortcircuit lazy evaluation related to context bei…

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang/AbstractJavaWrapper.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/AbstractJavaWrapper.xtend
@@ -35,7 +35,7 @@ class AbstractJavaWrapper<T> implements JavaWrapper<T> {
 	}
 	
 	def newInstanceWithWrapped(T wrapped) {
-		val transformedClassName = DefaultNativeObjectFactory.javaToWollokFQN(class.name)
+		val String transformedClassName = DefaultNativeObjectFactory.javaToWollokFQN(class.name)
 		evaluator.newInstanceWithWrapped(transformedClassName, wrapped)
 	} 
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/BooleanTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/BooleanTestCase.xtend
@@ -91,6 +91,30 @@ class BooleanTestCase extends AbstractWollokInterpreterTestCase {
 	}
 	
 	@Test
+	def void lazyPartOfTheAndShortCircuitAccessingTheContext() {
+		'''
+			object liberarAFiona {
+				var cantidadTrolls = 0
+				var solicitante = ""
+			
+				method solicitante() = return solicitante
+				method solicitante(_solicitante) { solicitante = _solicitante }
+				method cantidadTrolls(cant) { cantidadTrolls = cant }
+				method esDificil() {
+					const result = (cantidadTrolls > 3) and (cantidadTrolls < 6)
+					console.println(result)
+					return result
+				}
+				method puntosRecompensa() = return cantidadTrolls * 2
+			}
+			program a {
+				liberarAFiona.cantidadTrolls(5)
+				liberarAFiona.esDificil()
+			}
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
 	def void orShortcirtuitMustEvaluateSecondPart() {
 		'''
 			object p {

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -334,7 +334,10 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 	}
 
 	def lazyEval(EObject expression) {
-		[| expression.eval ]
+		val lazyContext = interpreter.currentContext
+		return [| 
+			interpreter.performOnStack(expression, lazyContext, [| expression.eval])
+		]
 	}
 
 	def dispatch evaluate(WPostfixOperation op) {


### PR DESCRIPTION
…ng confused. The lazy part now gets evaluated into the context of its declaration and not in the boolean method execution.

Almost a 1 line fixer :P
It keeps the same "design", just worksaround the problem.
Eventually we will need to design this "lazy concept" better as a language feature and not just a hack.
I've wrote an idea in the #622