### PR TITLE
Adding report of the error when super is used in the constructor

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ExceptionTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ExceptionTestCase.xtend
@@ -364,4 +364,40 @@ class ExceptionTestCase extends AbstractWollokInterpreterTestCase {
 		'''.interpretPropagatingErrors
 	}
 	
+	@Test
+	def void testExceptionWithMessage(){
+		'''
+			class UserException inherits wollok.lang.Exception {
+			    var valorInvalido = 0
+			    
+			    constructor(mensaje, value) = super(mensaje) { 	
+			    	valorInvalido = value
+			    }
+			}
+			
+			object monedero {
+			    var plata = 500
+			
+			    method plata() = return plata
+			
+			    method poner(cantidad) {
+			        if (cantidad < 0) {
+			            throw new UserException("La cantidad debe ser positiva", cantidad)
+			        } 
+			        plata += cantidad
+			    }
+			
+			    method sacar(cantidad) { plata -= cantidad }
+			}
+			
+			program p {
+				try{
+					monedero.poner(-2)
+					assert.fail('No should get here')
+				}catch e{
+					assert.equals("La cantidad debe ser positiva", e.getMessage())
+				}
+			}
+		'''.interpretPropagatingErrors
+	}
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ConstructorShouldNotCallSuperInBody.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ConstructorShouldNotCallSuperInBody.wlk.xt
@@ -1,0 +1,14 @@
+/* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
+
+class UserException inherits wollok.lang.Exception {
+	var inside = 0
+	
+	constructor(mensaje,valor)=super(mensaje){
+		inside = valor
+	}
+
+	constructor(mensaje){
+		// XPECT errors --> "You cannot call super in a constructor. Use delegated syntax." at "mensaje"
+		super(mensaje)
+	}
+}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
@@ -55,6 +55,7 @@ public class Messages extends NLS {
 	public static String WollokDslValidator_MUST_IMPLEMENT_ABSTRACT_METHODS;
 	
 	public static String WollokDslValidator_NO_RETURN_EXPRESSION_IN_CONSTRUCTOR;
+	public static String WollokDslValidator_SUPER_EXPRESSION_IN_CONSTRUCTOR;
 	public static String WollokDslValidator_RETURN_FORGOTTEN;
 	public static String WollokDslValidator_METHOD_DOES_NOT_RETURN_A_VALUE_ON_EVERY_POSSIBLE_FLOW;
 	public static String WollokDslValidator_VAR_ARG_PARAM_MUST_BE_THE_LAST_ONE;

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
@@ -52,6 +52,7 @@ WollokDslValidator_NO_EXPRESSION_AFTER_THROW = Unexpected expression after throw
 
 WollokDslValidator_UNREACHABLE_CODE = Unreachable code
 WollokDslValidator_NO_RETURN_EXPRESSION_IN_CONSTRUCTOR = You cannot return a value in constructor
+WollokDslValidator_SUPER_EXPRESSION_IN_CONSTRUCTOR = You cannot call super in a constructor. Use delegated syntax.
 WollokDslValidator_POSTFIX_ONLY_FOR_VAR = can only be applied to variable references
 
 WollokDslValidator_PROGRAM_IN_FILE = Program should be in a file with extension

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
@@ -49,6 +49,7 @@ WollokDslValidator_NO_EXPRESSION_AFTER_THROW = Expresi\u00F3n inv\u00E1lida lueg
 WollokDslValidator_UNREACHABLE_CODE = C\u00F3digo que nunca se va a ejecutar
 
 WollokDslValidator_NO_RETURN_EXPRESSION_IN_CONSTRUCTOR = No puedes devolver un valor en un constructor. 
+WollokDslValidator_SUPER_EXPRESSION_IN_CONSTRUCTOR = No se puede usar invocar con super en el cuerpo del constructor. Hay que usar la sintaxis de delegación.
 WollokDslValidator_POSTFIX_ONLY_FOR_VAR = S\u00F3lo se puede utilizar con referencias variables
 WollokDslValidator_PROGRAM_IN_FILE = Los programas deben estar en archivos con extensi\u00F3n
 WollokDslValidator_REFERENCIABLE_NAME_MUST_START_LOWERCASE = El nombre de la referencia debe comenzar en min\u00FAscula

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
@@ -300,6 +300,9 @@ class WollokModelExtensions {
 	def static dispatch boolean isInConstructor(WClass obj){ false }
 	def static dispatch boolean isInConstructor(WMethodDeclaration obj) { false }
 
+	def static dispatch boolean isInConstructorBody(EObject obj) { obj.eContainer != null && obj.eContainer.isInConstructorBody }
+	def static dispatch boolean isInConstructorBody(WBlockExpression obj) { obj.isInConstructor }
+
 	// *****************************
 	// ** valid return
 	// *****************************

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -520,6 +520,13 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	}
 
 	@Check
+	@DefaultSeverity(ERROR)
+	def noSuperInConstructorBody(WSuperInvocation it){
+		if(it.isInConstructorBody)
+			report(WollokDslValidator_SUPER_EXPRESSION_IN_CONSTRUCTOR, it, WSUPER_INVOCATION__MEMBER_CALL_ARGUMENTS)
+	}
+
+	@Check
 	@DefaultSeverity(WARN)
 	@CheckGroup(WollokCheckGroup.POTENTIAL_PROGRAMMING_PROBLEM)
 	def methodBodyProducesAValueButItIsNotBeingReturned(WMethodDeclaration it){


### PR DESCRIPTION
The idea is to fix this issue #644 
This fix adds the report of the error of using super in a constructor. 
The correct syntax for delegating in the constructor is:

``` constructor(mensaje, algo) = super(mensaje) {
       value = algo
}```