### PR TITLE
Change the right side evaluation at declarations

### DIFF
--- a/org.uqbar.project.wollok.game.ui/pom.xml
+++ b/org.uqbar.project.wollok.game.ui/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
 		<groupId>org.uqbar-project</groupId>
 		<artifactId>wollok-parent</artifactId>
-		<version>1.4.2</version>
+		<version>1.4.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.uqbar.project.wollok.game.ui</artifactId>

--- a/org.uqbar.project.wollok.game/pom.xml
+++ b/org.uqbar.project.wollok.game/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.game</artifactId>

--- a/org.uqbar.project.wollok.launch/pom.xml
+++ b/org.uqbar.project.wollok.launch/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.launch</artifactId>

--- a/org.uqbar.project.wollok.lib/pom.xml
+++ b/org.uqbar.project.wollok.lib/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.lib</artifactId>

--- a/org.uqbar.project.wollok.product.ui.feature/pom.xml
+++ b/org.uqbar.project.wollok.product.ui.feature/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.uqbar.project.wollok.product.ui.feature</artifactId>

--- a/org.uqbar.project.wollok.product.ui/pom.xml
+++ b/org.uqbar.project.wollok.product.ui/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.product.ui</artifactId>

--- a/org.uqbar.project.wollok.product/pom.xml
+++ b/org.uqbar.project.wollok.product/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.product</artifactId>

--- a/org.uqbar.project.wollok.releng/pom.xml
+++ b/org.uqbar.project.wollok.releng/pom.xml
@@ -4,7 +4,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.uqbar-project</groupId>
 	<artifactId>wollok-parent</artifactId>
-	<version>1.4.2</version>
+	<version>1.4.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Wollok Parent (Releng)</name>
 	<url>https://github.com/uqbar-project/wollok</url>

--- a/org.uqbar.project.wollok.sdk/pom.xml
+++ b/org.uqbar.project.wollok.sdk/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.uqbar.project.wollok.sdk</artifactId>

--- a/org.uqbar.project.wollok.targetplatform/pom.xml
+++ b/org.uqbar.project.wollok.targetplatform/pom.xml
@@ -7,7 +7,7 @@
 	    <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
 	    <groupId>org.uqbar-project</groupId>
 	    <artifactId>wollok-parent</artifactId>
-	    <version>1.4.2</version>
+	    <version>1.4.3-SNAPSHOT</version>
 	  </parent>
 
 	<artifactId>org.uqbar.project.wollok.targetplatform</artifactId>

--- a/org.uqbar.project.wollok.tests/pom.xml
+++ b/org.uqbar.project.wollok.tests/pom.xml
@@ -7,7 +7,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.tests</artifactId>

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/classes/InstanceVariableInitializationTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/classes/InstanceVariableInitializationTest.xtend
@@ -30,6 +30,23 @@ class InstanceVariableInitializationTest extends AbstractWollokInterpreterTestCa
 	}
 	
 	@Test
+	def void testCrossReferenceInitialization() {
+		'''
+			object abc {
+				var x = 20
+				var y = x * 2
+				
+				method getY() {
+					return y
+				}
+			}
+			program p {
+				assert.equals(40, abc.getY())
+			}			
+		'''.interpretPropagatingErrors
+	}
+		
+	@Test
 	def void assignmentToWKODeclared() {
 		'''
 			object before { method get() = "before" }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/classes/MethodTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/classes/MethodTest.xtend
@@ -5,7 +5,7 @@ import org.uqbar.project.wollok.tests.interpreter.AbstractWollokInterpreterTestC
 
 /**
  * 
- * @author jfernandes
+ * @author jfernandes, tesonep
  */
 class MethodTest extends AbstractWollokInterpreterTestCase {
 	
@@ -73,5 +73,21 @@ class MethodTest extends AbstractWollokInterpreterTestCase {
 		}
 		'''.interpretPropagatingErrors
 	}
-	
+
+	@Test
+	def void initOfVariables(){
+		'''
+			class Subject{
+				var x = 4
+				var y = x * 2
+				
+				method getY() = y
+			}
+			
+			test "Init of variables" {
+				var obj = new Subject()
+				assert.equals(8, obj.getY())
+			}
+		'''.interpretPropagatingErrors
+	}	
 }

--- a/org.uqbar.project.wollok.typeSystem.xsemantics.ui/pom.xml
+++ b/org.uqbar.project.wollok.typeSystem.xsemantics.ui/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.typeSystem.xsemantics.ui</artifactId>

--- a/org.uqbar.project.wollok.typeSystem.xsemantics/pom.xml
+++ b/org.uqbar.project.wollok.typeSystem.xsemantics/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.typeSystem.xsemantics</artifactId>

--- a/org.uqbar.project.wollok.typeSystem/pom.xml
+++ b/org.uqbar.project.wollok.typeSystem/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.typeSystem</artifactId>

--- a/org.uqbar.project.wollok.ui.diagrams/pom.xml
+++ b/org.uqbar.project.wollok.ui.diagrams/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.ui.diagrams</artifactId>

--- a/org.uqbar.project.wollok.ui.launch/pom.xml
+++ b/org.uqbar.project.wollok.ui.launch/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
 		<groupId>org.uqbar-project</groupId>
 		<artifactId>wollok-parent</artifactId>
-		<version>1.4.2</version>
+		<version>1.4.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.uqbar.project.wollok.ui.launch</artifactId>

--- a/org.uqbar.project.wollok.ui/pom.xml
+++ b/org.uqbar.project.wollok.ui/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok.ui</artifactId>

--- a/org.uqbar.project.wollok.updatesite/pom.xml
+++ b/org.uqbar.project.wollok.updatesite/pom.xml
@@ -7,7 +7,7 @@
 		<relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
 		<groupId>org.uqbar-project</groupId>
 		<artifactId>wollok-parent</artifactId>
-		<version>1.4.2</version>
+		<version>1.4.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.uqbar.project.wollok.updatesite</artifactId>

--- a/org.uqbar.project.wollok/pom.xml
+++ b/org.uqbar.project.wollok/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../org.uqbar.project.wollok.releng/pom.xml</relativePath>
     <groupId>org.uqbar-project</groupId>
     <artifactId>wollok-parent</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
 
 	<artifactId>org.uqbar.project.wollok</artifactId>

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokObject.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokObject.xtend
@@ -52,7 +52,7 @@ class WollokObject extends AbstractWollokCallable implements EvaluationContext<W
 
 	def dispatch void addMember(WMethodDeclaration method) { /** Nothing to do */ }
 	def dispatch void addMember(WVariableDeclaration declaration) {
-		instanceVariables.put(declaration.variable.name, declaration.right?.eval)
+		instanceVariables.put(declaration.variable.name, interpreter.performOnStack(declaration, this) [| declaration.right?.eval ])
 	}
 		
 	// ******************************************


### PR DESCRIPTION
Closes #645. Fix the problem like this:

```
			object abc {
				var x = 20
				var y = x * 2
				
				method getY() {
					return y
				}
			}
```

But the solution have a precedence problem. If you code something like this:
```
			object abc {
				var y = x * 2
				var x = 20
				
				method getY() {
					return y
				}
			}
```
It doesn't work because when evaluate the right side of the **y** declaration wasn't evaluated.