### PR TITLE
Fix maven-clean-plugin for xtend-gen directories

### DIFF
--- a/org.uqbar.project.wollok.releng/pom.xml
+++ b/org.uqbar.project.wollok.releng/pom.xml
@@ -115,58 +115,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>2.5</version>
-					<executions>
-						<execution>
-							<id>gen-clean</id>
-							<goals>
-								<goal>clean</goal>
-							</goals>
-							<configuration>
-								<filesets>
-									<fileset>
-										<directory>${basedir}/xtend-gen</directory>
-										<includes>
-											<include>**</include>
-										</includes>
-										<excludes>
-											<exclude>.gitignore</exclude>
-										</excludes>
-									</fileset>
-									<fileset>
-										<directory>${basedir}/src-gen</directory>
-										<includes>
-											<include>**</include>
-										</includes>
-										<excludes>
-											<exclude>.gitignore</exclude>
-										</excludes>
-									</fileset>
-									<fileset>
-										<directory>${basedir}/emf-gen</directory>
-										<includes>
-											<include>**</include>
-										</includes>
-										<excludes>
-											<exclude>.gitignore</exclude>
-										</excludes>
-									</fileset>
-									<fileset>
-										<directory>${basedir}/test-gen</directory>
-										<includes>
-											<include>**</include>
-										</includes>
-										<excludes>
-											<exclude>.gitignore</exclude>
-										</excludes>
-									</fileset>
-									<!-- <fileset> <directory>${basedir}/xsemantics-gen</directory> 
-										<includes> <include>**</include> </includes> <excludes> <exclude>.gitignore</exclude> 
-										</excludes> </fileset> -->
-								</filesets>
-							</configuration>
-						</execution>
-					</executions>
+					<version>3.0.0</version>
 				</plugin>
 
 				<!-- site -->
@@ -269,7 +218,34 @@
 		</pluginManagement>
 
 		<plugins>
-
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<configuration>
+					<filesets>
+						<fileset>
+							<directory>${basedir}/xtend-gen</directory>
+							<excludes>
+								<exclude>.gitignore</exclude>
+							</excludes>
+							<followSymlinks>false</followSymlinks>
+						</fileset>
+						<fileset>
+							<directory>${basedir}/emf-gen</directory>
+							<excludes>
+								<exclude>.gitignore</exclude>
+							</excludes>
+							<followSymlinks>false</followSymlinks>
+						</fileset>
+						<fileset>
+							<directory>${basedir}/test-gen</directory>
+							<excludes>
+								<exclude>.gitignore</exclude>
+							</excludes>
+							<followSymlinks>false</followSymlinks>
+						</fileset>
+					</filesets>
+				</configuration>
+			</plugin>
 			<!-- JAVA 8 -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -401,60 +377,62 @@
 				</configuration>
 			</plugin>
 			<!-- code coverage -->
-			
+
 			<!-- CHANGELOG generation -->
 			<plugin>
-			    <groupId>com.github.danielflower.mavenplugins</groupId>
-			    <artifactId>gitlog-maven-plugin</artifactId>
-			    <version>1.13.2</version>
-			    <executions>
-			       <execution>
-			         <goals>
-			          <goal>generate</goal>
-			         </goals>
-			       </execution>
-			    </executions>
-			    <configuration>
-			    	<generateMarkdownChangeLog>true</generateMarkdownChangeLog>
-			    	<markdownChangeLogFilename>CHANGELOG.md</markdownChangeLogFilename>
-			    	
-			    	<generatePlainTextChangeLog>true</generatePlainTextChangeLog>
-			    	<simpleHTMLChangeLogFilename>CHANGELOG.txt</simpleHTMLChangeLogFilename>
-			    	
-			    	<generateJSONChangeLog>false</generateJSONChangeLog>
-			    	
-			    	<excludeCommitsPattern>!(.*#.*)</excludeCommitsPattern>
-			    	<outputDirectory>${project.basedir}</outputDirectory>
-			    </configuration>
+				<groupId>com.github.danielflower.mavenplugins</groupId>
+				<artifactId>gitlog-maven-plugin</artifactId>
+				<version>1.13.2</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<generateMarkdownChangeLog>true</generateMarkdownChangeLog>
+					<markdownChangeLogFilename>CHANGELOG.md</markdownChangeLogFilename>
+
+					<generatePlainTextChangeLog>true</generatePlainTextChangeLog>
+					<simpleHTMLChangeLogFilename>CHANGELOG.txt</simpleHTMLChangeLogFilename>
+
+					<generateJSONChangeLog>false</generateJSONChangeLog>
+
+					<excludeCommitsPattern>!(.*#.*)</excludeCommitsPattern>
+					<outputDirectory>${project.basedir}</outputDirectory>
+				</configuration>
 			</plugin>
-			<!-- commit changelog  -->
+			<!-- commit changelog -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-scm-plugin</artifactId>
-		        <executions>
-		            <execution>
-		                <id>add-changelog-to-git</id>
-		                <goals>
-		                    <goal>add</goal>
-		                    <goal>checkin</goal>
-		                </goals>
-		                <configuration>
-		                    <basedir>./</basedir>
-		                    <includes>CHANGELOG.md,	changelog.txt</includes>
-		                    <message>Adding changelog</message>
-		                </configuration>
-		            </execution>
-		        </executions>
-		    </plugin>
-		    <!-- invoke commit on release prepare -->
-		    <plugin>
-		        <groupId>org.apache.maven.plugins</groupId>
-		        <artifactId>maven-release-plugin</artifactId>
-		        <version>2.5.3</version>
-		        <configuration>
-		          <preparationGoals>clean verify gitlog:generate org.apache.maven.plugins:maven-scm-plugin:add org.apache.maven.plugins:maven-scm-plugin:checking</preparationGoals>
-		        </configuration>
-		      </plugin>
+				<executions>
+					<execution>
+						<id>add-changelog-to-git</id>
+						<goals>
+							<goal>add</goal>
+							<goal>checkin</goal>
+						</goals>
+						<configuration>
+							<basedir>./</basedir>
+							<includes>CHANGELOG.md, changelog.txt</includes>
+							<message>Adding changelog</message>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- invoke commit on release prepare -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.3</version>
+				<configuration>
+					<preparationGoals>clean verify gitlog:generate
+						org.apache.maven.plugins:maven-scm-plugin:add
+						org.apache.maven.plugins:maven-scm-plugin:checking</preparationGoals>
+				</configuration>
+			</plugin>
 			<!-- /CHANGELOG generation -->
 		</plugins>
 


### PR DESCRIPTION
Close #882

I found [this tutorial](https://eclipse.org/Xtext/documentation/350_continuous_integration.html) to work with xtext + maven. When i go to code it, i found that is already coded. I fix the releng pom file that contains the misplaced plugin configuration. 

The additional configuration form maven-clean-plugin at org.uqbar.project.wollok project it's ok because the scm-gen files need to be cleaned in this project. [Here is](https://kthoms.wordpress.com/2011/10/06/xtext-maven-and-source-control/) an explanation.

