### PR TITLE
Fixing issue #819 - pasting text in a REPL console

### DIFF
--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsolePage.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsolePage.xtend
@@ -9,10 +9,10 @@ import org.eclipse.swt.events.MouseEvent
 import org.eclipse.swt.events.VerifyEvent
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.ui.console.IConsoleView
+import org.eclipse.ui.console.IScrollLockStateProvider
+import org.eclipse.ui.console.TextConsole
 import org.eclipse.ui.console.TextConsolePage
 import org.eclipse.ui.console.TextConsoleViewer
-import org.eclipse.ui.console.TextConsole
-import org.eclipse.ui.console.IScrollLockStateProvider
 import org.uqbar.project.wollok.ui.console.editor.WollokReplStyledText
 
 /**
@@ -80,7 +80,7 @@ class WollokReplConsolePage extends TextConsolePage implements KeyListener {
 	override keyPressed(KeyEvent e) {
 		if (!console.running) {
 			e.doit = false
-			return;
+			return
 		}
 
 		if (e.keyCode == SWT.ARROW_UP) {
@@ -105,12 +105,15 @@ class WollokReplConsolePage extends TextConsolePage implements KeyListener {
 			setCursorToEnd
 			return
 		}
-		// return key pressed 
+		// return key pressed
 		if (e.keyCode == KEY_RETURN && !e.controlPressed) {
+			console.updateIfDirty
 			console.sendInputBuffer
 			historyPosition = -1
-		} else
-			console.updateInputBuffer
+		} else {
+			console.updateInputBuffer	
+		}
+		
 		return
 	}
 

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/editor/WollokReplStyledText.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/editor/WollokReplStyledText.xtend
@@ -28,7 +28,7 @@ class WollokReplStyledText extends StyledText {
 
 	override copy() {
 		checkWidget()
-		this.doCopySelection(DND.CLIPBOARD);
+		this.doCopySelection(DND.CLIPBOARD)
 	}
 
 	def doCopySelection(int type) {
@@ -82,7 +82,7 @@ class WollokReplStyledText extends StyledText {
 			types = #[ plainTextTransfer ]
 		}
 		val clipboard = getFieldValue("clipboard") as Clipboard
-		clipboard.setContents(data, types, clipboardType);
+		clipboard.setContents(data, types, clipboardType)
 	}
 	
 	private def getEscapedBlockText() {
@@ -105,5 +105,5 @@ class WollokReplStyledText extends StyledText {
 		method.accessible = true
 		method.invoke(this, args)
 	}
-
+	
 }


### PR DESCRIPTION
Tried with one and many lines. Now you can paste text previously copied in REPL console.
It's not platform dependant, fortunately.