### PR TITLE
Dev #765 anonymous objects are not printable

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ObjectTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ObjectTest.xtend
@@ -34,7 +34,7 @@ class ObjectTest extends AbstractWollokInterpreterTestCase {
 					var altura = 2
 				}
 				
-				assert.equals("anObject[edad=23, altura=2]", anonymousObject.toString())
+				assert.equals("an Object[edad=23, altura=2]", anonymousObject.toString())
 			}
 		'''.interpretPropagatingErrors
 	}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ObjectTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ObjectTest.xtend
@@ -31,10 +31,10 @@ class ObjectTest extends AbstractWollokInterpreterTestCase {
 				
 				const anonymousObject = object {
 					var edad = 23
-					var altura = 1.7
+					var altura = 2
 				}
 				
-				assert.equals("anObject[edad=23, altura=1.7]", anonymousObject.toString())
+				assert.equals("anObject[edad=23, altura=2]", anonymousObject.toString())
 			}
 		'''.interpretPropagatingErrors
 	}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ObjectTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ObjectTest.xtend
@@ -34,8 +34,7 @@ class ObjectTest extends AbstractWollokInterpreterTestCase {
 					var altura = 1.7
 				}
 				
-«««				//TODO
-«««				assert.equals("anObject[edad=23, altura=1.7]", anonymousObject.toString())
+				assert.equals("anObject[edad=23, altura=1.7]", anonymousObject.toString())
 			}
 		'''.interpretPropagatingErrors
 	}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -230,9 +230,13 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 	}
 
 	def dispatch evaluate(WObjectLiteral l) {
-		new WollokObject(interpreter, l) => [
-			l.mixins.forEach[m|m.addMembersTo(it)]
-			l.members.forEach[m|addMember(m)]
+		new WollokObject(interpreter, l) => [ wo |
+			l.members.forEach[m|wo.addMember(m)]
+			l.parent.superClassesIncludingYourselfTopDownDo [
+				addMembersTo(wo)
+				if (native) wo.nativeObjects.put(it, createNativeObject(wo, interpreter))
+			]
+			l.mixins.forEach[m|m.addMembersTo(wo)]
 		]
 	}
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/linking/WollokLinker.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/linking/WollokLinker.xtend
@@ -42,5 +42,5 @@ class WollokLinker extends LazyLinker {
 	def dispatch EReference getParentRef(WClass wClass) { WollokDslPackage.Literals.WCLASS__PARENT }
 	def dispatch EReference getParentRef(WNamedObject wObject) { WollokDslPackage.Literals.WNAMED_OBJECT__PARENT }
 	def dispatch EReference getParentRef(WObjectLiteral wObject) { WollokDslPackage.Literals.WOBJECT_LITERAL__PARENT }
-
+	def dispatch EReference getParentRef(EObject wObject) { null }
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/linking/WollokLinker.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/linking/WollokLinker.xtend
@@ -12,6 +12,7 @@ import org.uqbar.project.wollok.wollokDsl.WClass
 import org.uqbar.project.wollok.wollokDsl.WollokDslPackage
 import org.uqbar.project.wollok.wollokDsl.WNamedObject
 import org.eclipse.emf.ecore.EReference
+import org.uqbar.project.wollok.wollokDsl.WObjectLiteral
 
 class WollokLinker extends LazyLinker {
 	@Inject
@@ -32,10 +33,14 @@ class WollokLinker extends LazyLinker {
 	}	
 	def dispatch shouldSetParent(WNamedObject wObject) {
 		wObject.parent == null
+	}	
+	def dispatch shouldSetParent(WObjectLiteral wObject) {
+		wObject.parent == null
 	}
 	def dispatch shouldSetParent(EObject obj) { false }
 
 	def dispatch EReference getParentRef(WClass wClass) { WollokDslPackage.Literals.WCLASS__PARENT }
 	def dispatch EReference getParentRef(WNamedObject wObject) { WollokDslPackage.Literals.WNAMED_OBJECT__PARENT }
+	def dispatch EReference getParentRef(WObjectLiteral wObject) { WollokDslPackage.Literals.WOBJECT_LITERAL__PARENT }
 
 }


### PR DESCRIPTION
Close #765 

The problem was anonymous objects didn't inherits from Object, so I added WObjectLiteral in the _WollokLinker_.
Then Wollok fails on execute `toString()` method, and it was because the Interpreter didn't add the inherits elements (and its natives). I change the `evaluate(WObjectLiteral l)` method in _WollokInterpreterEvaluator_ and delegate some duplicated code into methods.

### Some unrelated problems 

1. On add `getParentRef(WObjectLiteral wObject)` in the multi-method I get a compilation error: `Type mismatch: cannot convert from EObject to WMethodContainer`. 
I'm not sure why, but I can fix it adding a definition for EObject: `getParentRef(EObject wObject)`. 
But It's sounds to _hack_, there is other solution?

2. Wollok has a bug on printing objects with a Double property type: https://github.com/uqbar-project/wollok/issues/771
I had to change the test for avoid this problem.