### PR TITLE
Dev 1.4 #634 #421 repl issues

### DIFF
--- a/org.uqbar.project.wollok.launch/META-INF/MANIFEST.MF
+++ b/org.uqbar.project.wollok.launch/META-INF/MANIFEST.MF
@@ -33,6 +33,5 @@ Export-Package: org.uqbar.project.wollok.debugger,
  org.uqbar.project.wollok.debugger.server.rmi,
  org.uqbar.project.wollok.launch,
  org.uqbar.project.wollok.launch.io,
- org.uqbar.project.wollok.launch.repl,
  org.uqbar.project.wollok.launch.setup,
  org.uqbar.project.wollok.launch.tests

--- a/org.uqbar.project.wollok.launch/META-INF/MANIFEST.MF
+++ b/org.uqbar.project.wollok.launch/META-INF/MANIFEST.MF
@@ -29,9 +29,10 @@ Bundle-ClassPath: lib/lipermi-0-4-2.jar,
  lib/gson-2.4.jar,
  .
 Export-Package: org.uqbar.project.wollok.debugger,
- org.uqbar.project.wollok.launch,
- org.uqbar.project.wollok.launch.setup,
- org.uqbar.project.wollok.launch.io,
- org.uqbar.project.wollok.launch.tests,
  org.uqbar.project.wollok.debugger.server,
- org.uqbar.project.wollok.debugger.server.rmi
+ org.uqbar.project.wollok.debugger.server.rmi,
+ org.uqbar.project.wollok.launch,
+ org.uqbar.project.wollok.launch.io,
+ org.uqbar.project.wollok.launch.repl,
+ org.uqbar.project.wollok.launch.setup,
+ org.uqbar.project.wollok.launch.tests

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
@@ -189,12 +189,15 @@ class WollokRepl {
 			handleException(e.cause)
 		}
 	}
-	
+	def static getPrompt(){
+		prompt.messageStyle.toString
+	}
 	// ********** STYLING
 	
 	// applies styles for errors
-	def errorStyle(CharSequence msg) { ansi.fg(COLOR_ERROR).a(msg).reset }
-	def importantMessageStyle(CharSequence msg) { ansi.fg(COLOR_REPL_MESSAGE).bold.a(msg).reset }
-	def messageStyle(CharSequence msg) { ansi.fg(COLOR_REPL_MESSAGE).a(msg).reset }
-	def returnStyle(CharSequence msg) { ansi().fg(COLOR_RETURN_VALUE).a(msg).reset }
+	def static errorStyle(CharSequence msg) { ansi.fg(COLOR_ERROR).a(msg).reset }
+	def static importantMessageStyle(CharSequence msg) { ansi.fg(COLOR_REPL_MESSAGE).bold.a(msg).reset }
+	def static messageStyle(CharSequence msg) { ansi.fg(COLOR_REPL_MESSAGE).a(msg).reset }
+	def static returnStyle(CharSequence msg) { ansi().fg(COLOR_RETURN_VALUE).a(msg).reset }
+	
 }

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsolePage.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsolePage.xtend
@@ -18,6 +18,7 @@ import org.eclipse.ui.console.TextConsolePage
  */
 class WollokReplConsolePage extends TextConsolePage implements KeyListener {
 	static val KEY_RETURN = 0x0d
+	static val PROMPT = "[36m>>> [m"
 	val WollokReplConsole console
 	var int historyPosition = -1
 	
@@ -71,14 +72,26 @@ class WollokReplConsolePage extends TextConsolePage implements KeyListener {
 			viewer.textWidget.selection = viewer.textWidget.charCount
 			return
 		}
-
+		if (e.keyCode == SWT.HOME){
+			var strLine = viewer.textWidget.getLine(viewer.textWidget.getLineAtOffset(viewer.textWidget.charCount))
+			viewer.textWidget.selection = viewer.textWidget.charCount - (strLine.length - PROMPT.length)
+			return
+		}
+		
+		if (e.keyCode == SWT.END){
+			viewer.textWidget.selection = viewer.textWidget.charCount
+			return
+		}
+		
 		// return key pressed 
 		if (e.keyCode == KEY_RETURN && !e.controlPressed) {
 			console.sendInputBuffer
 			historyPosition = -1
+			return
 		}
 		else
 			console.updateInputBuffer
+		return
 	}
 	
 	def isControlPressed(KeyEvent it) { stateMask.bitwiseAnd(SWT.CTRL) == SWT.CTRL }

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsolePage.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsolePage.xtend
@@ -6,7 +6,8 @@ import org.eclipse.swt.events.KeyListener
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.ui.console.IConsoleView
 import org.eclipse.ui.console.TextConsolePage
-import org.uqbar.project.wollok.launch.repl.WollokRepl
+import org.eclipse.swt.events.MouseAdapter
+import org.eclipse.swt.events.MouseEvent
 
 /**
  * Extends eclipse's console page for integrating
@@ -33,6 +34,13 @@ class WollokReplConsolePage extends TextConsolePage implements KeyListener {
 		viewer.textWidget.addVerifyListener [ event |
 			event.doit = console.isRunning && !console.canWriteAt(event.start)
 		]
+		viewer.textWidget.addMouseListener(
+		new MouseAdapter() {
+			override def mouseDown(MouseEvent e) {
+			if (isCursorInTheLasLine && isCursorInReadOnlyZone)
+				setCursorToEnd
+			}
+		})
 		viewer.textWidget.setFocus
 	}
 
@@ -74,7 +82,7 @@ class WollokReplConsolePage extends TextConsolePage implements KeyListener {
 			return
 		}
 		if (e.keyCode == SWT.HOME) {
-			viewer.textWidget.selection = getFirstCharOfLastLinePosition()
+			viewer.textWidget.selection = getHomePosition()
 			return
 		}
 
@@ -82,7 +90,6 @@ class WollokReplConsolePage extends TextConsolePage implements KeyListener {
 			setCursorToEnd
 			return
 		}
-
 		// return key pressed 
 		if (e.keyCode == KEY_RETURN && !e.controlPressed) {
 			console.sendInputBuffer
@@ -96,13 +103,11 @@ class WollokReplConsolePage extends TextConsolePage implements KeyListener {
 		viewer.textWidget.getLineAtOffset(viewer.textWidget.getCaretOffset()) ==
 			viewer.textWidget.getLineAtOffset(viewer.textWidget.charCount)
 	}
-
+	
+	def isCursorInReadOnlyZone() { viewer.textWidget.selectionCount < getHomePosition }
 	def setCursorToEnd() { viewer.textWidget.selection = viewer.textWidget.charCount }
 
-	def getFirstCharOfLastLinePosition() {
-		var strLine = viewer.textWidget.getLine(viewer.textWidget.getLineAtOffset(viewer.textWidget.charCount))
-		viewer.textWidget.charCount - (strLine.length - WollokRepl.getPrompt().length)
-	}
+	def getHomePosition() {	console.outputTextEnd }
 
 	def isControlPressed(KeyEvent it) { stateMask.bitwiseAnd(SWT.CTRL) == SWT.CTRL }
 


### PR DESCRIPTION
Close #634 and #421 

The changes are:

- Create the HOME/END keys behavior.
- Launch the REPL and get focus immediately.
- Capture the left-click event and if cursor is at the last line and it's in the read-only zone, moves after the prompt.