### PR TITLE
Fix random in range

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang/Range.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/Range.xtend
@@ -6,6 +6,7 @@ import org.uqbar.project.wollok.interpreter.core.WollokObject
 import static org.uqbar.project.wollok.sdk.WollokDSK.*
 
 import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions.*
+import static extension org.uqbar.project.wollok.utils.XtendExtensions.*
 
 /**
  * 
@@ -46,7 +47,6 @@ class Range extends AbstractJavaWrapper<IntegerRange> {
 	
 	def anyOne() {
 		val wrapped = initWrapped()
-		((Math.random * (wrapped.end - wrapped.start)) + wrapped.start).intValue()
+		wrapped.toList.random
 	}
-	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RangeTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RangeTestCase.xtend
@@ -128,6 +128,22 @@ class RangeTestCase extends AbstractWollokInterpreterTestCase {
 	}
 
 	@Test
+	def void anyOneProbability() {
+		'''
+		const range = 0 .. 10
+		range.step(2)
+		const counter = new Dictionary()
+		range.forEach({n => counter.put(n,0)})
+		5000.times({
+			var n = range.anyOne()
+			var c = counter.get(n) + 1
+			counter.put(n,c)
+		})
+		range.forEach({n => assert.that(counter.get(n) > 500)})
+		'''.test	
+	}
+
+	@Test
 	def void min() {
 		'''
 		const range = -2 .. 10

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/AbstractWollokQuickFixTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/AbstractWollokQuickFixTestCase.xtend
@@ -20,7 +20,7 @@ import org.uqbar.project.wollok.wollokDsl.WFile
 import static org.mockito.Matchers.*
 import static org.mockito.Mockito.*
 
-class AbstractWollokQuickFixTestCase extends AbstractWollokInterpreterTestCase {
+abstract class AbstractWollokQuickFixTestCase extends AbstractWollokInterpreterTestCase {
 	
 	WollokDslQuickfixProvider issueResolutionProvider
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/XtendExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/XtendExtensions.xtend
@@ -1,5 +1,8 @@
 package org.uqbar.project.wollok.utils
 
+import java.util.List
+import java.util.Random
+
 /**
  * Our extensions to basic Java/XTend classes
  */
@@ -8,4 +11,12 @@ class XtendExtensions {
 	 * Divides a string into lines
 	 */
 	static def lines(CharSequence input) { input.toString.split("[" + System.lineSeparator() + "]+") }
+	
+	/**
+	 * Returns an random element  
+	 */
+	static def random(List<Integer> it) {
+		val index = new Random().nextInt(size)
+		get(index)
+	}
 }


### PR DESCRIPTION
The native implementation was wrong calculating the range size.

At first, I thought that changing it for:
```
((Math.random * wrapped.size) + wrapped.start).intValue()
```

should be good. But it **fails** when step != 1.

So I create a _XtendExtension_ for lists that returns an element al random (with equal probability).

Close  #1003