### PR TITLE
Fixes #1019 check for method call on self was not working with inheri…

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/mixins/MixinsTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/mixins/MixinsTestCase.xtend
@@ -378,6 +378,33 @@ class MixinsTestCase extends AbstractWollokInterpreterTestCase {
 		'''.interpretPropagatingErrors
 	}
 	
+	@Test
+	def void classMixedCallsInheritedMethodFromMixinWithSelf() {
+		'''
+		mixin Flies {
+			var times = 0
+			method fly() {
+				times += 1
+			}
+			method times() = times
+		}
+		
+		class Bird mixed with Flies {
+			method doubleFly() {
+				self.fly()
+				self.fly()
+			}
+		}
+		
+		program t {
+			const pepita = new Bird()
+			pepita.doubleFly()
+			assert.equals(2, pepita.times())
+		} 
+		'''.interpretPropagatingErrors
+	}
+	
+	
 	// OBJECT LITERALS
 	
 	@Test

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -131,17 +131,7 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 	def static dispatch Iterable<WMethodDeclaration> allMethods(WNamedObject it) { inheritedMethods }
 	def static dispatch Iterable<WMethodDeclaration> allMethods(WObjectLiteral it) { inheritedMethods }
 	def static dispatch Iterable<WMethodDeclaration> allMethods(MixedMethodContainer it) { inheritedMethods }
-	def static dispatch Iterable<WMethodDeclaration> allMethods(WClass c) {
-		val methods = newArrayList
-		// TODO: should we replace this with the "linearization()" method call ?
-		c.superClassesIncludingYourselfTopDownDo[cl |
-			// remove overriden
-			cl.overrideMethods.forEach[methods.remove(it.overridenMethod)]
-			// add all
-			methods.addAll(cl.methods)
-		]
-		methods
-	}
+	def static dispatch Iterable<WMethodDeclaration> allMethods(WClass it) { inheritedMethods }
 
 	def static getInheritedMethods(WMethodContainer it) {
 		linearizateHierarhcy.fold(newArrayList) [methods, type |


### PR DESCRIPTION
…ted methods from mixins. Wrongly reporting error

A base method to get all methods of an object was not using the linearized hierarchy for WClass but a custom impl going up only over the class hierarchy without considering mixins.

Now fixed.
