### PR TITLE
Dev #828 line separator

### DIFF
--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/VisualComponent.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/VisualComponent.xtend
@@ -33,7 +33,7 @@ abstract class VisualComponent {
 	}
 
 	def drawAttributesIfNecesary(Window window) {		
-		var printableString = getAttributes.join("\n")
+		var printableString = getAttributes.join(System.lineSeparator)
 		if (printableString != "" && inMyZone) {
 			window.writeAttributes(printableString, position, Color.WHITE)
 		}

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/debugger/server/XDebuggerImpl.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/debugger/server/XDebuggerImpl.xtend
@@ -48,7 +48,7 @@ class XDebuggerImpl implements XDebugger {
 	}
 	
 	protected def logEvent(String event, EObject element) {
-		log.trace('''ON STATE [«state»] «event» [«element.fileURI.lastSegment»:«element.lineNumber» - id=«System.identityHashCode(currentStepObject)»]: «element.shortSouceCode»''')
+		log.trace('''ON STATE [«state»] «event» [«element.fileURI.lastSegment»:«element.lineNumber» - id=«System.identityHashCode(currentStepObject)»]: «element.shortSourceCode»''')
 	}
 	
 	override evaluated(EObject element) {

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/debugger/server/XDebuggerState.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/debugger/server/XDebuggerState.xtend
@@ -47,7 +47,7 @@ class SteppingOver extends XDebuggerState {
 			d.state = new PauseOnNext
 		}
 	}
-	override toString() { "STEPPING_OVER(" + currentStepObject.shortSouceCode + "-" + System.identityHashCode(currentStepObject) + ")" }
+	override toString() { "STEPPING_OVER(" + currentStepObject.shortSourceCode + "-" + System.identityHashCode(currentStepObject) + ")" }
 }
 
 /**

--- a/org.uqbar.project.wollok.lib/src/wollok/lib.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib.wlk
@@ -14,6 +14,12 @@ object console {
 	
 	/** Reads an int character from input stream */
 	method readInt() native
+	
+	/** Returns the system's representation of a new line:
+	 * - \n in Unix systems
+	 * - \r\n in Windows systems
+	 */
+	 method newline() native
 }
 
 /**
@@ -68,7 +74,7 @@ object assert {
 class StringPrinter {
 	var buffer = ""
 	method println(obj) {
-		buffer += obj.toString() + "\n"
+		buffer += obj.toString() + console.newline()
 	}
 	method getBuffer() = buffer
 }	

--- a/org.uqbar.project.wollok.lib/src/wollok/lib/ConsoleObject.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib/ConsoleObject.xtend
@@ -26,4 +26,8 @@ class ConsoleObject {
 		val line = reader.readLine
 		Integer.parseInt(line)
 	}
+	
+	def newline() {
+		System.lineSeparator
+	}
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/AbstractWollokInterpreterTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/AbstractWollokInterpreterTestCase.xtend
@@ -103,7 +103,7 @@ abstract class AbstractWollokInterpreterTestCase extends Assert {
 					it.interpret(propagatingErrors)
 				catch (WollokProgramExceptionWrapper e) {
 					println("MESSAGE = " + e.wollokException.resolve("message"))
-					fail(e.wollokException.resolve("message") + "\n" + e.wollokStackTrace)
+					fail(e.wollokException.resolve("message") + System.lineSeparator + e.wollokStackTrace)
 					println("after fail")
 				}
 			]

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -18,7 +18,7 @@ class ListTest extends ListTestCase {
 	}
 	
 	override instantiateStrings() {
-		"const strings = new List(); \n ['hello', 'hola', 'bonjour', 'ciao', 'hi'].forEach{e=> strings.add(e) }"
+		"const strings = new List(); " + System.lineSeparator + " ['hello', 'hola', 'bonjour', 'ciao', 'hi'].forEach{e=> strings.add(e) }"
 	}
 	
 	@Test

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/AbstractWollokTypeSystemTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/AbstractWollokTypeSystemTestCase.xtend
@@ -86,7 +86,7 @@ abstract class AbstractWollokTypeSystemTestCase extends AbstractWollokInterprete
 		
 		val nonCompliant = expectedIssues.filter[expected| !issues.exists[message == expected]]
 		if (!nonCompliant.empty)
-			fail("Expecting the following issues on '" +  programToken + "' but they were not present: " + nonCompliant + "\nAlthough there were the following errors: " + issues)
+			fail("Expecting the following issues on '" +  programToken + "' but they were not present: " + nonCompliant + System.lineSeparator + "Although there were the following errors: " + issues)
 		
 		val unexpecteds = issues.filter[i| !expectedIssues.contains(i.message)]
 		if (!unexpecteds.empty)
@@ -105,7 +105,7 @@ abstract class AbstractWollokTypeSystemTestCase extends AbstractWollokInterprete
 	}
 	
 	def static String escapeNodeTextToCompare(String nodeText) {
-		if (nodeText.startsWith("\n"))
+		if (nodeText.startsWith(System.lineSeparator))
 			nodeText.substring(1).escapeNodeTextToCompare
 		else if (nodeText.startsWith("\t"))
 			nodeText.substring(1).escapeNodeTextToCompare

--- a/org.uqbar.project.wollok.typeSystem.xsemantics/src/org/uqbar/project/wollok/typesystem/substitutions/CheckTypeRule.xtend
+++ b/org.uqbar.project.wollok.typeSystem.xsemantics/src/org/uqbar/project/wollok/typesystem/substitutions/CheckTypeRule.xtend
@@ -56,7 +56,7 @@ class CheckTypeRule extends TypeRule {
 
 	// object
 
-	override toString() { '''«a» «check.operandString» «b» ''' + "\t\t\t\t(" + source.lineNumber + ": " + source.sourceCode.trim.replaceAll('\n', ' ') + ")" }
+	override toString() { '''«a» «check.operandString» «b» ''' + "\t\t\t\t(" + source.lineNumber + ": " + source.sourceCode.trim.replaceAll(System.lineSeparator, ' ') + ")" }
 
 	override equals(Object obj) {
 		if (obj instanceof CheckTypeRule)

--- a/org.uqbar.project.wollok.typeSystem.xsemantics/src/org/uqbar/project/wollok/typesystem/substitutions/FactTypeRule.xtend
+++ b/org.uqbar.project.wollok.typeSystem.xsemantics/src/org/uqbar/project/wollok/typesystem/substitutions/FactTypeRule.xtend
@@ -28,7 +28,7 @@ class FactTypeRule extends TypeRule {
 	override typeOf(EObject object) { if (object == model) type else null }
 	
 	// object
-	override toString() { '''t(«model.sourceCode.trim.replaceAll('\n', ' ')») = «type»''' + "\t\t\t\t(" + source.lineNumber + ": " + source.sourceCode.trim.replaceAll('\n', ' ') + ")" }
+	override toString() { '''t(«model.sourceCode.trim.replaceAll(System.lineSeparator, ' ')») = «type»''' + "\t\t\t\t(" + source.lineNumber + ": " + source.sourceCode.trim.replaceAll(System.lineSeparator, ' ') + ")" }
 	override equals(Object obj) {
 		obj instanceof FactTypeRule && model == (obj as FactTypeRule).model && type == (obj as FactTypeRule).type 
 	}

--- a/org.uqbar.project.wollok.typeSystem.xsemantics/src/org/uqbar/project/wollok/typesystem/substitutions/SubstitutionBasedTypeSystem.xtend
+++ b/org.uqbar.project.wollok.typeSystem.xsemantics/src/org/uqbar/project/wollok/typesystem/substitutions/SubstitutionBasedTypeSystem.xtend
@@ -230,7 +230,8 @@ class SubstitutionBasedTypeSystem implements TypeSystem {
 	}
 
 	override toString() {
-		'{\n\t' + rules.join("\n\t") + '\n}'
+		'{' + System.lineSeparator + '\t' + 
+		rules.join(System.lineSeparator + "\t") + System.lineSeparator
 	}
 
 	override queryMessageTypeForMethod(WMethodDeclaration declaration) {

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsole.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsole.xtend
@@ -160,7 +160,7 @@ class WollokReplConsole extends TextConsole {
 	}
 
 	def sendInputBuffer() {
-		val x = inputBuffer + "\n";
+		val x = inputBuffer + System.lineSeparator;
 
 		addCommandToHistory
 		sessionCommands += inputBuffer
@@ -192,7 +192,7 @@ class WollokReplConsole extends TextConsole {
 		if (inputBuffer.empty) {
 			updateInputBuffer
 			// hack - delete all RETURN keys to avoid several >>> 
-			inputBuffer = inputBuffer.replaceAll('\n', '')
+			inputBuffer = inputBuffer.replaceAll(System.lineSeparator, '')
 		}
 	}
 }

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokCodeHighLightLineStyleListener.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokCodeHighLightLineStyleListener.xtend
@@ -41,8 +41,8 @@ class WollokCodeHighLightLineStyleListener implements LineStyleListener {
 	
 	var PARSER_ERROR_COLOR = newColor(255, 0, 0)
 	
-	val programHeader = "program repl {\n"
-	val programFooter =  "\n}"
+	val programHeader = "program repl {" + System.lineSeparator
+	val programFooter =  System.lineSeparator + "}"
 	val headerLength = programHeader.length
 	
 	@Inject ISemanticHighlightingCalculator calculator

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/refactoring/ExtractMethodHandler.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/refactoring/ExtractMethodHandler.xtend
@@ -61,11 +61,11 @@ class ExtractMethodHandler extends AbstractHandler {
 		} 
 		catch (InterruptedException e) {
 			LOG.error("Error during refactoring", e)
-			MessageDialog.openError(Display.current.activeShell, "Error during refactoring", e.message + "\nSee log for details")
+			MessageDialog.openError(Display.current.activeShell, "Error during refactoring", e.message + System.lineSeparator + "See log for details")
 		} 
 		catch (Exception exc) {
 			LOG.error("Error during refactoring", exc)
-			MessageDialog.openError(Display.current.activeShell, "Error during refactoring", exc.message + "\nSee log for details")
+			MessageDialog.openError(Display.current.activeShell, "Error during refactoring", exc.message + System.lineSeparator + "See log for details")
 		}
 		null
 	}

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/QuickFixUtils.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/QuickFixUtils.xtend
@@ -22,12 +22,12 @@ class QuickFixUtils {
 	 * It will keep the same indentation as the previous line.
 	 */
 	def static insertAfter(IModificationContext context, EObject e, String textToInsert) {
-		val newBlock = ('\n' + textToInsert).replaceAll('\n', e.marginFromPreviousLine(context))
+		val newBlock = (System.lineSeparator + textToInsert).replaceAll(System.lineSeparator, e.marginFromPreviousLine(context))
 		context.xtextDocument.replace(e.after, 0, newBlock)
 	}
 	
 	def static insertBefore(IModificationContext context, EObject e, String textToInsert) {
-		val newBlock = (textToInsert + "\n").replaceAll('\n', e.marginFromPreviousLine(context))
+		val newBlock = (textToInsert + System.lineSeparator).replaceAll(System.lineSeparator, e.marginFromPreviousLine(context))
 		context.xtextDocument.replace(e.before, 0, newBlock)
 	}
 	
@@ -70,7 +70,7 @@ class QuickFixUtils {
 	}
 	
 	def static marginFromPreviousLine(EObject e, IModificationContext context) {
-		// finds out the text from the last line '\n' and ths first char of this object
+		// finds out the text from the last line System.lineSeparator and the first char of this object
 		val lastLine = context.getLineInfo(e.node.previousSibling)
 		context.textBetween(lastLine.endOfLine, e.before)
 	}

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
@@ -46,7 +46,7 @@ import org.uqbar.project.wollok.wollokDsl.WBlockExpression
  */
 class WollokDslQuickfixProvider extends DefaultQuickfixProvider {
 	val tabChar = "\t"
-	val returnChar ="\n"
+	val returnChar = System.lineSeparator
 			
 	@Inject
 	WollokClassFinder classFinder
@@ -95,9 +95,9 @@ class WollokDslQuickfixProvider extends DefaultQuickfixProvider {
 			context.xtextDocument.replace(
 				placeToAdd,
 				0,
-				"\n" + "\t" + METHOD + " " + call.feature +
+				System.lineSeparator + "\t" + METHOD + " " + call.feature +
 					callText.substring(callText.indexOf('('), callText.lastIndexOf(')') + 1) +
-					" {\n\t\t//TODO: " + Messages.WollokDslQuickfixProvider_createMethod_stub + "\n\t}"
+					" {" + System.lineSeparator + "\t\t//TODO: " + Messages.WollokDslQuickfixProvider_createMethod_stub + System.lineSeparator + "\t}"
 			)
 		]
 	}
@@ -150,7 +150,7 @@ class WollokDslQuickfixProvider extends DefaultQuickfixProvider {
 	def addConstructorsFromSuperclass(Issue issue, IssueResolutionAcceptor acceptor) {
 		acceptor.accept(issue, 'Add constructors from superclass', 'Add same constructors as superclass.', null) [ e, it |
 			val clazz = e as WClass
-			val constructors = clazz.parent.constructors.map[ '''«tabChar»constructor(«parameters.map[name].join(',')») = super(«parameters.map[name].join(',')»)«returnChar»'''].join('\n')
+			val constructors = clazz.parent.constructors.map[ '''«tabChar»constructor(«parameters.map[name].join(',')») = super(«parameters.map[name].join(',')»)«returnChar»'''].join(System.lineSeparator)
 			addConstructor(clazz, constructors)
 		]
 	}
@@ -310,7 +310,7 @@ class WollokDslQuickfixProvider extends DefaultQuickfixProvider {
 		issueResolutionAcceptor.accept(issue, 'Create new class', 'Create a new class definition.', "class.png") [ e, context |
 			val newClassName = xtextDocument.get(issue.offset, issue.length)
 			val container = (e as WExpression).method.declaringContext
-			context.xtextDocument.replace(container.after, 0, "\n" + CLASS + newClassName + " {\n}\n")
+			context.xtextDocument.replace(container.after, 0, System.lineSeparator + CLASS + newClassName + " {" + System.lineSeparator + "}" + System.lineSeparator)
 		]
 		
 	}

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/WollokProjectFactory.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/WollokProjectFactory.xtend
@@ -9,9 +9,9 @@ class WollokProjectFactory extends PluginProjectFactory {
 	override protected createBuildProperties(IProject project, IProgressMonitor progressMonitor) {
 		val StringBuilder content = new StringBuilder("source.. = ");
 		content => [
-			append(folders.map[it + "/"].join(",\\\n"))
-			append("\n");
-			append("bin.includes = META-INF/,\\\n");
+			append(folders.map[it + "/"].join(",\\" + System.lineSeparator))
+			append(System.lineSeparator);
+			append("bin.includes = META-INF/,\\" + System.lineSeparator);
 			append("               .");
 		]
 

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/objects/NewWollokObjectsWizard.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/objects/NewWollokObjectsWizard.java
@@ -22,7 +22,13 @@ public class NewWollokObjectsWizard extends AbstractNewWollokFileWizard implemen
 	@Override
 	protected InputStream openContentStream() {
 		String contents =
-			"\nobject abc {\n\n\n\n}";
+			System.lineSeparator() + 
+			"object abc {" + 
+					System.lineSeparator() + 
+					System.lineSeparator() + 
+					System.lineSeparator() + 
+					System.lineSeparator() + 
+			"}";
 		return new ByteArrayInputStream(contents.getBytes());
 	}
 }

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/program/NewWollokProgramWizard.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/program/NewWollokProgramWizard.java
@@ -22,7 +22,14 @@ public class NewWollokProgramWizard extends AbstractNewWollokFileWizard implemen
 	@Override
 	protected InputStream openContentStream() {
 		String contents =
-			"\nprogram abc {\n\n\tconsole.println('Hello Wollok')\n\n}";
+			System.lineSeparator() + 
+			"program abc {" + 
+				System.lineSeparator() + 
+				System.lineSeparator() + 
+				"\tconsole.println('Hello Wollok')" + 
+				System.lineSeparator() + 
+				System.lineSeparator() + 
+			"}";
 		return new ByteArrayInputStream(contents.getBytes());
 	}
 }

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/tests/NewWollokTestWizard.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/tests/NewWollokTestWizard.java
@@ -22,7 +22,14 @@ public class NewWollokTestWizard extends AbstractNewWollokFileWizard implements 
 	@Override
 	protected InputStream openContentStream() {
 		String contents =
-			"\ntest \"testX\" {\n\n\tassert.that(true)\n\n}";
+			System.lineSeparator() + 
+			"test \"testX\" {" +
+			System.lineSeparator() +
+			System.lineSeparator() +
+			"\tassert.that(true)" +
+			System.lineSeparator() +
+			System.lineSeparator() +
+		"}";
 		return new ByteArrayInputStream(contents.getBytes());
 	}
 }

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/tests/NewWollokTestWizard.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/tests/NewWollokTestWizard.java
@@ -24,12 +24,12 @@ public class NewWollokTestWizard extends AbstractNewWollokFileWizard implements 
 		String contents =
 			System.lineSeparator() + 
 			"test \"testX\" {" +
-			System.lineSeparator() +
-			System.lineSeparator() +
-			"\tassert.that(true)" +
-			System.lineSeparator() +
-			System.lineSeparator() +
-		"}";
+				System.lineSeparator() +
+				System.lineSeparator() +
+				"\tassert.that(true)" +
+				System.lineSeparator() +
+				System.lineSeparator() +
+			"}";
 		return new ByteArrayInputStream(contents.getBytes());
 	}
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/XTextExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/XTextExtensions.xtend
@@ -46,7 +46,7 @@ class XTextExtensions {
 	def static fileURI(EObject o) { o.eResource.URI }
 	def static lineNumber(EObject o) { o.astNode.startLine }
 	def static sourceCode(EObject o) { o.astNode.text }
-	def static shortSouceCode(EObject o) { o.sourceCode.trim.replaceAll('\n', ' ') }
+	def static shortSourceCode(EObject o) { o.sourceCode.trim.replaceAll(System.lineSeparator, ' ') }
 	
 	def static objectURI(EObject o) { (o.eResource as XtextResource).getURIFragment(o) }
 	

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/XtendExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/XtendExtensions.xtend
@@ -7,5 +7,5 @@ class XtendExtensions {
 	/**
 	 * Divides a string into lines
 	 */
-	static def lines(CharSequence input) { input.toString.split("[\r\n]+") }
+	static def lines(CharSequence input) { input.toString.split("[" + System.lineSeparator() + "]+") }
 }

--- a/org.uqbar.project.xinterpreter/src/org/uqbar/project/xtext/utils/XTextExtensions.xtend
+++ b/org.uqbar.project.xinterpreter/src/org/uqbar/project/xtext/utils/XTextExtensions.xtend
@@ -30,7 +30,7 @@ class XTextExtensions {
 	def static fileURI(EObject o) { o.eResource.URI }
 	def static lineNumber(EObject o) { o.astNode.startLine }
 	def static sourceCode(EObject o) { o.astNode.text }
-	def static shortSouceCode(EObject o) { o.sourceCode.trim.replaceAll('\n', ' ') }
+	def static shortSouceCode(EObject o) { o.sourceCode.trim.replaceAll(System.lineSeparator, ' ') }
 	
 	def static objectURI(EObject o) { (o.eResource as XtextResource).getURIFragment(o) }
 	


### PR DESCRIPTION
- Creates method ```newline``` in the console WKO and its corresponding native class to be able to get the OS implementation: ```\n``` for Unix-like systems and ```\r\n``` for Windows.
- Replaces hardcoded ```\n```s in the code with either System.lineSeparator (XTend code) or console.newline() (Wollok code).