### PR TITLE
Fixing Validation of  New Objects and Classes Wizard for Windows

### DIFF
--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/abstractWizards/AbstractNewWollokFileWizardPage.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/wizard/abstractWizards/AbstractNewWollokFileWizardPage.java
@@ -1,5 +1,7 @@
 package org.uqbar.project.wollok.ui.wizard.abstractWizards;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Iterator;
@@ -209,12 +211,16 @@ public abstract class AbstractNewWollokFileWizardPage extends WizardPage {
 		
 		
 		String fullPathFile = container.getRawLocationURI().getPath() + "/" + fileName;
+		try {
+			fullPathFile = URLEncoder.encode(fullPathFile, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+		}
 		java.nio.file.Path path = Paths.get(fullPathFile);
 		if (Files.exists(path)) {
 			updateStatus(Messages.AbstractNewWollokFileWizardPage_fileNameAlreadyExists);
 			return;
 		}
-			
+		
 		boolean ok = doDialogChanged();
 		if (ok) updateStatus(null);
 	}


### PR DESCRIPTION
During Hackaton, trying to use New Objects and Wollok Wizard I discovered a bug in Windows installation.
The wizard verifies if a certain file already exists, so I used URLEncode to fix it.
