### PR TITLE
Fixes #680  glitch in editor corrupts the view

### DIFF
--- a/org.uqbar.project.wollok.ui.diagrams/src/org/uqbar/project/wollok/ui/diagrams/classes/ClassDiagramView.xtend
+++ b/org.uqbar.project.wollok.ui.diagrams/src/org/uqbar/project/wollok/ui/diagrams/classes/ClassDiagramView.xtend
@@ -71,6 +71,14 @@ import org.uqbar.project.wollok.wollokDsl.WollokDslPackage
 
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 import org.uqbar.project.wollok.ui.diagrams.classes.parts.InheritanceConnectionEditPart
+import org.eclipse.ui.PlatformUI
+import org.eclipse.core.runtime.Platform
+import org.eclipse.ui.internal.UISynchronizer
+import org.eclipse.core.runtime.jobs.Job
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.IStatus
+import org.eclipse.core.runtime.Status
+import org.eclipse.ui.progress.UIJob
 
 /**
  * 
@@ -336,16 +344,24 @@ class ClassDiagramView extends ViewPart implements ISelectionListener, ISourceVi
 			refresh()
 		}
 	}
+	val refreshJob = new UIJob("Updating diagram view") {
+			override def runInUIThread(IProgressMonitor monitor) {
+				diagram = createDiagramModel
+				initializeGraphicalViewer
+				Status.OK_STATUS
+			}
+		}
 	
 	def refresh() {
-		diagram = createDiagramModel
-		initializeGraphicalViewer
+		refreshJob.schedule
 	}
 	
 	// IDocumentListener
 	
 	override documentAboutToBeChanged(DocumentEvent event) { }
-	override documentChanged(DocumentEvent event) { refresh }
+	override documentChanged(DocumentEvent event) { 
+		refresh
+	}
 	
 	// ****************************	
 	// ** Palette


### PR DESCRIPTION
This fixes the horrible bug #680

Seems like if you put a document listener into an xtext document and you perform a task that takes some time (like layout the class diagram) screws other parts of the editor.

What I've done is, probably what should have been done always, to run the listener code in a separated UIJob scheduled to be run in another moment.
So that it won't interfere with the editor behavior.

It now works fine.

My only explanation for other cases when people saw this happening in xtext own editor (and not just in wollok) is that they also have some listener that, sometimes takes longer and screws it up).

Fixes #680
