### PR TITLE
Issue #681 - Static diagram temporarily hidden for Wollok perspective

### DIFF
--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/perspectives/WollokCodingPerspectiveFactory.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/perspectives/WollokCodingPerspectiveFactory.xtend
@@ -46,9 +46,10 @@ class WollokCodingPerspectiveFactory implements IPerspectiveFactory {
 			addView("org.eclipse.ui.views.ContentOutline");
 		]
 		
-		createFolder("right", IPageLayout.BOTTOM, 0.25f, "org.eclipse.ui.views.ContentOutline") => [
-			addView("org.uqbar.project.wollok.ui.diagrams.class");
-		]
+//		#681 - For release 1.5, static diagram will remain hidden for Wollok perspective
+//		createFolder("right", IPageLayout.BOTTOM, 0.25f, "org.eclipse.ui.views.ContentOutline") => [
+//			addView("org.uqbar.project.wollok.ui.diagrams.class");
+//		]
 		
 		addFastView("org.eclipse.team.ccvs.ui.RepositoriesView", 0.50f)
 		addFastView("org.eclipse.team.sync.views.SynchronizeView", 0.50f)


### PR DESCRIPTION
Just static diagram in Wollok Perspective is hidden. Nothing else.