### PR TITLE
Add roundUp(n) and truncate(n) to Integer

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -1020,7 +1020,26 @@ class Number {
 	method rem(other) { return self % other }
 	
 	method stringValue() = throw new Exception("Should be implemented in the subclass")
-	
+
+	/**
+	 * Rounds up self up to a certain amount of decimals.
+	 * Amount of decimals must be positive
+	 * 1.223445.roundUp(3) ==> 1.224
+	 * -1.223445.roundUp(3) ==> -1.224
+	 * 14.6165.roundUp(3) ==> 14.617
+	 * 5.roundUp(3) ==> 5
+	 */
+	 method roundUp(_decimals)
+
+	/**
+	 * Truncates self up to a certain amount of decimals.
+	 * Amount of decimals must be positive
+	 * 1.223445.truncate(3) ==> 1.223
+	 * 14.6165.truncate(3) ==> 14.616
+	 * -14.6165.truncate(3) ==> -14.616
+	 * 5.truncate(3) ==> 5
+	 */
+	method truncate(_decimals)
 }
 
 /**
@@ -1151,25 +1170,8 @@ class Integer inherits Number {
 		(1..self).forEach(action) 
 	}
 	
-	/**
-	 * Rounds up self up to a certain amount of decimals.
-	 * Amount of decimals must be positive
-	 * 1.223445.roundUp(3) ==> 1.224
-	 * -1.223445.roundUp(3) ==> -1.224
-	 * 14.6165.roundUp(3) ==> 14.617
-	 * 5.roundUp(3) ==> 5
-	 */
-	method roundUp(_decimals) = self
-	
-	/**
-	 * Truncates self up to a certain amount of decimals.
-	 * Amount of decimals must be positive
-	 * 1.223445.truncate(3) ==> 1.223
-	 * 14.6165.truncate(3) ==> 14.616
-	 * -14.6165.truncate(3) ==> -14.616
-	 * 5.truncate(3) ==> 5
-	 */
-	method truncate(_decimals) = self
+	override method roundUp(_decimals) = self
+	override method truncate(_decimals) = self
 }
 
 /**
@@ -1244,23 +1246,8 @@ class Double inherits Number {
 	 */
 	method roundUp() = self.roundUp(0)
 	
-	/**
-	 * Rounds up self up to a certain amount of decimals.
-	 * Amount of decimals must be positive
-	 * 1.223445.roundUp(3) ==> 1.224
-	 * -1.223445.roundUp(3) ==> -1.224
-	 * 14.6165.roundUp(3) ==> 14.617
-	 */
-	method roundUp(_decimals) native
-	
-	/**
-	 * Truncates self up to a certain amount of decimals.
-	 * Amount of decimals must be positive
-	 * 1.223445.truncate(3) ==> 1.223
-	 * 14.6165.truncate(3) ==> 14.616
-	 * -14.6165.truncate(3) ==> -14.616
-	 */
-	method truncate(_decimals) native
+	override method roundUp(_decimals) native
+	override method truncate(_decimals) native
 }
 
 /**

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -1150,6 +1150,26 @@ class Integer inherits Number {
 	method times(action) { 
 		(1..self).forEach(action) 
 	}
+	
+	/**
+	 * Rounds up self up to a certain amount of decimals.
+	 * Amount of decimals must be positive
+	 * 1.223445.roundUp(3) ==> 1.224
+	 * -1.223445.roundUp(3) ==> -1.224
+	 * 14.6165.roundUp(3) ==> 14.617
+	 * 5.roundUp(3) ==> 5
+	 */
+	method roundUp(_decimals) = self
+	
+	/**
+	 * Truncates self up to a certain amount of decimals.
+	 * Amount of decimals must be positive
+	 * 1.223445.truncate(3) ==> 1.223
+	 * 14.6165.truncate(3) ==> 14.616
+	 * -14.6165.truncate(3) ==> -14.616
+	 * 5.truncate(3) ==> 5
+	 */
+	method truncate(_decimals) = self
 }
 
 /**

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -151,11 +151,11 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void gcdForDecimalsIsInvalid() {
 		try {
-		'''
-		program a {
-			(5.5).gcd(12)
-		}
-		'''.interpretPropagatingErrors 
+			'''
+			program a {
+				(5.5).gcd(12)
+			}
+			'''.interpretPropagatingErrors 
 			fail("decimals should not understand gcd message")
 		} catch (AssertionError e) {
 			assertTrue(e.message.startsWith("5.5 does not understand gcd(p0)"))
@@ -165,14 +165,14 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void gcdForDecimalsIsInvalid2() {
 		try {
-		'''
-		program a {
-			console.println((5).gcd(12.3))
-		}
-		'''.interpretPropagatingErrors
+			'''
+			program a {
+				console.println((5).gcd(12.3))
+			}
+			'''.interpretPropagatingErrors
 			fail("gcd works also for decimal argument!!")
 		} catch (AssertionError e) {
-		assertTrue(e.message.startsWith("gcd expects an integer as first argument"))
+			assertTrue(e.message.startsWith("gcd expects an integer as first argument"))
 		}
 	}
 
@@ -266,14 +266,29 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void integerRoundUp() {
 		'''
-		assert.equals(5, 10/2.roundUp())
+		assert.equals(5, (10/2).roundUp(2))
 		'''.test
 	}
 
 	@Test
 	def void integerTruncate() {
 		'''
-		assert.equals(5, 10/2.truncate())
+		assert.equals(5, (10/2).truncate(2))
 		'''.test
 	}
+	
+	@Test
+	def void doubleRoundUp() {
+		'''
+		assert.equals(1.3, (5/4).roundUp(1))
+		'''.test
+	}
+
+	@Test
+	def void doubleTruncate() {
+		'''
+		assert.equals(1.2, (5/4).truncate(1))
+		'''.test
+	}
+
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -262,5 +262,18 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 		assert.equals(25.0, 5.0 ** 2.0)
 		'''.test
 	}
+	
+	@Test
+	def void integerRoundUp() {
+		'''
+		assert.equals(5, 10/2.roundUp())
+		'''.test
+	}
 
+	@Test
+	def void integerTruncate() {
+		'''
+		assert.equals(5, 10/2.truncate())
+		'''.test
+	}
 }


### PR DESCRIPTION
Numbers should always understand these messages, and so they're added as abstract methods in Number.
Implementation for both messages on Integer class is added.