### PR TITLE
Dev #1045 incorrect error marked regarding returns in overriden method

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckMethodReturnOverriding.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckMethodReturnOverriding.wlk.xt
@@ -74,9 +74,19 @@ class Persona {
   method quiereSubirA(unMicro) {
     return false
   }
+  method subirNivelSkill(value){
+  	//do nothing
+  }
+  method bloqueaCazador(otroCazador){
+    self.subirNivelSkill(3)
+    otroCazador.bajarNivelSkill(3)
+  }
 }
 class Indeciso inherits Persona {
   override method quiereSubirA(unMicro) {
+    throw new Exception()
+  }
+  override method bloqueaCazador(otroCazador){
     throw new Exception()
   }
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckMethodReturnOverriding.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckMethodReturnOverriding.wlk.xt
@@ -74,19 +74,21 @@ class Persona {
   method quiereSubirA(unMicro) {
     return false
   }
-  method subirNivelSkill(value){
-  	//do nothing
-  }
-  method bloqueaCazador(otroCazador){
-    self.subirNivelSkill(3)
-    otroCazador.bajarNivelSkill(3)
-  }
 }
 class Indeciso inherits Persona {
   override method quiereSubirA(unMicro) {
     throw new Exception()
   }
-  override method bloqueaCazador(otroCazador){
+}
+
+class WithoutReturnMethod {
+  var x
+  method myMethod(){
+    x = 3
+  }	
+}
+class WithReturnMethod inherits WithoutReturnMethod {
+  override method myMethod(){
     throw new Exception()
   }
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
@@ -77,7 +77,7 @@ class WollokModelExtensions {
 	
 	def static file(EObject it) { eResource }
 
-	def static boolean isException(WClass it) { fqn == Exception.name || (parent != null && parent.exception) }
+	def static boolean isException(WClass it) { fqn == Exception.name || (parent !== null && parent.exception) }
 
 	def static dispatch name(WNamed it) { name }
 	def static dispatch name(WObjectLiteral it) { "anonymousObject" }
@@ -89,7 +89,7 @@ class WollokModelExtensions {
 	def static dispatch fqn(WSuite it) { nameWithPackage }
 
 	def static getNameWithPackage(WMethodContainer it) {
-		implicitPackage + "." + if (package != null) package.name + "." + name else name
+		implicitPackage + "." + if (package !== null) package.name + "." + name else name
 	}
 
 	def static dispatch fqn(WObjectLiteral it) {
@@ -101,7 +101,7 @@ class WollokModelExtensions {
 	def static WPackage getPackage(WMethodContainer it) { if(eContainer instanceof WPackage) eContainer as WPackage else null }
 
 	def static boolean isSuperTypeOf(WClass a, WClass b) {
-		a.fqn == b.fqn || (b.parent != null && a.isSuperTypeOf(b.parent))
+		a.fqn == b.fqn || (b.parent !== null && a.isSuperTypeOf(b.parent))
 	}
 
 	// *******************
@@ -112,11 +112,11 @@ class WollokModelExtensions {
 	def static dispatch isModifiableFrom(WReferenciable v, WAssignment from) { true }
 
 	def static boolean initializesInstanceValueFromConstructor(WAssignment a, WVariable v) {
-		v.declaration.right == null && a.isWithinConstructor
+		v.declaration.right === null && a.isWithinConstructor
 	}
 
 	def static boolean isWithinConstructor(EObject e) {
-		e.eContainer != null && (e.eContainer.isAConstructor || e.eContainer.isWithinConstructor)
+		e.eContainer !== null && (e.eContainer.isAConstructor || e.eContainer.isWithinConstructor)
 	}
 
 	def static dispatch boolean isAConstructor(EObject it) { false }
@@ -148,7 +148,7 @@ class WollokModelExtensions {
 	def static dispatch WBlockExpression block(EObject b) { b.eContainer.block }
 
 	def static dispatch WExpression firstExpressionInContext(EObject e) {
-		if (e.eContainer == null) return null 
+		if (e.eContainer === null) return null 
 		e.eContainer.firstExpressionInContext
 	}
 	def static dispatch WExpression firstExpressionInContext(WProgram p) { p.elements.head }
@@ -227,9 +227,9 @@ class WollokModelExtensions {
 		c.classRef.hasConstructorForArgs(c.numberOfParameters)
 	}
 
-	def static numberOfParameters(WConstructorCall c) { if(c.arguments == null) 0 else c.arguments.size }
+	def static numberOfParameters(WConstructorCall c) { if(c.arguments === null) 0 else c.arguments.size }
 
-	def static hasConstructorDefinitions(WClass c) { c.constructors != null && c.constructors.size > 0 }
+	def static hasConstructorDefinitions(WClass c) { c.constructors !== null && c.constructors.size > 0 }
 
 	def static hasConstructorForArgs(WClass c, int nrOfArgs) {
 		(nrOfArgs == 0 && !c.hasConstructorDefinitions) || c.constructors.exists[matches(nrOfArgs)]
@@ -245,8 +245,8 @@ class WollokModelExtensions {
 	def static dispatch hasVarArgs(WConstructor it) { parameters.exists[isVarArg] }
 	def static dispatch hasVarArgs(WMethodDeclaration it) { parameters.exists[isVarArg] }
 
-	def static superClassRequiresNonEmptyConstructor(WClass it) { parent != null && !parent.hasEmptyConstructor }
-	def static superClassRequiresNonEmptyConstructor(WNamedObject it) { parent != null && !parent.hasEmptyConstructor }
+	def static superClassRequiresNonEmptyConstructor(WClass it) { parent !== null && !parent.hasEmptyConstructor }
+	def static superClassRequiresNonEmptyConstructor(WNamedObject it) { parent !== null && !parent.hasEmptyConstructor }
 
 	def static hasEmptyConstructor(WClass c) { !c.hasConstructorDefinitions || c.hasConstructorForArgs(0) }
 
@@ -283,7 +283,7 @@ class WollokModelExtensions {
 
 	def static IFile getIFile(EObject obj) {
 		val platformString = obj.eResource.URI.toPlatformString(true)
-		if (platformString == null) {
+		if (platformString === null) {
 			// could be a synthetic file
 			return null;
 		}
@@ -327,27 +327,28 @@ class WollokModelExtensions {
 		exps.filter(WReferenciable).exists[it != named && name == named.name]
 	}
 
-	def static dispatch boolean isInConstructor(EObject obj) { obj.eContainer != null && obj.eContainer.inConstructor }
+	def static dispatch boolean isInConstructor(EObject obj) { obj.eContainer !== null && obj.eContainer.inConstructor }
 	def static dispatch boolean isInConstructor(WConstructor obj) { true }
 	def static dispatch boolean isInConstructor(WClass obj){ false }
 	def static dispatch boolean isInConstructor(WMethodDeclaration obj) { false }
 
-	def static dispatch boolean isInConstructorBody(EObject obj) { obj.eContainer != null && obj.eContainer.isInConstructorBody }
+	def static dispatch boolean isInConstructorBody(EObject obj) { obj.eContainer !== null && obj.eContainer.isInConstructorBody }
 	def static dispatch boolean isInConstructorBody(WBlockExpression obj) { obj.isInConstructor }
 
 	// *****************************
 	// ** valid return
 	// *****************************
 
-	def static dispatch boolean returnsOnAllPossibleFlows(WMethodDeclaration it) { expressionReturns || expression.returnsOnAllPossibleFlows }
-	def static dispatch boolean returnsOnAllPossibleFlows(WReturnExpression it) { true }
-	def static dispatch boolean returnsOnAllPossibleFlows(WThrow it) { true }
-	def static dispatch boolean returnsOnAllPossibleFlows(WBlockExpression it) { expressions.last.returnsOnAllPossibleFlows }
-	def static dispatch boolean returnsOnAllPossibleFlows(WIfExpression it) { then.returnsOnAllPossibleFlows && ^else != null && ^else.returnsOnAllPossibleFlows }
-	def static dispatch boolean returnsOnAllPossibleFlows(WTry it) { expression.returnsOnAllPossibleFlows && catchBlocks.forall[c | c.returnsOnAllPossibleFlows ] }
-	def static dispatch boolean returnsOnAllPossibleFlows(WCatch it) { expression.returnsOnAllPossibleFlows }
-	def static dispatch boolean returnsOnAllPossibleFlows(Void it) { false } // ?
-	def static dispatch boolean returnsOnAllPossibleFlows(WExpression it) { false }
+
+	def static dispatch boolean returnsOnAllPossibleFlows(WMethodDeclaration it, boolean returnsOnSuperExpression) { expressionReturns || expression.returnsOnAllPossibleFlows(returnsOnSuperExpression) }
+	def static dispatch boolean returnsOnAllPossibleFlows(WReturnExpression it, boolean returnsOnSuperExpression) { true }
+	def static dispatch boolean returnsOnAllPossibleFlows(WThrow it, boolean returnsOnSuperExpression) { returnsOnSuperExpression }
+	def static dispatch boolean returnsOnAllPossibleFlows(WBlockExpression it, boolean returnsOnSuperExpression) { expressions.last.returnsOnAllPossibleFlows(returnsOnSuperExpression) }
+	def static dispatch boolean returnsOnAllPossibleFlows(WIfExpression it, boolean returnsOnSuperExpression) { then.returnsOnAllPossibleFlows(returnsOnSuperExpression) && ^else !== null && ^else.returnsOnAllPossibleFlows(returnsOnSuperExpression) }
+	def static dispatch boolean returnsOnAllPossibleFlows(WTry it, boolean returnsOnSuperExpression) { expression.returnsOnAllPossibleFlows(returnsOnSuperExpression) && catchBlocks.forall[c | c.returnsOnAllPossibleFlows(returnsOnSuperExpression) ] }
+	def static dispatch boolean returnsOnAllPossibleFlows(WCatch it, boolean returnsOnSuperExpression) { expression.returnsOnAllPossibleFlows(returnsOnSuperExpression) }
+	def static dispatch boolean returnsOnAllPossibleFlows(Void it, boolean returnsOnSuperExpression) { false } // ?
+	def static dispatch boolean returnsOnAllPossibleFlows(WExpression it, boolean returnsOnSuperExpression) { false }
 
 
 	def static tri(WCatch it) { eContainer as WTry }
@@ -380,7 +381,7 @@ class WollokModelExtensions {
 	// ** variables
 	// *******************************
 	
-	def static isLocalToMethod(WVariableDeclaration it) { EcoreUtil2.getContainerOfType(it, WMethodDeclaration) != null }
+	def static isLocalToMethod(WVariableDeclaration it) { EcoreUtil2.getContainerOfType(it, WMethodDeclaration) !== null }
 
 	def static onlyUsedInReturn(WVariableDeclaration it) {
 		val visitor = new VariableUsesVisitor
@@ -390,7 +391,7 @@ class WollokModelExtensions {
 	}
 	
 	def static boolean isReturnOrInReturn(EObject e) { e instanceof WReturnExpression || e.isInReturn }
-	def static boolean isInReturn(EObject e) { e.eContainer != null && e.eContainer.isReturnOrInReturn }
+	def static boolean isInReturn(EObject e) { e.eContainer !== null && e.eContainer.isReturnOrInReturn }
 
 	// *******************************
 	// ** imports

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -39,7 +39,6 @@ import org.uqbar.project.wollok.wollokDsl.WProgram
 import org.uqbar.project.wollok.wollokDsl.WReferenciable
 import org.uqbar.project.wollok.wollokDsl.WReturnExpression
 import org.uqbar.project.wollok.wollokDsl.WSelf
-import org.uqbar.project.wollok.wollokDsl.WSuite
 import org.uqbar.project.wollok.wollokDsl.WSuperInvocation
 import org.uqbar.project.wollok.wollokDsl.WTest
 import org.uqbar.project.wollok.wollokDsl.WThrow
@@ -112,7 +111,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	public static val WARNING_UNUSED_VARIABLE = "WARNING_UNUSED_VARIABLE"
 
 	def validatorExtensions() {
-		if (wollokValidatorExtensions != null)
+		if (wollokValidatorExtensions !== null)
 			return wollokValidatorExtensions
 
 		val configs = Platform.getExtensionRegistry.getConfigurationElementsFor("org.uqbar.project.wollok.wollokValidationExtension")
@@ -159,7 +158,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def cannotInstantiateAbstractClasses(WConstructorCall it) {
-		if (classRef == null) return
+		if (classRef === null) return
 		val abstractMethods = classRef.unimplementedAbstractMethods
 		if (!abstractMethods.empty) {
 			val methodDescriptions = abstractMethods.map[methodName].join(", ")
@@ -193,7 +192,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 		if (!c.isValidConstructorCall()) {
 			val expectedMessage =
 				" new " + c.classRef.name +
-					if (c.classRef.constructors == null)
+					if (c.classRef.constructors === null)
 						""
 					else
 						c.classRef.constructors.map[ '(' + parameters.map[name].join(",") + ')'].join(' or ')
@@ -220,7 +219,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def construtorMustExpliclityCallSuper(WConstructor it) {
-		if (delegatingConstructorCall == null && wollokClass.superClassRequiresNonEmptyConstructor) {
+		if (delegatingConstructorCall === null && wollokClass.superClassRequiresNonEmptyConstructor) {
 			report("Must call a super class constructor explicitly", it, WCONSTRUCTOR__PARAMETERS, MUST_CALL_SUPER)
 		}
 	}
@@ -230,7 +229,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def cannotUseSelfInConstructorDelegation(WSelf it) {
-		if (EcoreUtil2.getContainerOfType(it, WDelegatingConstructorCall) != null)
+		if (EcoreUtil2.getContainerOfType(it, WDelegatingConstructorCall) !== null)
 			report("Cannot access instance methods within constructor delegation.", it)
 	}
 	
@@ -251,7 +250,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def cannotUseSuperInConstructorDelegation(WSuperInvocation it) {
-		if (EcoreUtil2.getContainerOfType(it, WDelegatingConstructorCall) != null)
+		if (EcoreUtil2.getContainerOfType(it, WDelegatingConstructorCall) !== null)
 			report("Cannot access super methods within constructor delegation.", it)
 	}
 
@@ -270,7 +269,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	def delegatedConstructorExists(WDelegatingConstructorCall it) {
 		try {
 			val resolved = it.wollokClass.resolveConstructorReference(it)
-			if (resolved == null) {
+			if (resolved === null) {
 				// we could actually show the available options
 				report("Invalid constructor call. Does Not exist", it.eContainer, WCONSTRUCTOR__DELEGATING_CONSTRUCTOR_CALL, CONSTRUCTOR_IN_SUPER_DOESNT_EXIST)
 			}
@@ -295,10 +294,10 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	def overridingMethodMustReturnAValueIfOriginalMethodReturnsAValue(WMethodDeclaration m) {
 		if (m.overrides && !m.native) {
 			val overriden = m.overridenMethod
-			if (overriden != null && !overriden.abstract) {
-				if (overriden.supposedToReturnValue && !m.returnsOnAllPossibleFlows)
+			if (overriden !== null && !overriden.abstract) {
+				if (overriden.supposedToReturnValue && !m.returnsOnAllPossibleFlows(overriden.supposedToReturnValue))
 					m.report(WollokDslValidator_OVERRIDING_METHOD_MUST_RETURN_VALUE, OVERRIDING_METHOD_MUST_RETURN_VALUE)
-				if (!overriden.supposedToReturnValue && m.returnsOnAllPossibleFlows)
+				if (!overriden.supposedToReturnValue && m.returnsOnAllPossibleFlows(overriden.supposedToReturnValue))
 					m.report(WollokDslValidator_OVERRIDING_METHOD_MUST_NOT_RETURN_VALUE, OVERRIDING_METHOD_MUST_NOT_RETURN_VALUE)
 			}
 		}
@@ -307,7 +306,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def methodDoesNotReturnAValueOnEveryPossibleFlow(WMethodDeclaration it) {
-		if (supposedToReturnValue  && !returnsOnAllPossibleFlows)
+		if (supposedToReturnValue  && !returnsOnAllPossibleFlows(supposedToReturnValue))
 			report(WollokDslValidator_METHOD_DOES_NOT_RETURN_A_VALUE_ON_EVERY_POSSIBLE_FLOW)
 	}
 
@@ -385,7 +384,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def methodInvocationToThisMustExist(WMemberFeatureCall call) {
-		if (call.callOnThis && call.method != null && !call.method.declaringContext.isValidCall(call, classFinder)) {
+		if (call.callOnThis && call.method !== null && !call.method.declaringContext.isValidCall(call, classFinder)) {
 			report(WollokDslValidator_METHOD_ON_THIS_DOESNT_EXIST, call, WMEMBER_FEATURE_CALL__FEATURE, METHOD_ON_THIS_DOESNT_EXIST)
 		}
 	}
@@ -407,7 +406,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def objectMustExplicitlyCallASuperclassConstructor(WNamedObject it) {
-		if (parent != null && parentParameters.empty && superClassRequiresNonEmptyConstructor) {
+		if (parent !== null && parentParameters.empty && superClassRequiresNonEmptyConstructor) {
 			report('''No default constructor in super type «parent.name». You must explicitly call a constructor: «parent.constructors.map["(" + parameters.map[name].join(",") + ")"].join(", ")»''', it, WNAMED_OBJECT__PARENT, REQUIRED_SUPERCLASS_CONSTRUCTOR)
 		}
 	}
@@ -415,7 +414,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def objectSuperClassConstructorMustExists(WNamedObject it) {
-		if (parent != null && !parentParameters.empty && !parent.hasConstructorForArgs(parentParameters.size)) {
+		if (parent !== null && !parentParameters.empty && !parent.hasConstructorForArgs(parentParameters.size)) {
 			report('''No superclass constructor or wrong number of arguments. You must explicitly call a constructor: «parent.constructors.map["(" + parameters.map[name].join(",") + ")"].join(", ")»''', it, WNAMED_OBJECT__PARENT)
 		}
 	}
@@ -435,7 +434,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@CheckGroup(WollokCheckGroup.POTENTIAL_PROGRAMMING_PROBLEM)
 	def voidMessagesCannotBeUsedAsValues(WMemberFeatureCall call) {
 		val method = call.resolveMethod(classFinder)
-		if (method != null && !method.native && !method.abstract && !method.supposedToReturnValue && call.isUsedAsValue(classFinder)) {
+		if (method !== null && !method.native && !method.abstract && !method.supposedToReturnValue && call.isUsedAsValue(classFinder)) {
 			report(WollokDslValidator_VOID_MESSAGES_CANNOT_BE_USED_AS_VALUES, call, WMEMBER_FEATURE_CALL__FEATURE, VOID_MESSAGES_CANNOT_BE_USED_AS_VALUES)
 		}
 	}
@@ -502,7 +501,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(ERROR)
 	@CheckGroup(WollokCheckGroup.POTENTIAL_PROGRAMMING_PROBLEM)
 	def unnecessaryIf(WIfExpression it) {
-		if (^else == null && condition.isTrueLiteral)
+		if (^else === null && condition.isTrueLiteral)
 			report(WollokDslValidator_UNNECESSARY_IF, it, WIF_EXPRESSION__CONDITION)
 	}
 	
@@ -510,7 +509,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(ERROR)
 	@CheckGroup(WollokCheckGroup.POTENTIAL_PROGRAMMING_PROBLEM)
 	def unreachableCodeInIf(WIfExpression it) {
-		if (^else != null && condition.isTrueLiteral)
+		if (^else !== null && condition.isTrueLiteral)
 			report(WollokDslValidator_UNREACHABLE_CODE, it, WIF_EXPRESSION__ELSE)
 		if (condition.isFalseLiteral)
 			report(WollokDslValidator_UNREACHABLE_CODE, it, WIF_EXPRESSION__THEN)
@@ -520,7 +519,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(ERROR)
 	@CheckGroup(WollokCheckGroup.POTENTIAL_PROGRAMMING_PROBLEM)
 	def unreachableCodeInBooleanBinaryOperation(WBinaryOperation it) {
-		if (!isBooleanExpression || leftOperand == null || rightOperand == null)
+		if (!isBooleanExpression || leftOperand === null || rightOperand === null)
 			return;
 		// and
 		if (isAndExpression) {
@@ -572,21 +571,21 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def catchExceptionTypeMustExtendException(WCatch it) {
-		if (exceptionType != null && !exceptionType.exception) report(WollokDslValidator_CATCH_ONLY_EXCEPTION, it, WCATCH__EXCEPTION_TYPE)
+		if (exceptionType !== null && !exceptionType.exception) report(WollokDslValidator_CATCH_ONLY_EXCEPTION, it, WCATCH__EXCEPTION_TYPE)
 	}
 
 	@Check
 	@DefaultSeverity(ERROR)
 	def unreachableCatch(WCatch it) {
 		val hidingCatch = catchesBefore.findFirst[c|
-			c.exceptionType == null || c.exceptionType.isSameOrSuperClassOf(it.exceptionType)
+			c.exceptionType === null || c.exceptionType.isSameOrSuperClassOf(it.exceptionType)
 		]
-		if (hidingCatch != null)
+		if (hidingCatch !== null)
 			report(WollokDslValidator_UNREACHABLE_CATCH, it, WCATCH__EXCEPTION_VAR_NAME)
 	}
 
 	def boolean isSameOrSuperClassOf(WClass one, WClass other) {
-		other != null && (one.fqn == other.fqn || one.isSuperTypeOf(other))
+		other !== null && (one.fqn == other.fqn || one.isSuperTypeOf(other))
 	}
 
 	@Check
@@ -703,7 +702,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	}
 
 	def checkNoAfter(WBlockExpression it, WExpression riturn, String errorKey) {
-		if (riturn != null) {
+		if (riturn !== null) {
 			it.getExpressionsAfter(riturn).forEach[e|
 				report(errorKey, it, WBLOCK_EXPRESSION__EXPRESSIONS, it.expressions.indexOf(e))
 			]
@@ -721,7 +720,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def cannotReturnAssignment(WReturnExpression it){
-		if (expression != null && expression instanceof WAssignment)
+		if (expression !== null && expression instanceof WAssignment)
 			report(WollokDslValidator_CANNOT_RETURN_ASSIGNMENT, it, WRETURN_EXPRESSION__EXPRESSION)
 	}
 
@@ -743,7 +742,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def overridingMethodMustHaveABody(WMethodDeclaration it) {
-		if (overrides && expression == null && !native)
+		if (overrides && expression === null && !native)
 			report(WollokDslValidator_OVERRIDING_METHOD_MUST_HAVE_A_BODY, it) 
 	}
 	
@@ -782,7 +781,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(ERROR)
 	def nativeMethodsChecks(WMethodDeclaration it) {
 		if (native) {
-			 if (expression != null) report("Native methods cannot have a body", it, WMETHOD_DECLARATION__EXPRESSION)
+			 if (expression !== null) report("Native methods cannot have a body", it, WMETHOD_DECLARATION__EXPRESSION)
 //			I remove this because I'm not sure if it is needed (Pablo 2016/07/25)
 //			 if (overrides) report("Native methods cannot override anything", it, WMETHOD_DECLARATION__OVERRIDES, NATIVE_METHOD_CANNOT_OVERRIDES)
 			 if (declaringContext instanceof WObjectLiteral) report("Native methods can only be defined in classes", it, WMETHOD_DECLARATION__NATIVE)


### PR DESCRIPTION
I find in WollokModelExtensions this: 

`def static dispatch boolean returnsOnAllPossibleFlows(WThrow it) { true }`

Throw not always must be modeled to return a **true** value on it's flow. It depends if the super method have a return value or not. So WThrow need to have the same behavior. 