### PR TITLE
Dev 1.4 #641 printing duplicated elements in list

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok.wlk
@@ -128,13 +128,18 @@ package lang {
 		}
 		method toSmartString(alreadyShown) {
 			if (alreadyShown.any { e => e.identity() == self.identity() } ) { 
-				return self.kindName() 
+				return self.simplifiedToSmartString() 
 			}
 			else {
 				alreadyShown.add(self)
 				return self.internalToSmartString(alreadyShown)
 			}
 		} 
+		
+		method simplifiedToSmartString(){
+			return self.kindName()
+		}
+		
 		method internalToSmartString(alreadyShown) {
 			return self.kindName() + "[" 
 				+ self.instanceVariables().map { v => 
@@ -488,6 +493,7 @@ package lang {
 		
 		method toString() native
 		
+		override method simplifiedToSmartString(){ return self.stringValue() }
 		override method internalToSmartString(alreadyShown) { return self.stringValue() }
 		method stringValue() native	
 		

--- a/org.uqbar.project.wollok.lib/src/wollok.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok.wlk
@@ -472,7 +472,11 @@ package lang {
 		method limitBetween(limitA,limitB) = if(limitA <= limitB) 
 												limitA.max(self).min(limitB) 
 											 else 
+
 											 	limitB.max(self).min(limitA)
+
+		override method simplifiedToSmartString(){ return self.stringValue() }
+		override method internalToSmartString(alreadyShown) { return self.stringValue() }
 	}
 	
 	/**
@@ -493,8 +497,6 @@ package lang {
 		
 		method toString() native
 		
-		override method simplifiedToSmartString(){ return self.stringValue() }
-		override method internalToSmartString(alreadyShown) { return self.stringValue() }
 		method stringValue() native	
 		
 		method ..(end) = new Range(self, end)
@@ -531,7 +533,6 @@ package lang {
 		
 		method toString() native
 		
-		override method internalToSmartString(alreadyShown) { return self.stringValue() }
 		method stringValue() native	
 		
 		method >(other) native

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
@@ -97,4 +97,21 @@ class ListTestCase extends CollectionTestCase {
 		}'''.interpretPropagatingErrors
 	}
 	
+	@Test
+	def void printingDuplicatedElements(){
+		'''
+			program p {
+				const l1 = [[3,5,2], [4,2,6]].flatten()
+				assert.equals("[3, 5, 2, 4, 2, 6]", l1.toString())
+
+
+				const l2 = [1,2,3].flatMap({x => [x, x * 2, x * 3]})
+				assert.equals("[1, 2, 3, 2, 4, 6, 3, 6, 9]", l2.toString())
+
+				const l3 = [1,1,1]
+				assert.equals("[1, 1, 1]", l3.toString())
+			}
+		'''.interpretPropagatingErrors		
+	}
+	
 }


### PR DESCRIPTION
I have fixed when showing duplicated numbers in a List. It is the same behavior when an object has two instances variables with the same numeric value.