### PR TITLE
Fix #864 - Change Number.times() to void instead of null

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -1147,7 +1147,9 @@ class Integer inherits Number {
 	 * 			3
 	 * 			4
 	 */
-	method times(action) = (1..self).forEach(action)
+	method times(action) { 
+		(1..self).forEach(action) 
+	}
 }
 
 /**


### PR DESCRIPTION
Change in Number.times() implementation in order to make it a void method instead of returning null.