### PR TITLE
Fix #279 cyclic hierarchy

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromCyclicHierarchy.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromCyclicHierarchy.wlk.xt
@@ -1,4 +1,8 @@
 /* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
 
 // XPECT errors --> "Infinite Cycle hierarchy" at "B"
-class B inherits B { }
+class A inherits B { }
+
+// XPECT errors --> "Infinite Cycle hierarchy" at "A"
+class B inherits A { }
+

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromCyclicHierarchy.wlk2.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromCyclicHierarchy.wlk2.xt
@@ -1,5 +1,0 @@
-/* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
-
-// XPECT errors --> "Infinite Cycle hierarchy" at "class B inherits B { }"
-class B inherits B { }
-

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromCyclicHierarchy.wlk2.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromCyclicHierarchy.wlk2.xt
@@ -1,0 +1,5 @@
+/* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
+
+// XPECT errors --> "Infinite Cycle hierarchy" at "class B inherits B { }"
+class B inherits B { }
+

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromCyclicHierarchyMultipleClasses.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromCyclicHierarchyMultipleClasses.wlk.xt
@@ -1,0 +1,13 @@
+/* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
+
+// XPECT errors --> "Infinite Cycle hierarchy" at "B"
+class A inherits B { }
+
+// XPECT errors --> "Infinite Cycle hierarchy" at "C"
+class B inherits C { }
+
+// XPECT errors --> "Infinite Cycle hierarchy" at "E"
+class C inherits E { }
+
+// XPECT errors --> "Infinite Cycle hierarchy" at "A"
+class E inherits A { }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromSameClass.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ClassInherintingFromSameClass.wlk.xt
@@ -1,0 +1,7 @@
+/* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
+
+// XPECT errors --> "Infinite Cycle hierarchy" at "class A inherits B { }"
+class A inherits B { }
+
+// XPECT errors --> "Infinite Cycle hierarchy" at "class B inherits A { }"
+class B inherits A { }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
@@ -34,6 +34,7 @@ public class Messages extends NLS {
 	public static String WollokDslValidator_GETTER_METHOD_SHOULD_RETURN_VALUE;
 	public static String WollokDslValidator_CANNOT_MODIFY_VAL;
 	public static String WollokDslValidator_CANNOT_ASSIGN_TO_ITSELF;
+	public static String WollokDslValidator_CYCLIC_HIERARCHY;
 	public static String WollokDslValidator_DUPLICATED_METHOD;
 	public static String WollokDslValidator_DUPLICATED_VARIABLE_IN_HIERARCHY;
 	public static String WollokDslValidator_DUPLICATED_NAME;

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokObject.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokObject.xtend
@@ -224,10 +224,10 @@ class WollokObject extends AbstractWollokCallable implements EvaluationContext<W
 	}
 	
 	def callSuper(WMethodContainer superFrom, String message, WollokObject[] parameters) {
-		val hierarchy = behavior.linearizateHierarhcy
-		val subhierarhcy = hierarchy.subList(hierarchy.indexOf(superFrom) + 1, hierarchy.size)
+		val hierarchy = behavior.linearizeHierarchy
+		val subhierarchy = hierarchy.subList(hierarchy.indexOf(superFrom) + 1, hierarchy.size)
 		
-		val method = subhierarhcy.fold(null) [method, t |
+		val method = subhierarchy.fold(null) [method, t |
 			if (method != null)
 				method
 			else 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
@@ -32,6 +32,7 @@ WollokDslValidator_CLASSES_IN_FILE = Classes and Objects should be defined in a 
 WollokDslValidator_CLASS_NAME_MUST_START_UPPERCASE = Class name must start with uppercase
 WollokDslValidator_DUPLICATED_CLASS_IN_PACKAGE = Duplicated class name in package
 WollokDslValidator_DUPLICATED_CLASS_IN_FILE = Duplicated class name in file
+WollokDslValidator_CYCLIC_HIERARCHY = Infinite Cycle hierarchy
 WollokDslValidator_DUPLICATED_METHOD = Duplicated method
 WollokDslValidator_DUPLICATED_NAME = Duplicated Name
 WollokDslValidator_DUPLICATED_PACKAGE = Duplicated package

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
@@ -33,7 +33,8 @@ WollokDslValidator_CLASSES_IN_FILE = Clases y objetos se deben definir en archiv
 WollokDslValidator_CLASS_NAME_MUST_START_UPPERCASE = El nombre de clase debe comenzar en may\u00FAscula
 
 WollokDslValidator_DUPLICATED_CLASS_IN_PACKAGE = Nombre de clase duplicado en package
-WollokDslValidator_DUPLICATED_CLASS_IN_FILE = Nombre de clase duplicado en archivo 
+WollokDslValidator_DUPLICATED_CLASS_IN_FILE = Nombre de clase duplicado en archivo
+WollokDslValidator_CYCLIC_HIERARCHY = La jerarqu\u00EDa de clases produce un ciclo infinito 
 WollokDslValidator_DUPLICATED_METHOD = M\u00E9todo duplicado
 WollokDslValidator_DUPLICATED_NAME = Nombre duplicado
 WollokDslValidator_DUPLICATED_PACKAGE = Package duplicado

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -354,7 +354,6 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(ERROR)
 	def cyclicHierarchy(WMethodContainer it) {
 		if (declaringContext.hasCyclicHierarchy) {
-			println("Lanzo error con " + it)
 			report(WollokDslValidator_CYCLIC_HIERARCHY, it, WCLASS__PARENT)
 		}
 	}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -103,6 +103,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	public static val CONSTRUCTOR_IN_SUPER_DOESNT_EXIST = "CONSTRUCTOR_IN_SUPER_DOESNT_EXIST"
 	public static val METHOD_DOESNT_OVERRIDE_ANYTHING = "METHOD_DOESNT_OVERRIDE_ANYTHING"
 	public static val DUPLICATED_METHOD = "DUPLICATED_METHOD"
+	public static val CYCLIC_HIERARCHY = "CYCLIC_HIERARCHY"
 	public static val VARIABLE_NEVER_ASSIGNED = "VARIABLE_NEVER_ASSIGNED"
 	public static val RETURN_FORGOTTEN = "RETURN_FORGOTTEN"
 	public static val VAR_ARG_PARAM_MUST_BE_THE_LAST_ONE = "VAR_ARG_PARAM_MUST_BE_THE_LAST_ONE"
@@ -347,6 +348,15 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 		val rightSide = a.right as WVariableReference
 		if(a.variable == rightSide.ref)
 			report(WollokDslValidator_CANNOT_ASSIGN_TO_ITSELF, a, WVARIABLE_DECLARATION__VARIABLE, CANNOT_ASSIGN_TO_ITSELF)
+	}
+
+	@Check
+	@DefaultSeverity(ERROR)
+	def cyclicHierarchy(WMethodContainer it) {
+		if (declaringContext.hasCyclicHierarchy) {
+			println("Lanzo error con " + it)
+			report(WollokDslValidator_CYCLIC_HIERARCHY, it, WCLASS__PARENT)
+		}
 	}
 
 	@Check


### PR DESCRIPTION
Well, it fixes not only

``` scala
class B inherits B { }
```

but also

``` scala
class A inherits B { }
class B inherits A { }
```

Added Xpect tests also. And fixes stack overflow problem in validations.