### PR TITLE
Common division algorithm for integers and decimals #1016

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WDouble.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WDouble.xtend
@@ -39,8 +39,12 @@ class WDouble extends WNumber<BigDecimal> implements Comparable<WDouble> {
 
 	@NativeMessage("/")
 	def divide(WollokObject other) { operate(other) [ doDivide(it) ] }
-		def dispatch Number doDivide(Integer w) { wrapped / new BigDecimal(w) }
-		def dispatch Number doDivide(BigDecimal w) { wrapped / w }
+		def dispatch Number doDivide(Integer w) { 
+			this.div(wrapped, new BigDecimal(w))
+		}
+		def dispatch Number doDivide(BigDecimal w) { 
+			this.div(wrapped, w)
+		}
 		def dispatch Number doDivide(Object w) { throw new WollokRuntimeException("Cannot divide " + w) }
 
 	@NativeMessage("**")

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WInteger.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WInteger.xtend
@@ -41,14 +41,11 @@ class WInteger extends WNumber<Integer> implements Comparable<WInteger> {
 	@NativeMessage("/")
 	def divide(WollokObject other) { operate(other) [ doDivide(it) ] }
 		def dispatch Number doDivide(Integer w) {
-			val result = new BigDecimal(wrapped).divide(new BigDecimal(w), 34, RoundingMode.HALF_UP)
-			val resultIntValue = result.intValue
-			if (result == resultIntValue) {
-				return resultIntValue
-			}
-			return result
+			this.div(new BigDecimal(wrapped), new BigDecimal(w))
 		}
-		def dispatch Number doDivide(BigDecimal w) { new BigDecimal(wrapped) / w }
+		def dispatch Number doDivide(BigDecimal w) { 
+			this.div(new BigDecimal(wrapped), w)
+		}
 		def dispatch Number doDivide(Object w) { throw new WollokRuntimeException("Cannot divide " + w) }
 		
 	@NativeMessage("**")

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WNumber.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WNumber.xtend
@@ -1,6 +1,7 @@
 package wollok.lang
 
 import java.math.BigDecimal
+import java.math.RoundingMode
 import org.uqbar.project.wollok.interpreter.WollokInterpreter
 import org.uqbar.project.wollok.interpreter.WollokInterpreterEvaluator
 import org.uqbar.project.wollok.interpreter.WollokRuntimeException
@@ -35,6 +36,15 @@ abstract class WNumber<T extends Number> extends AbstractJavaWrapper<T> {
 	def div(WollokObject other) {
 		val n = other.nativeNumber
 		Math.floor(this.doubleValue / n.doubleValue).intValue
+	}
+	
+	def div(BigDecimal divisor, BigDecimal dividend) {
+		val result = divisor.setScale(5).divide(dividend, RoundingMode.HALF_UP)
+		val resultIntValue = result.intValue
+		if (result == resultIntValue) {
+			return resultIntValue
+		}
+		return result
 	}
 
 	// ********************************************************************************************

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -58,6 +58,16 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	}
 
 	@Test
+	def void divisionByZero() {
+		'''
+		assert.throwsExceptionWithMessage("/ by zero", { 1 / 0 })
+		assert.throwsExceptionWithMessage("/ by zero", { 1.0 / 0 })
+		assert.throwsExceptionWithMessage("/ by zero", { 1.0 / 0.0 })
+		assert.throwsExceptionWithMessage("/ by zero", { 1 / 0.0 })
+		'''.test
+	}
+
+	@Test
 	def void dividePeriodicDecimals() {
 		'''
 		assert.equals(0.72727, 40 / 55)

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -19,8 +19,21 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	
 	@Test
 	def void sum() {
-		'''3 + 1
+		'''
 		assert.equals(4, 3 + 1)
+		assert.equals(4.0, 3.0 + 1)
+		assert.equals(4.0, 3.0 + 1.0)
+		assert.equals(4.0, 3 + 1.0)
+		'''.test
+	}
+
+	@Test
+	def void multiply() {
+		'''
+		assert.equals(8, 4 * 2)
+		assert.equals(8.0, 4 * 2.0)
+		assert.equals(8.0, 4.0 * 2.0)
+		assert.equals(8.0, 4.0 * 2)
 		'''.test
 	}
 
@@ -35,12 +48,24 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	}
 
 	@Test
+	def void divideZero() {
+		'''
+		assert.equals(0, 0 / 10)
+		assert.equals(0, 0 / 10.0)
+		assert.equals(0, 0.0 / 10.0)
+		assert.equals(0, 0 / 10.0)
+		'''.test
+	}
+
+	@Test
 	def void dividePeriodicDecimals() {
 		'''
-		assert.equals(0.7272727272727272727272727272727273, 40 / 55)
-		assert.equals(0.7272727272727272727272727272727273, 40 / 55.0)
-		assert.equals(0.7272727272727272727272727272727273, 40.0 / 55.0)
-		assert.equals(0.7272727272727272727272727272727273, 40.0 / 55)
+		assert.equals(0.72727, 40 / 55)
+		assert.equals(0.72727, 40 / 55.0)
+		assert.equals(0.72727, 40.0 / 55.0)
+		assert.equals(0.72727, 40.0 / 55)
+		assert.equals(0.33333, 1 / 3)
+		assert.equals(0.66667, 2 / 3)
 		'''.test
 	}
 


### PR DESCRIPTION
I changed Wollok default to 5 decimals for division. If you want you can use a constant.
Unified division algorithm in WNumber (see div(BigDecimal, BigDecimal) method).