### PR TITLE
Fix #904 - Decimal numbers operations

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WDouble.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WDouble.xtend
@@ -20,21 +20,33 @@ class WDouble extends WNumber<BigDecimal> implements Comparable<WDouble> {
 
 	@NativeMessage("+")
 	def plus(WollokObject other) { operate(other) [ doPlus(it) ] }
-		def dispatch Number doPlus(Integer w) { wrapped + new BigDecimal(w) }
-		def dispatch Number doPlus(BigDecimal w) { wrapped + w }
+		def dispatch Number doPlus(Integer w) { 
+			this.add(wrapped, new BigDecimal(w))
+		}
+		def dispatch Number doPlus(BigDecimal w) {
+			this.add(wrapped, w) 
+		}
 		//TODO: here it should throw a 100% wollok exception class
 		def dispatch Number doPlus(Object w) { throw new WollokRuntimeException("Cannot add " + w) }
 
 	@NativeMessage("-")
 	def minus(WollokObject other) { operate(other) [ doMinus(it) ] }
-		def dispatch Number doMinus(Integer w) { wrapped - new BigDecimal(w) }
-		def dispatch Number doMinus(BigDecimal w) { wrapped - w }
+		def dispatch Number doMinus(Integer w) { 
+			this.subtract(wrapped, new BigDecimal(w))
+		}
+		def dispatch Number doMinus(BigDecimal w) {
+			this.subtract(wrapped, w) 
+		}
 		def dispatch Number doMinus(Object w) { throw new WollokRuntimeException("Cannot substract " + w) }
 
 	@NativeMessage("*")
 	def multiply(WollokObject other) { operate(other) [ doMultiply(it) ] }
-		def dispatch Number doMultiply(Integer w) { wrapped * new BigDecimal(w) }
-		def dispatch Number doMultiply(BigDecimal w) { wrapped * w }
+		def dispatch Number doMultiply(Integer w) {
+			this.mul(wrapped, new BigDecimal(w)) 
+		}
+		def dispatch Number doMultiply(BigDecimal w) {
+			this.mul(wrapped, w) 
+		}
 		def dispatch Number doMultiply(Object w) { throw new WollokRuntimeException("Cannot multiply " + w) }
 
 	@NativeMessage("/")
@@ -55,8 +67,12 @@ class WDouble extends WNumber<BigDecimal> implements Comparable<WDouble> {
 	
 	@NativeMessage("%")
 	def module(WollokObject other) { operate(other) [ doModule(it) ] }
-		def dispatch Number doModule(Integer w) { wrapped.remainder(new BigDecimal(w)) }
-		def dispatch Number doModule(BigDecimal w) { wrapped.remainder(w) }
+		def dispatch Number doModule(Integer w) {
+			this.remainder(wrapped, new BigDecimal(w)) 
+		}
+		def dispatch Number doModule(BigDecimal w) {
+			this.remainder(wrapped, w) 
+		}
 		def dispatch Number doModule(Object w) { throw new WollokRuntimeException("Cannot module " + w) }
 
 	@NativeMessage(">")

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WNumber.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WNumber.xtend
@@ -17,6 +17,8 @@ import org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions
  */
 abstract class WNumber<T extends Number> extends AbstractJavaWrapper<T> {
 
+	public static int DECIMAL_PRECISION = 5
+	
 	new(WollokObject obj, WollokInterpreter interpreter) {
 		super(obj, interpreter)
 	}	
@@ -37,9 +39,28 @@ abstract class WNumber<T extends Number> extends AbstractJavaWrapper<T> {
 		val n = other.nativeNumber
 		Math.floor(this.doubleValue / n.doubleValue).intValue
 	}
+
+	def add(BigDecimal sumand1, BigDecimal sumand2) {
+		checkResult(sumand1.setScale(DECIMAL_PRECISION).add(sumand2))
+	}
 	
+	def subtract(BigDecimal minuend, BigDecimal sustraend) {
+		checkResult(minuend.setScale(DECIMAL_PRECISION).subtract(sustraend))
+	}
+	
+	def mul(BigDecimal mul1, BigDecimal mul2) {
+		checkResult(mul1.setScale(DECIMAL_PRECISION).multiply(mul2))
+	}
+
 	def div(BigDecimal divisor, BigDecimal dividend) {
-		val result = divisor.setScale(5).divide(dividend, RoundingMode.HALF_UP)
+		checkResult(divisor.setScale(DECIMAL_PRECISION).divide(dividend, RoundingMode.HALF_UP))
+	}
+
+	def remainder(BigDecimal divisor, BigDecimal dividend) {
+		checkResult(divisor.setScale(DECIMAL_PRECISION).remainder(dividend))
+	}
+	
+	def checkResult(BigDecimal result) {
 		val resultIntValue = result.intValue
 		if (result == resultIntValue) {
 			return resultIntValue

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WNumber.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WNumber.xtend
@@ -41,31 +41,42 @@ abstract class WNumber<T extends Number> extends AbstractJavaWrapper<T> {
 	}
 
 	def add(BigDecimal sumand1, BigDecimal sumand2) {
-		checkResult(sumand1.setScale(DECIMAL_PRECISION).add(sumand2))
+		adapt(sumand1).add(sumand2).checkResult
 	}
 	
 	def subtract(BigDecimal minuend, BigDecimal sustraend) {
-		checkResult(minuend.setScale(DECIMAL_PRECISION).subtract(sustraend))
+		adapt(minuend).subtract(sustraend).checkResult
 	}
 	
 	def mul(BigDecimal mul1, BigDecimal mul2) {
-		checkResult(mul1.setScale(DECIMAL_PRECISION).multiply(mul2))
+		adapt(mul1).multiply(mul2).checkResult
 	}
 
-	def div(BigDecimal divisor, BigDecimal dividend) {
-		checkResult(divisor.setScale(DECIMAL_PRECISION).divide(dividend, RoundingMode.HALF_UP))
+	def div(BigDecimal dividend, BigDecimal divisor) {
+		adapt(dividend).divide(divisor, RoundingMode.HALF_UP).checkResult
 	}
 
-	def remainder(BigDecimal divisor, BigDecimal dividend) {
-		checkResult(divisor.setScale(DECIMAL_PRECISION).remainder(dividend))
+	def remainder(BigDecimal dividend, BigDecimal divisor) {
+		adapt(dividend).remainder(divisor).checkResult
 	}
-	
-	def checkResult(BigDecimal result) {
+
+	/** *******************************************************************
+	 * 
+	 * INTERNAL METHODS
+	 * 
+	 * *******************************************************************
+	 */
+	private def adapt(BigDecimal operand) {
+		operand.setScale(DECIMAL_PRECISION, BigDecimal.ROUND_HALF_UP)
+	}
+
+	private def checkResult(BigDecimal result) {
+		val resultRounded = adapt(result)
 		val resultIntValue = result.intValue
 		if (result == resultIntValue) {
 			return resultIntValue
 		}
-		return result
+		return resultRounded
 	}
 
 	// ********************************************************************************************

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -18,7 +18,7 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	}
 	
 	@Test
-	def void sum() {
+	def void add() {
 		'''
 		assert.equals(4, 3 + 1)
 		assert.equals(4.0, 3.0 + 1)
@@ -32,6 +32,26 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	}
 
 	@Test
+	def void addSeveralDecimals() {
+		'''
+		assert.equals(4.00001, 3.000004 + 1.000006)
+		assert.equals(4.00001, 3.000002 + 1.000006)
+		assert.equals(4, 3.000002 + 1.000002)
+		'''.test
+	}
+
+	@Test
+	def void subtractSeveralDecimals() {
+		'''
+		assert.equals(-0.00001, 4.000004 - 4.000006)
+		assert.equals(0, 4.000007 - 4.000006)
+		assert.equals(2, 3.000002 - 1.000001)
+		assert.equals(1.99999, 3.000002 - 1.000006)
+		assert.equals(1.99978, 3.000002 - 1.000222)
+		'''.test
+	}
+
+	@Test
 	def void multiply() {
 		'''
 		assert.equals(8, 4 * 2)
@@ -41,6 +61,16 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 		'''.test
 	}
 	
+	@Test
+	def void multiplySeveralDecimals() {
+		'''
+		assert.equals(8, 4.00000000001 * 2.000000000003)
+		assert.equals(0, 4.00222222222222000000001 * 0)
+		assert.equals(4.00270, 4.00222222222222000000001 * 1.00012)
+		assert.equals(4.00415, 4.00222522222222000000001 * 1.00048)
+		'''.test
+	}
+
 	@Test
 	def void multiplyByZero() {
 		'''
@@ -69,6 +99,15 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 		assert.equals(0, 0 / 10.0)
 		assert.equals(0, 0.0 / 10.0)
 		assert.equals(0, 0 / 10.0)
+		'''.test
+	}
+
+	@Test
+	def void divideSeveralDecimals() {
+		'''
+		assert.equals(0.51235, 5.123456 / 10.00000011)
+		assert.equals(0.51235, 5.123456 / 10)
+		assert.equals(0.51235, 5123456 / 10000000)		
 		'''.test
 	}
 
@@ -182,6 +221,7 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 		const remainder2 = 12.rem(6)
 		assert.equals(3, remainder)
 		assert.equals(0, remainder2)
+		assert.equals(0.11521, 1.1152112.rem(1.0000002))
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -425,4 +425,28 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 		'''.test
 	}
 
+	@Test
+	def void veryBigIntegerAdd() {
+		'''
+		var a = 100000000000000000
+		assert.equals(100000000000000001, a + 1)
+		'''.test
+	}
+
+	@Test
+	def void veryBigIntegerMultiply() {
+		'''
+		var a = 100000000000000000
+		assert.equals(100000000000000000, a * 1)
+		'''.test
+	}
+
+	@Test
+	def void veryBigIntegerDivide() {
+		'''
+		var a = 100000000000000000
+		assert.equals(100000, a / 1000000000000)
+		'''.test
+	}
+
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -99,6 +99,8 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 		assert.equals(0, 0 / 10.0)
 		assert.equals(0, 0.0 / 10.0)
 		assert.equals(0, 0 / 10.0)
+		assert.equals(0, 0 / 100.0)
+		assert.equals(0, 1 / 100000000000.0)
 		'''.test
 	}
 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -24,6 +24,10 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 		assert.equals(4.0, 3.0 + 1)
 		assert.equals(4.0, 3.0 + 1.0)
 		assert.equals(4.0, 3 + 1.0)
+		assert.equals(4, 4 + 0.0)
+		assert.equals(4, 4.0 + 0.0)
+		assert.equals(4, 4.0 + 0)
+		assert.equals(4, 4 + 0)
 		'''.test
 	}
 
@@ -34,6 +38,17 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 		assert.equals(8.0, 4 * 2.0)
 		assert.equals(8.0, 4.0 * 2.0)
 		assert.equals(8.0, 4.0 * 2)
+		'''.test
+	}
+	
+	@Test
+	def void multiplyByZero() {
+		'''
+		assert.equals(6.2500000 * 0.5 * 0, 0)
+		assert.equals(6.2500000 * 0, 0)
+		assert.equals(0.0 * 0, 0)
+		assert.equals(0.0 * 0.0, 0)
+		assert.equals(0 * 0.0, 0)
 		'''.test
 	}
 
@@ -123,6 +138,11 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	def void absoluteValueOfAPositiveInteger() {
 		'''
 		assert.equals(3, 3.abs())
+		assert.equals(0, 0.abs())
+		assert.equals(0, 0.0.abs())
+		assert.equals(60, (-60.0).abs())
+		assert.equals(60.664, (-60.664).abs())
+		assert.equals(60.664, (60.664).abs())
 		'''.test
 	}
 
@@ -295,6 +315,10 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 		assert.equals(0.2, 5 ** (-1.0))
 		assert.equals(0.2, 5.0 ** (-1.0))
 		assert.equals(0.2, 5.0 ** (-1))
+		assert.equals(1, 5.0 ** 0)
+		assert.equals(1, 5.0 ** 0.0)
+		assert.equals(1, 5 ** 0)
+		assert.equals(1, 5 ** 0.0)
 		'''.test
 	}
 	
@@ -333,6 +357,29 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	def void doubleTruncate() {
 		'''
 		assert.equals(1.2, (5/4).truncate(1))
+		'''.test
+	}
+
+	@Test
+	def void modulus() {
+		'''
+		assert.equals(1, 5 % 4)
+		assert.equals(1.5, 5.5 % 4)
+		assert.equals(0, 4 % 4)
+		assert.equals(0, 4.0 % 4)
+		assert.equals(0, 4.0 % 1)
+		'''.test
+	}
+
+	@Test
+	def void numberComparison() {
+		'''
+		assert.that((1.1 / 1) > (1.000002))
+		assert.that(1 < 1.0001)
+		assert.notThat(1 < 1)
+		assert.notThat(1 > 1)
+		assert.that(1 <= 1)
+		assert.that(1 >= 1)
 		'''.test
 	}
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -3,6 +3,7 @@ package org.uqbar.project.wollok.interpreter
 import com.google.inject.Inject
 import java.lang.ref.WeakReference
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.util.List
 import java.util.Map
 import org.eclipse.emf.common.util.EList

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -218,7 +218,12 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 		if (value.contains('.'))
 			doInstantiateNumber(DOUBLE, new BigDecimal(value))
 		else {
-			doInstantiateNumber(INTEGER, Integer.valueOf(value))
+			try {
+				doInstantiateNumber(INTEGER, Integer.valueOf(value))
+			} catch (NumberFormatException e) {
+				// If value is too long, use a decimal
+				doInstantiateNumber(DOUBLE, new BigDecimal(value))
+			}
 		}
 	}
 


### PR DESCRIPTION
Original issue #904 
- Using a common definition in WNumber for decimal operations: add. subtract, multiply, divide, remainder
- Created several test cases for decimal numbers.
