### PR TITLE
Running the REPL alone - Adding a workaround creating a hidden project

### DIFF
--- a/org.uqbar.project.wollok.ui.launch/plugin.xml
+++ b/org.uqbar.project.wollok.ui.launch/plugin.xml
@@ -199,7 +199,7 @@
       </command>
       <command
             categoryId="org.eclipse.debug.ui.category.run"
-            defaultHandler="org.uqbar.project.wollok.ui.launch.handlers.LaunchReplWithoutFileHandler"
+            defaultHandler="org.uqbar.project.wollok.ui.launch.WollokDslExecutableExtensionFactory:org.uqbar.project.wollok.ui.launch.handlers.LaunchReplWithoutFileHandler"
             description="%wollok.launch.replWithoutFile.desc"
             id="org.uqbar.project.wollok.ui.launch.launchReplWithoutFile"
             name="%wollok.launch.replWithoutFile">

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/handlers/LaunchReplWithoutFileHandler.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/handlers/LaunchReplWithoutFileHandler.xtend
@@ -1,26 +1,44 @@
 package org.uqbar.project.wollok.ui.launch.handlers
 
+import com.google.inject.Inject
 import org.eclipse.core.commands.AbstractHandler
-
 import org.eclipse.core.commands.ExecutionEvent
 import org.eclipse.core.commands.ExecutionException
+import org.eclipse.core.resources.IProject
 import org.eclipse.core.runtime.CoreException
 import org.eclipse.core.runtime.Platform
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
-import org.eclipse.debug.internal.ui.DebugUIPlugin
 import org.eclipse.debug.ui.DebugUITools
 import org.eclipse.debug.ui.RefreshTab
 import org.uqbar.project.wollok.launch.WollokLauncher
-import org.uqbar.project.wollok.ui.Messages
+import org.uqbar.project.wollok.ui.wizard.WollokDslProjectInfo
+import org.uqbar.project.wollok.ui.wizard.WollokProjectCreator
 
 import static org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants.*
 import static org.uqbar.project.wollok.ui.launch.WollokLaunchConstants.*
-import static org.uqbar.project.wollok.ui.launch.WollokLaunchConstants.*
+import static org.uqbar.project.wollok.utils.WEclipseUtils.*
 
 import static extension org.uqbar.project.wollok.ui.launch.shortcut.WDebugExtensions.*
-import static extension org.uqbar.project.wollok.utils.WEclipseUtils.*
+
+/**
+ * This launcher is used to launch the REPL without an open project.
+ * What is actually doing is creating an empty project if there is no open, but it is hidden by the project view.
+ * 
+ * @author tesonep
+ * 
+ * @TODO: Check if there is a way of launching it calculating the complete classpath. 
+ * This is not so easy as the classpath should include all the bundles used by the wollok launcher plugin and lib. 
+ * So, the classpath should include all the plugins of XText and eclipse that we are using.
+ * Calculating that path and launching the application is as heavy as creating the empty project. With the difference that the creation
+ * of the empty project is only made once per workspace.
+ * 
+ */
 
 class LaunchReplWithoutFileHandler extends AbstractHandler {
+	@Inject WollokProjectCreator projectCreator
+
+	public val String EMPTY_PROJECT_NAME = "__EMPTY__"
+
 	override execute(ExecutionEvent event) throws ExecutionException {
 		DebugUITools.launch(createConfiguration, "run");
 		null
@@ -35,13 +53,15 @@ class LaunchReplWithoutFileHandler extends AbstractHandler {
 
 	def configureConfiguration(ILaunchConfigurationWorkingCopy it) {
 		val projects = openProjects
-		if(projects.empty){  // TODO: If there is no open project, create one
-			val x = new RuntimeException(Messages.LaunchReplWithoutFileHandler_notHavingWollokProject)
-			DebugUIPlugin.errorDialog(DebugUIPlugin.shell, Messages.LaunchReplWithoutFileHandler_notHavingWollokProject, Messages.LaunchReplWithoutFileHandler_notHavingWollokProject, x) //
-			throw x
+		var IProject projectToUse
+
+		if (projects.empty) {
+			projectToUse = getOrCreateEmptyProject()
+		} else {
+			projectToUse = projects.get(0)
 		}
-		
-		setAttribute(ATTR_PROJECT_NAME, projects.get(0).name)
+
+		setAttribute(ATTR_PROJECT_NAME, projectToUse.name)
 		setAttribute(ATTR_MAIN_TYPE_NAME, WollokLauncher.name)
 		setAttribute(ATTR_STOP_IN_MAIN, false)
 		setAttribute(ATTR_USE_START_ON_FIRST_THREAD, false) // fixes wollok-game in osx
@@ -53,4 +73,18 @@ class LaunchReplWithoutFileHandler extends AbstractHandler {
 		setAttribute(RefreshTab.ATTR_REFRESH_RECURSIVE, true)
 	}
 
+	def getOrCreateEmptyProject() {
+		val emptyProject = getProject(EMPTY_PROJECT_NAME)
+
+		if (emptyProject != null) {
+			emptyProject.open(null)
+			return emptyProject
+		}
+
+		projectCreator.projectInfo = new WollokDslProjectInfo() => [
+			projectName = EMPTY_PROJECT_NAME
+		]
+		projectCreator.run(null)
+		return getProject(EMPTY_PROJECT_NAME)
+	}
 }

--- a/org.uqbar.project.wollok.ui/META-INF/MANIFEST.MF
+++ b/org.uqbar.project.wollok.ui/META-INF/MANIFEST.MF
@@ -40,10 +40,11 @@ Export-Package: org.uqbar.project.wollok.refactoring,
  org.uqbar.project.wollok.ui,
  org.uqbar.project.wollok.ui.contentassist,
  org.uqbar.project.wollok.ui.contentassist.antlr,
+ org.uqbar.project.wollok.ui.contentassist.antlr.internal,
  org.uqbar.project.wollok.ui.editor,
  org.uqbar.project.wollok.ui.internal,
  org.uqbar.project.wollok.ui.labeling,
  org.uqbar.project.wollok.ui.preferences,
  org.uqbar.project.wollok.ui.quickfix,
- org.uqbar.project.wollok.ui.contentassist.antlr.internal
+ org.uqbar.project.wollok.ui.wizard
 Bundle-Activator: org.uqbar.project.wollok.ui.WollokActivator

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/view/WollokViewerFilter.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/view/WollokViewerFilter.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.internal.ui.packageview.ClassPathContainer;
 import org.eclipse.jdt.internal.ui.packageview.LibraryContainer;
 import org.eclipse.jface.viewers.Viewer;
@@ -16,12 +18,16 @@ import org.eclipse.jface.viewers.ViewerFilter;
  * - Classpath Elements
  * - properties files and OSGI related.
  * 
+ * It is also hiding the empty project, needed to run the REPL without open project.
+ * 
  * @author jfernandes
+ * @author tesonep
  */
 public class WollokViewerFilter extends ViewerFilter {
 	private List<String> hiddenFiles = Arrays.asList("build.properties", "log4j.properties", "WOLLOK.ROOT");
 	private List<String> hiddenFolders = Arrays.asList("META-INF", "OSGI-INF");
-	private List<Class> hiddenClasses = Arrays.<Class>asList(LibraryContainer.class, ClassPathContainer.class);
+	private List<String> hiddenProjects = Arrays.asList("__EMPTY__");
+	private List<Class<?>> hiddenClasses = Arrays.<Class<?>>asList(LibraryContainer.class, ClassPathContainer.class);
 	
 	@Override
 	public boolean select(Viewer viewer, Object parentElement, Object element) {
@@ -29,6 +35,11 @@ public class WollokViewerFilter extends ViewerFilter {
 			return !hiddenFiles.contains(((IFile) element).getName());
 		if (element instanceof IFolder)
 			return !hiddenFolders.contains(((IFolder) element).getName());
+		if (element instanceof IProject)
+			return !hiddenProjects.contains(((IProject) element).getName());
+		if (element instanceof IJavaProject)
+			return !hiddenProjects.contains(((IJavaProject) element).getElementName());
+
 		
 		return !hiddenClasses.contains(element.getClass());
 	}


### PR DESCRIPTION
It fixes the issue #739.

I have created a workaround for this.
Basically I am creating (or reusing) an empty project, this project is hidden in the view.
I have chosen this approach because to run as a external tool, the whole classpath for the bundle should be calculated (it need the launcher, the lib, and all the xtext / eclipse dependencies). This is calculated in the build to generate the scripts to run from the console but they are not persisted. Even accesing to this classpath, it should be transformed to get the JARs from the plugins directory.

Maybe a better implementation can recalculate this classpath and store them for usage.

Please @fdodino, check if this is good enough.