### PR TITLE
Fixing error style highlighter when the issue reported by xtext doesn…

### DIFF
--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokCodeHighLightLineStyleListener.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokCodeHighLightLineStyleListener.xtend
@@ -125,10 +125,12 @@ class WollokCodeHighLightLineStyleListener implements LineStyleListener {
 		]
 	}
 	
-	def checkerError(LineStyleEvent event, int offset, int length) { errorStyle(event, offset, length, "CHECK_ERROR") } 
-	def parserError(LineStyleEvent event, int offset, int length) { errorStyle(event, offset, length, "PARSER_ERROR") }
-	def errorStyle(LineStyleEvent event, int offset, int length, String type) {
-		new StyleRange(event.lineOffset + (offset - programHeader.length), length, PARSER_ERROR_COLOR, null, SWT.ITALIC) => [
+	def checkerError(LineStyleEvent event, Integer offset, Integer length) { errorStyle(event, offset, length, "CHECK_ERROR") } 
+	def parserError(LineStyleEvent event, Integer offset, Integer length) { errorStyle(event, offset, length, "PARSER_ERROR") }
+	def errorStyle(LineStyleEvent event, Integer offset, Integer length, String type) {
+		val theOffset = if (offset != null) offset else programHeader.length
+		val theLength = if (length != null) length else event.lineText.length
+		new StyleRange(event.lineOffset + (theOffset - programHeader.length), theLength, PARSER_ERROR_COLOR, null, SWT.ITALIC) => [
 			data = type
 		]
 	}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -133,6 +133,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def cannotInstantiateAbstractClasses(WConstructorCall it) {
+		if (classRef == null) return
 		val abstractMethods = classRef.unimplementedAbstractMethods
 		if (!abstractMethods.empty) {
 			val methodDescriptions = abstractMethods.map[methodName].join(", ")


### PR DESCRIPTION
…'t have offset or length. Also fixed the wollok validation for constructor invocation when the user didn't type the class name yet