### PR TITLE
Fixing returning a value from a catch. It is weird but the method eva…

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ExceptionTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ExceptionTestCase.xtend
@@ -394,10 +394,67 @@ class ExceptionTestCase extends AbstractWollokInterpreterTestCase {
 				try{
 					monedero.poner(-2)
 					assert.fail('No should get here')
-				}catch e{
+				} catch e {
 					assert.equals("La cantidad debe ser positiva", e.getMessage())
 				}
 			}
 		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void testCatchWithAReturnStatement() {
+		'''
+		object cuenta {
+			method sacar() {
+				try {
+					throw new Exception("saldo insuficiente")
+				} 
+				catch e {
+					return 20
+				}
+			}
+		}
+		program p {
+			assert.equals(20, cuenta.sacar())
+		}'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void testCatchWithAReturnStatementReturningFromTryBodyAndFromCatch() {
+		'''
+		object cuenta {
+			method sacar(c) {
+				try {
+					if (c > 0)
+						throw new Exception("saldo insuficiente")
+					return 19
+				} 
+				catch e {
+					return 20
+				}
+			}
+		}
+		program p {
+			assert.equals(20, cuenta.sacar(10))
+			assert.equals(19, cuenta.sacar(0))
+		}'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void testCatchEvaluationInAShortCutMethod() {
+		'''
+		object cuenta {
+			method sacar(c) = try { 
+					if (c > 0) 
+						throw new Exception("saldo insuficiente") 
+					else 19
+				} catch e {
+					20
+				}
+		}
+		program p {
+			assert.equals(20, cuenta.sacar(10))
+			assert.equals(19, cuenta.sacar(0))
+		}'''.interpretPropagatingErrors
 	}
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/AbstractWollokCallable.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/AbstractWollokCallable.xtend
@@ -22,6 +22,8 @@ import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJav
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
 import static extension org.uqbar.project.wollok.ui.utils.XTendUtilExtensions.*
 
+import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
+
 /**
  * Methods to be shared between WollokObject and CallableSuper
  * 
@@ -58,7 +60,7 @@ abstract class AbstractWollokCallable implements WCallable {
 			}
 			else {
 				val WollokObject r = method.expression.eval as WollokObject
-				return if (method.expressionReturns)
+				return if (method.supposedToReturnValue)
 						r
 					else
 						theVoid

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -142,7 +142,7 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 		try
 			t.expression.eval
 		catch (WollokProgramExceptionWrapper e) {
-			val cach = t.catchBlocks.findFirst[c|c.matches(e.wollokException)]
+			val cach = t.catchBlocks.findFirst[ it.matches(e.wollokException) ]
 			if (cach != null) {
 				cach.evaluate(e)
 			} else


### PR DESCRIPTION
…luation was only returning a value if it was a shortcut method (a method declared with a = symbol. And was not consisten with static checks that assumes that a method generates a value in that case, but also in case it has a 'return something' statement as part of the body). I have reused the extension method for that and added some tests for different situations

#732 