### PR TITLE
New feature "test" method - issue #737

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/AbstractWollokInterpreterTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/AbstractWollokInterpreterTestCase.xtend
@@ -49,6 +49,15 @@ abstract class AbstractWollokInterpreterTestCase extends Assert {
 	def interpretPropagatingErrors(CharSequence programAsString) {
 		interpretPropagatingErrors(newArrayList(null as String -> programAsString.toString))
 	}
+	
+	def test(CharSequence testCode) {
+	    '''
+	    program a {
+    		«testCode»
+	    } 
+    	'''.interpretPropagatingErrors
+	}
+	
 
 	def interpretPropagatingErrors(String... programAsString) {
 		interpretPropagatingErrors(programAsString.map[null -> it])
@@ -137,4 +146,5 @@ abstract class AbstractWollokInterpreterTestCase extends Assert {
 		}
 		
 	}
+	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RangeTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RangeTestCase.xtend
@@ -12,269 +12,217 @@ class RangeTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void testForEach() {
 		'''
-		program a {
-			const range = 0 .. 10
-			var sum = 0
-			assert.that(range != null)
-			range.forEach { i => sum += i }
-			assert.equals(55, sum)
-		}
-		'''.interpretPropagatingErrors
+		const range = 0 .. 10
+		var sum = 0
+		assert.that(range != null)
+		range.forEach { i => sum += i }
+		assert.equals(55, sum)
+		'''.test
 	}
 
 	@Test
 	def void fold() {
 		'''
-		program a {
-			var range = 0 .. 10 
-			var sum = range.fold(0, { acum, each => acum + each })
-			assert.equals(55, sum)
-		}
-		'''.interpretPropagatingErrors
+		var range = 0 .. 10 
+		var sum = range.fold(0, { acum, each => acum + each })
+		assert.equals(55, sum)
+		'''.test
 	}
 
 	@Test
 	def void sum() {
 		'''
-		program a {
-			var range = 0 .. 9 
-			assert.equals(45, range.sum())
-		}
-		'''.interpretPropagatingErrors
+		var range = 0 .. 9 
+		assert.equals(45, range.sum())
+		'''.test
 	}
 
 	@Test
 	def void sumClosure() {
 		'''
-		program a {
-			var range = 0 .. 9 
-			assert.equals(90, range.sum({ n => n * 2 }))
-		}
-		'''.interpretPropagatingErrors
+		var range = 0 .. 9 
+		assert.equals(90, range.sum({ n => n * 2 }))
+		'''.test
 	}
 
 	@Test
 	def void contains() {
 		'''
-		program a {
-			var range = 0 .. 9 
-			assert.that(range.contains(9))
-			assert.that(range.contains(0))
-			assert.that(range.contains(4))
-			assert.notThat(range.contains(-1))
-			assert.notThat(range.contains(10))
-		}
-		'''.interpretPropagatingErrors
+		var range = 0 .. 9 
+		assert.that(range.contains(9))
+		assert.that(range.contains(0))
+		assert.that(range.contains(4))
+		assert.notThat(range.contains(-1))
+		assert.notThat(range.contains(10))
+		'''.test
 	}
 		
 	@Test
 	def void size() {
 		'''
-		program a {
-			var range = 0 .. 10 
-			assert.equals(11, range.size())
-			assert.equals(10, (12..21).size())
-			assert.equals(7, (-3..3).size())
-		}
-		'''.interpretPropagatingErrors
+		assert.equals(11, (0..10).size())
+		assert.equals(10, (12..21).size())
+		assert.equals(7, (-3..3).size())
+		'''.test
 	
 	}
 	
 	@Test
 	def void isEmpty() {
 		'''
-		program a {
-			var range = 0 .. 10 
-			assert.notThat(range.isEmpty())
-			assert.notThat((0 .. 0).isEmpty())
-		}
-		'''.interpretPropagatingErrors
-	
+		assert.notThat((0..10).isEmpty())
+		assert.notThat((0 .. 0).isEmpty())
+		'''.test
 	}
 	
 	@Test
 	def void any() {
 		'''
-		program a {
-			var range = 0 .. 10 
-			assert.that(range.any({ elem => elem == 5}))
-			assert.notThat(range.any({ elem => elem == 15}))
-		}
-		'''.interpretPropagatingErrors	
+		assert.that((0..10).any({ elem => elem == 5}))
+		assert.notThat((0..10).any({ elem => elem == 15}))
+		'''.test	
 	}
 
 	@Test
 	def void all() {
 		'''
-		program a {
-			var range = 0 .. 10 
-			assert.notThat(range.all({ elem => elem.even()}))
-			assert.that(range.any({ elem => elem < 11}))
-		}
-		'''.interpretPropagatingErrors	
+		var range = 0 .. 10 
+		assert.notThat(range.all({ elem => elem.even()}))
+		assert.that(range.any({ elem => elem < 11}))
+		'''.test	
 	}
 
 	@Test
 	def void map() {
 		'''
-		program a {
-			var range = 0 .. 5 
-			assert.that([0, 2, 4, 6, 8, 10] == range.map({ elem => elem * 2}))
-		}
-		'''.interpretPropagatingErrors	
+		var range = 0 .. 5 
+		assert.that([0, 2, 4, 6, 8, 10] == range.map({ elem => elem * 2}))
+		'''.test	
 	}
 
 	@Test
 	def void filter() {
 		'''
-		program a {
-			const range = 0 .. 10
-			const evenFiltered = range.filter({ elem => elem.even() })
-			assert.that([0, 2, 4, 6, 8, 10] == evenFiltered)
-		}
-		'''.interpretPropagatingErrors	
+		const range = 0 .. 10
+		const evenFiltered = range.filter({ elem => elem.even() })
+		assert.that([0, 2, 4, 6, 8, 10] == evenFiltered)
+		'''.test	
 	}
 
 	@Test
 	def void count() {
 		'''
-		program a {
-			const range = 0 .. 9
-			const evenCount = range.count({ elem => elem.even() })
-			assert.equals(5, evenCount)
-		}
-		'''.interpretPropagatingErrors	
+		const range = 0 .. 9
+		const evenCount = range.count({ elem => elem.even() })
+		assert.equals(5, evenCount)
+		'''.test	
 	}
 
 	@Test
 	def void anyOne() {
 		'''
-		program a {
-			const range = 0 .. 10
-			const anyOne = range.anyOne()
-			assert.that(range.contains(anyOne))
-		}
-		'''.interpretPropagatingErrors	
+		const range = 0 .. 10
+		const anyOne = range.anyOne()
+		assert.that(range.contains(anyOne))
+		'''.test	
 	}
 
 	@Test
 	def void min() {
 		'''
-		program a {
-			const range = -2 .. 10
-			const range2 = 7 .. 3
-			assert.equals(-2, range.min())
-			assert.equals(3, range2.min())
-		}
-		'''.interpretPropagatingErrors	
+		const range = -2 .. 10
+		const range2 = 7 .. 3
+		assert.equals(-2, range.min())
+		assert.equals(3, range2.min())
+		'''.test	
 	}
 
 	@Test
 	def void max() {
 		'''
-		program a {
-			const range = -22 .. -3
-			const range2 = 7 .. 3
-			assert.equals(-3, range.max())
-			assert.equals(7, range2.max())
-		}
-		'''.interpretPropagatingErrors	
+		const range = -22 .. -3
+		const range2 = 7 .. 3
+		assert.equals(-3, range.max())
+		assert.equals(7, range2.max())
+		'''.test	
 	}
 	
 	@Test
 	def void testRangeForDecimalsNotAllowed() {
 		'''
-		program a {
-			assert.throwsException({ => new Range(2.0, 5.0)})
-		}
-		'''.interpretPropagatingErrors
+		assert.throwsException({ => new Range(2.0, 5.0)})
+		'''.test
 	}	
 
 	@Test
 	def void testRangeForStringsNotAllowed() {
 		'''
-		program a {
-			assert.throwsException({ => new Range("ABRACADBRA", "PATA")})
-		}
-		'''.interpretPropagatingErrors
+		assert.throwsException({ => new Range("ABRACADBRA", "PATA")})
+		'''.test
 	}	
 
 	@Test
 	def void find() {
 		'''
-		program a {
-			const range = 1 .. 9
-			const evenFound = range.find({ elem => elem.even() })
-			assert.equals(2, evenFound)
-		}
-		'''.interpretPropagatingErrors	
+		const range = 1 .. 9
+		const evenFound = range.find({ elem => elem.even() })
+		assert.equals(2, evenFound)
+		'''.test	
 	}
 
 	@Test
 	def void findOrValue() {
 		'''
-		program a {
-			const range = 1 .. 9
-			const valueNotFound = range.findOrDefault({ elem => elem > 55 }, 22)
-			assert.equals(22, valueNotFound)
-		}
-		'''.interpretPropagatingErrors	
+		const range = 1 .. 9
+		const valueNotFound = range.findOrDefault({ elem => elem > 55 }, 22)
+		assert.equals(22, valueNotFound)
+		'''.test	
 	}
 
 	@Test
 	def void findOrElse() {
 		'''
-		program a {
-			var encontro = true
-			const range = 1 .. 9
-			const valueNotFound = range.findOrElse({ elem => elem > 55 }, { encontro = false })
-			assert.notThat(encontro)
-		}
-		'''.interpretPropagatingErrors	
+		var encontro = true
+		const range = 1 .. 9
+		const valueNotFound = range.findOrElse({ elem => elem > 55 }, { encontro = false })
+		assert.notThat(encontro)
+		'''.test	
 	}
 	
 	@Test
 	def void sortedBy() {
 		'''
-		program a {
-			const range = 1 .. 9
-			const sortedRange = range.sortedBy({ a, b => a.even() && b.even().negate() })
-			assert.equals([2, 4, 6, 8, 1, 3, 5, 7, 9], sortedRange)
-		}
-		'''.interpretPropagatingErrors	
+		const range = 1 .. 9
+		const sortedRange = range.sortedBy({ a, b => a.even() && b.even().negate() })
+		assert.equals([2, 4, 6, 8, 1, 3, 5, 7, 9], sortedRange)
+		'''.test	
 	}
 
 	@Test
 	def void sumStep3() {
 		'''
-		program a {
-			const range = 1 .. 14
-			range.step(3)
-			assert.equals(35, range.sum())
-		}
-		'''.interpretPropagatingErrors	
+		const range = 1 .. 14
+		range.step(3)
+		assert.equals(35, range.sum())
+		'''.test	
 	}
 
 	@Test
 	def void countStepMinus3() {
 		'''
-		program a {
-			const range = 8 .. 1
-			range.step(-3)
-			assert.equals(2, range.count({ elem => elem.even() }))
-		}
-		'''.interpretPropagatingErrors	
+		const range = 8 .. 1
+		range.step(-3)
+		assert.equals(2, range.count({ elem => elem.even() }))
+		'''.test	
 	}
 
 	@Test
 	def void filterStepMinus3() {
 		'''
-		program a {
-			const range = 8 .. 1
-			range.step(-3)
-			assert.equals([8,2], range.filter({ elem => elem.even() }))
-		}
-		'''.interpretPropagatingErrors	
+		const range = 8 .. 1
+		range.step(-3)
+		assert.equals([8,2], range.filter({ elem => elem.even() }))
+		'''.test	
 	}
 
 }


### PR DESCRIPTION
Making a mini pull request just to notify everyone there is now a test method that simplifies testing.
Instead of doing

``` java
	@Test
	def void filterStepMinus3() {
		'''
		program a {
			const range = 8 .. 1
			range.step(-3)
			assert.equals([8,2], range.filter({ elem => elem.even() }))
		}
		'''.interpretPropagatingErrors	
	}
```

You can do:

``` java
	@Test
	def void filterStepMinus3() {
		'''
		const range = 8 .. 1
		range.step(-3)
		assert.equals([8,2], range.filter({ elem => elem.even() }))
		'''.test	
	}
```
