### PR TITLE
Adding quickfixes for 'getter should return value'

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/GetterShouldReturnValueQuickFixTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/GetterShouldReturnValueQuickFixTest.xtend
@@ -1,0 +1,132 @@
+package org.uqbar.project.wollok.tests.quickfix
+
+import org.junit.Test
+import org.uqbar.project.wollok.ui.Messages
+
+class GetterShouldReturnValueQuickFixTest extends AbstractWollokQuickFixTestCase {
+	@Test
+	def testGetterWithoutBodyAndExistentVariable(){
+		val initial = #['''
+			class MyClass{
+				var x = 23
+				method getX(){
+				}
+				
+				method setX(obj){
+					x = obj
+				}
+			}
+		''']
+
+		val result = #['''
+			class MyClass{
+				var x = 23
+				method getX(){
+					return x
+				}
+				
+				method setX(obj){
+					x = obj
+				}
+			}
+		''']
+		assertQuickfix(initial, result, Messages.WollokDslQuickfixProvider_return_variable_name)
+	}
+	
+	
+	@Test
+	def testGetterWithBodyAndExistentVariable(){
+		val initial = #['''
+			class MyClass{
+				var x = 23
+				var y = 0
+				method getX(){
+					y = y + 1
+				}
+				
+				method setX(obj){
+					x = obj
+				}
+			}
+		''']
+
+		val result = #['''
+			class MyClass{
+				var x = 23
+				var y = 0
+				method getX(){
+					y = y + 1
+					return x
+				}
+				
+				method setX(obj){
+					x = obj
+				}
+			}
+		''']
+		assertQuickfix(initial, result, Messages.WollokDslQuickfixProvider_return_variable_name)
+	}
+
+	@Test
+	def testGetterMissingReturn(){
+		val initial = #['''
+			class MyClass{
+				var y = 0
+				method getX(){
+					y + 1
+				}
+				
+				method setY(obj){
+					y = obj
+				}
+			}
+		''']
+
+		val result = #['''
+			class MyClass{
+				var y = 0
+				method getX(){
+					return 
+					y + 1
+				}
+				
+				method setY(obj){
+					y = obj
+				}
+			}
+		''']
+		assertQuickfix(initial, result, Messages.WollokDslQuickfixProvider_return_last_expression_name)
+	}
+
+	@Test
+	def testGetterMissingReturnWithCall(){
+		val initial = #['''
+			class MyClass{
+				method getX(){
+					self.doSomething()
+					self.doSomething()
+				}
+				
+				method doSomething(){
+					return 1
+				}
+			}
+		''']
+
+		val result = #['''
+			class MyClass{
+				method getX(){
+					self.doSomething()
+					return 
+					self.doSomething()
+				}
+				
+				method doSomething(){
+					return 1
+				}
+			}
+		''']
+		assertQuickfix(initial, result, Messages.WollokDslQuickfixProvider_return_last_expression_name)
+	}
+
+}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/QuickFixTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/QuickFixTest.xtend
@@ -27,6 +27,31 @@ class QuickFixTest extends AbstractWollokQuickFixTestCase {
 	}
 	
 	@Test
+	def testMethodWithExpressionNotReturning(){
+		val initial = #['''
+			class MyClass{
+				var y = 0
+				method getX(){
+					y + 1
+				}
+			}
+		''']
+
+		val result = #['''
+			class MyClass{
+				var y = 0
+				method getX(){
+					return 
+					y + 1
+				}
+			}
+		''']
+		assertQuickfix(initial, result, Messages.WollokDslQuickfixProvider_return_last_expression_name)
+	}
+	
+	
+	
+	@Test
 	def addOverrideToMethod(){
 		val initial = #['''
 			class MyClass{

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/Messages.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/Messages.java
@@ -82,7 +82,11 @@ public class Messages extends NLS {
 	public static String WollokDslQuickfixProvider_changeToVar_description;
 	public static String WollokDslQuickfixProvider_createMethod_name;
 	public static String WollokDslQuickfixProvider_createMethod_description;
-	public static String WollokDslQuickfixProvider_createMethod_stub;
+	public static String WollokDslQuickfixProvider_createMethod_stub;	
+	public static String WollokDslQuickfixProvider_return_variable_name;
+	public static String WollokDslQuickfixProvider_return_variable_description;
+	public static String WollokDslQuickfixProvider_return_last_expression_name;
+	public static String WollokDslQuickfixProvider_return_last_expression_description;
 	
 	public static String WollokRootPreferencePage_autoformat_description;
 	public static String WollokRootPreferencePage_debuggerWaitTimeForConnect;

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages.properties
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages.properties
@@ -75,6 +75,11 @@ WollokDslNewProjectWizard_windowTitle = New Wollok Project
 WollokDslQuickfixProvider_capitalize_name = Capitalize name
 WollokDslQuickfixProvider_capitalize_description = Capitalize the name
 
+WollokDslQuickfixProvider_return_variable_name = Return the variable.
+WollokDslQuickfixProvider_return_variable_description = Adds a return statement using the instance variable following the pattern "getVar" where Var is the variable name.
+WollokDslQuickfixProvider_return_last_expression_name = Return last expression in method
+WollokDslQuickfixProvider_return_last_expression_description = Modifies the last expression, adding a return statement.
+
 WollokDslQuickfixProvider_changeToVar_name = Change to var
 WollokDslQuickfixProvider_changeToVar_description = Change declaration to var
 
@@ -128,7 +133,6 @@ WollokTemplateProposalProvider_WClosure_description = Add a closure literal
 	
 WollokTemplateProposalProvider_WTry_name = Try Catch block
 WollokTemplateProposalProvider_WTry_description = Add a try-catch block
-
 
 #
 # Refactoring

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages_es.properties
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages_es.properties
@@ -74,6 +74,12 @@ WollokDslNewProjectWizard_windowTitle = Nuevo Proyecto Wollok
 # Quick fixes
 #
 WollokDslQuickfixProvider_capitalize_description = Convertir el nombre a may\u00FAsculas
+
+WollokDslQuickfixProvider_return_variable_name = Retorna la variable.
+WollokDslQuickfixProvider_return_variable_description = Agrega un return al final del método con la variable a la que hace referencia el nombre del método.
+WollokDslQuickfixProvider_return_last_expression_name = Retorna la ultima expresión del método.
+WollokDslQuickfixProvider_return_last_expression_description = Modifica la última instrucción del metodo y le agrega un return.
+
 WollokDslQuickfixProvider_capitalize_name = Convertir a may\u00FAsculas
 WollokDslQuickfixProvider_changeToVar_description = Cambiar declaraci\u00F3n a "var"
 WollokDslQuickfixProvider_changeToVar_name = Cambiar a "var"

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -106,7 +106,7 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 	def static supposedToReturnValue(WMethodDeclaration it) { expressionReturns || eAllContents.exists[e | e.isReturnWithValue] }
 	def static hasSameSignatureThan(WMethodDeclaration it, WMethodDeclaration other) { matches(other.name, other.parameters) }
 
-	def static isGetter(WMethodDeclaration it) { name.length > 4 && name.startsWith("get") && Character.isUpperCase(name.charAt(3)) }
+	def static isGetter(WMethodDeclaration it) { name.length > 3 && name.startsWith("get") && Character.isUpperCase(name.charAt(3)) }
 
 	def dispatch static isReturnWithValue(EObject it) { false }
 	// REVIEW: this is a hack solution. We don't want to compute "return" statements that are

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -726,7 +726,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(WARN)
 	@CheckGroup(WollokCheckGroup.POTENTIAL_PROGRAMMING_PROBLEM)
 	def methodBodyProducesAValueButItIsNotBeingReturned(WMethodDeclaration it){
-		if (!native && !abstract && !supposedToReturnValue && expression.isEvaluatesToAValue(classFinder))
+		if (!native && !getter && !abstract && !supposedToReturnValue && expression.isEvaluatesToAValue(classFinder))
 			report(WollokDslValidator_RETURN_FORGOTTEN, it, WMETHOD_DECLARATION__EXPRESSION, RETURN_FORGOTTEN)
 	}
 	


### PR DESCRIPTION
Fixes #310 
Adding some quickfixes to solve the getter should return value. 
Reuse of the existent "Prepend return" and I18N of it.