### PR TITLE
Fix #685 running all tests

### DIFF
--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/Messages.java
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/Messages.java
@@ -1,4 +1,4 @@
-package org.uqbar.project.wollok.launch.repl;
+package org.uqbar.project.wollok.launch;
 
 import org.eclipse.osgi.util.NLS;
 
@@ -8,8 +8,9 @@ import org.eclipse.osgi.util.NLS;
  * @author jfernandes
  */
 public class Messages extends NLS {
-	private static final String BUNDLE_NAME = "org.uqbar.project.wollok.launch.repl.messages"; //$NON-NLS-1$
+	private static final String BUNDLE_NAME = "org.uqbar.project.wollok.launch.messages"; //$NON-NLS-1$
 	
+	public static String ALL_TEST_IN_PROJECT;
 	public static String LINE;
 	public static String REPL_WELCOME;
 	public static String WVM_ERROR;

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
@@ -3,6 +3,7 @@ package org.uqbar.project.wollok.launch
 import com.google.inject.Injector
 import java.io.File
 import java.rmi.ConnectException
+import java.util.List
 import net.sf.lipermi.handler.CallHandler
 import net.sf.lipermi.net.Client
 import org.uqbar.project.wollok.debugger.server.XDebuggerImpl
@@ -29,6 +30,20 @@ class WollokLauncher extends WollokChecker {
 
 	def static void main(String[] args) {
 		new WollokLauncher().doMain(args)
+	}
+	
+	override doSomething(List<String> fileNames, Injector injector, WollokLauncherParameters parameters) {
+		try {
+			val interpreter = injector.getInstance(WollokInterpreter)
+			val debugger = createDebugger(interpreter, parameters)
+			interpreter.setDebugger(debugger)
+			val filesToParse = fileNames.map [ wollokFile | new File(wollokFile) ]
+			interpreter.interpret(filesToParse.parse)
+			System.exit(0)
+		} catch (Exception e) {
+			System.exit(-1)
+		}
+		
 	}
 
 	override doSomething(WFile parsed, Injector injector, File mainFile, WollokLauncherParameters parameters) {

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherInterpreterEvaluator.xtend
@@ -60,7 +60,8 @@ class WollokLauncherInterpreterEvaluator extends WollokInterpreterEvaluator {
 	override evaluateAll(List<EObject> eObjects) {
 		wollokTestsReporter.initProcessManyFiles
 		val result = eObjects.fold(null, [ o, eObject |
-			interpreter.initStack(eObject)		 
+			interpreter.initStack
+			interpreter.generateStack(eObject)		 
 			evaluate(eObject as WFile)
 		])
 		wollokTestsReporter.endProcessManyFiles

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherInterpreterEvaluator.xtend
@@ -1,6 +1,8 @@
 package org.uqbar.project.wollok.launch
 
 import com.google.inject.Inject
+import java.util.List
+import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.uqbar.project.wollok.interpreter.WollokInterpreter
 import org.uqbar.project.wollok.interpreter.WollokInterpreterEvaluator
@@ -14,9 +16,12 @@ import static extension org.uqbar.project.wollok.launch.tests.WollokExceptionUti
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 
 /**
+ * 
  * Subclasses the wollok evaluator to support tests
  * 
  * @author tesonep
+ * @author dodain -- describe development
+ * 
  */
 class WollokLauncherInterpreterEvaluator extends WollokInterpreterEvaluator {
 
@@ -26,10 +31,10 @@ class WollokLauncherInterpreterEvaluator extends WollokInterpreterEvaluator {
 	// EVALUATIONS (as multimethods)
 	override dispatch evaluate(WFile it) {
 		// Files are not allowed to have both a main program and tests at the same time.
-		if (main != null)
+		if (main !== null)
 			main.eval
 		else {
-			val isASuite = tests.empty && suite != null
+			val isASuite = tests.empty && suite !== null
 			var testsToRun = tests
 			var String suiteName = null
 			if (isASuite) {
@@ -52,11 +57,21 @@ class WollokLauncherInterpreterEvaluator extends WollokInterpreterEvaluator {
 		}
 	}
 
+	override evaluateAll(List<EObject> eObjects) {
+		wollokTestsReporter.initProcessManyFiles
+		val result = eObjects.fold(null, [ o, eObject |
+			interpreter.initStack(eObject)		 
+			evaluate(eObject as WFile)
+		])
+		wollokTestsReporter.endProcessManyFiles
+		result
+	}
+	
 	def WollokObject evalInSuite(WTest test, WSuite suite) {
 		// If in a suite, we should create a suite wko so this will be our current context to eval the tests
 		try {
 			val suiteObject = new SuiteBuilder(suite, interpreter).forTest(test).build
-			if (suite.fixture != null) {
+			if (suite.fixture !== null) {
 				suite.fixture.elements.forEach [ element |
 					interpreter.performOnStack(test, suiteObject, [|element.eval])
 				]
@@ -116,8 +131,7 @@ class SuiteBuilder {
 		suite.members.forEach [ member |
 			suiteObject.addMember(member)
 		]
-		if (test != null) {
-			// suite.members.evalAll
+		if (test !== null) {
 			// Now, declaring test local variables as suite wko instance variables
 			test.variableDeclarations.forEach[variable|suiteObject.addMember(variable)]
 		}

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherParameters.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherParameters.xtend
@@ -23,18 +23,18 @@ class WollokLauncherParameters {
 	boolean jsonOutput = false
 	boolean tests = false
 	boolean noAnsiFormat = false
-	
+
 	def build() {
 		val sb = new StringBuilder
-		if (hasRepl)sb.append("-r").append(" ")
-		if (requestsPort != null) sb.append("-requestsPort " + requestsPort.toString).append(" ")
-		if (eventsPort != null) sb.append("-eventsPort " + eventsPort.toString).append(" ")
-		if (testPort != null) sb.append("-testPort " + testPort.toString).append(" ")
-		if (tests) sb.append("-t ")
-		if (jsonOutput) sb.append("-jsonOutput ")
-		if (noAnsiFormat) sb.append("-noAnsiFormat ")
-		
-		wollokFiles.forEach [ sb.append(it).append(" ") ]
+		if(hasRepl) sb.append("-r").append(" ")
+		if(requestsPort != null) sb.append("-requestsPort " + requestsPort.toString).append(" ")
+		if(eventsPort != null) sb.append("-eventsPort " + eventsPort.toString).append(" ")
+		if(testPort != null) sb.append("-testPort " + testPort.toString).append(" ")
+		if(tests) sb.append("-t ")
+		if(jsonOutput) sb.append("-jsonOutput ")
+		if(noAnsiFormat) sb.append("-noAnsiFormat ")
+
+		wollokFiles.forEach[sb.append(it).append(" ")]
 		sb.toString
 	}
 
@@ -42,12 +42,12 @@ class WollokLauncherParameters {
 		val parser = new GnuParser
 		val cmdLine = parser.parse(options, args)
 		hasRepl = cmdLine.hasOption("r")
-		
+
 		tests = cmdLine.hasOption("t")
 		testPort = parseParameter(cmdLine, "testPort")
-		
+
 		jsonOutput = cmdLine.hasOption("jsonOutput")
-		
+
 		noAnsiFormat = cmdLine.hasOption("noAnsiFormat")
 
 		requestsPort = parseParameter(cmdLine, "requestsPort")
@@ -56,31 +56,31 @@ class WollokLauncherParameters {
 		if ((requestsPort == 0 && eventsPort != 0) || (requestsPort != 0 && eventsPort == 0)) {
 			throw new RuntimeException("Both RequestsPort and EventsPort should be informed")
 		}
-		
+
 		wollokFiles = cmdLine.argList
-		
-		if (!wollokFiles.empty && hasRepl && !wollokFiles.get(0).endsWith(".wlk")){
+
+		if (!wollokFiles.empty && hasRepl && !wollokFiles.get(0).endsWith(".wlk")) {
 			throw new RuntimeException("Repl can only be used with .wlk files.")
 		}
-		
-		if (wollokFiles.empty && !hasRepl){
+
+		if (wollokFiles.empty && !hasRepl) {
 			throw new RuntimeException("You must provide a file or use the REPL")
 		}
-		
-		//If the parameters are empty and we are in the REPL, I generate an empty file to be able of loading the REPL
-		if (wollokFiles.empty && hasRepl){
+
+		// If the parameters are empty and we are in the REPL, I generate an empty file to be able of loading the REPL
+		if (wollokFiles.empty && hasRepl) {
 			val temp = new File("wollokREPL.wlk")
 			temp.deleteOnExit
-		
+
 			val fos = new FileWriter(temp)
 			fos.write('''
-			object __repl {}
+				object __repl {}
 			''')
 			fos.close
-		
+
 			wollokFiles.add(temp.absolutePath)
 		}
-		
+
 		this
 	}
 
@@ -94,7 +94,7 @@ class WollokLauncherParameters {
 			}
 		}
 	}
-	
+
 	def hasDebuggerPorts() {
 		this.eventsPort != 0
 	}
@@ -103,17 +103,15 @@ class WollokLauncherParameters {
 		new Options => [
 			addOption(new Option("r", "Starts an interactive REPL") => [longOpt = "repl"])
 			addOption(new Option("t", "Running tests") => [longOpt = "tests"])
-			
 			addOption(new Option("jsonOutput", "JSON test report output"))
-			
 			addOption(new Option("noAnsiFormat", "Disables ANSI colors for the console"))
-			
+
 			add("testPort", "Server port for tests", "port", 1)
 			add("requestsPort", "Request ports", "port", 1)
-			add("eventsPort", "Events ports", "port", 1)			
+			add("eventsPort", "Events ports", "port", 1)
 		]
 	}
-	
+
 	def add(Options options, String opt, String description, String argName, int args) {
 		options.addOption(
 			new Option(opt, description) => [
@@ -122,5 +120,5 @@ class WollokLauncherParameters {
 			]
 		)
 	}
-	
+
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherParameters.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherParameters.xtend
@@ -1,36 +1,27 @@
 package org.uqbar.project.wollok.launch
 
-import java.util.ArrayList
+import java.io.File
+import java.io.FileWriter
 import java.util.List
 import org.apache.commons.cli.CommandLine
 import org.apache.commons.cli.GnuParser
 import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import org.eclipse.xtend.lib.annotations.Accessors
-import java.io.File
-import java.io.FileOutputStream
-import java.io.FileWriter
 
 /**
  * @author jfernandes
  * @author tesonep
  */
+@Accessors
 class WollokLauncherParameters {
-	@Accessors
 	Integer requestsPort = null
-	@Accessors
 	Integer eventsPort = null
-	@Accessors
-	List<String> wollokFiles = new ArrayList();
-	@Accessors
+	List<String> wollokFiles = newArrayList
 	boolean hasRepl = false
-	@Accessors
 	Integer testPort = null
-	@Accessors
 	boolean jsonOutput = false
-	@Accessors
 	boolean tests = false
-	@Accessors
 	boolean noAnsiFormat = false
 	
 	def build() {
@@ -77,7 +68,7 @@ class WollokLauncherParameters {
 		}
 		
 		//If the parameters are empty and we are in the REPL, I generate an empty file to be able of loading the REPL
-		if (wollokFiles.empty){
+		if (wollokFiles.empty && hasRepl){
 			val temp = new File("wollokREPL.wlk")
 			temp.deleteOnExit
 		

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages.properties
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages.properties
@@ -1,0 +1,9 @@
+#
+# Unit testing
+ALL_TEST_IN_PROJECT=All tests in {0}
+
+#
+# REPL
+REPL_WELCOME=Wollok interactive console (type \"quit\" to quit):
+LINE=line
+WVM_ERROR=Wollok VM Error in line 

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages.properties
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages.properties
@@ -1,6 +1,6 @@
 #
 # Unit testing
-ALL_TEST_IN_PROJECT=All tests in {0}
+ALL_TEST_IN_PROJECT=All tests in project
 
 #
 # REPL

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages_es.properties
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages_es.properties
@@ -1,4 +1,10 @@
 
+#
+# Unit testing
+ALL_TEST_IN_PROJECT=Todos los ests de {0}
+
+#
+# REPL
 REPL_WELCOME=Consola Interactiva de Wollok (escriba \"quit\" para salir): 
 LINE=linea
 WVM_ERROR=Error de la VM de Wollok en la linea

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages_es.properties
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages_es.properties
@@ -1,7 +1,7 @@
 
 #
 # Unit testing
-ALL_TEST_IN_PROJECT=Todos los ests de {0}
+ALL_TEST_IN_PROJECT=Todos los tests del proyecto
 
 #
 # REPL

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
@@ -19,7 +19,7 @@ import org.uqbar.project.wollok.wollokDsl.WFile
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
 import org.uqbar.project.wollok.interpreter.core.WollokObject
 
-import static org.uqbar.project.wollok.launch.repl.Messages.*
+import static org.uqbar.project.wollok.launch.Messages.*
 
 /**
  * 

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/messages.properties
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/messages.properties
@@ -1,4 +1,0 @@
-
-REPL_WELCOME=Wollok interactive console (type \"quit\" to quit):
-LINE=line
-WVM_ERROR=WVM Error in line 

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/DefaultWollokTestsReporter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/DefaultWollokTestsReporter.xtend
@@ -31,4 +31,10 @@ class DefaultWollokTestsReporter implements WollokTestsReporter {
 	
 	}
 	
+	override initProcessManyFiles() {
+	}
+	
+	override endProcessManyFiles() {
+	}
+	
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokConsoleTestsReporter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokConsoleTestsReporter.xtend
@@ -36,4 +36,10 @@ class WollokConsoleTestsReporter implements WollokTestsReporter {
 	override finished() {
 	}
 
+	override initProcessManyFiles() {
+	}
+	
+	override endProcessManyFiles() {
+	}
+
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteTestReporter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteTestReporter.xtend
@@ -7,15 +7,13 @@ import java.util.List
 import net.sf.lipermi.handler.CallHandler
 import net.sf.lipermi.net.Client
 import org.eclipse.emf.common.util.URI
+import org.uqbar.project.wollok.launch.Messages
 import org.uqbar.project.wollok.launch.WollokLauncherParameters
 import org.uqbar.project.wollok.wollokDsl.WFile
 import org.uqbar.project.wollok.wollokDsl.WTest
 import wollok.lib.AssertionException
 
-import static extension org.uqbar.project.wollok.utils.WEclipseUtils.*
 import static extension org.uqbar.project.wollok.launch.tests.WollokExceptionUtils.*
-import org.uqbar.project.wollok.launch.Messages
-import org.eclipse.osgi.util.NLS
 
 /**
  * WollokTestReporter implementation that sends the event to a remote
@@ -37,13 +35,13 @@ class WollokRemoteTestReporter implements WollokTestsReporter {
 	var boolean processingManyFiles
 	
 	String suiteName
-	List<WTest> allTests
-
+	List<WollokTestInfo> testFiles
+	
 	@Inject
 	def init() {
 		client = new Client("localhost", parameters.testPort, callHandler)
 		remoteTestNotifier = client.getGlobal(WollokRemoteUITestNotifier) as WollokRemoteUITestNotifier
-		allTests = newArrayList
+		testFiles = newArrayList
 	}
 
 	override reportTestAssertError(WTest test, AssertionException assertionException, int lineNumber, URI resource) {
@@ -56,12 +54,12 @@ class WollokRemoteTestReporter implements WollokTestsReporter {
 
 	override testsToRun(String _suiteName, WFile file, List<WTest> tests) {
 		this.suiteName = _suiteName
+		val fileURI = file.eResource.URI.toString
 		if (processingManyFiles) {
-			this.suiteName = NLS.bind(Messages.ALL_TEST_IN_PROJECT, file.project.name)
-			this.allTests.addAll(tests)
+			this.suiteName = Messages.ALL_TEST_IN_PROJECT
+			this.testFiles.addAll(getRunnedTestsInfo(tests, fileURI))
 		} else {
-			this.allTests = tests
-			remoteTestNotifier.testsToRun(suiteName, file.eResource.URI.toString, new ArrayList(tests.map[new WollokTestInfo(it)]))
+			remoteTestNotifier.testsToRun(suiteName, fileURI, getRunnedTestsInfo(tests, fileURI))
 		}
 	}
 
@@ -86,13 +84,15 @@ class WollokRemoteTestReporter implements WollokTestsReporter {
 	}
 	
 	override endProcessManyFiles() {
+		remoteTestNotifier => [
+			testsToRun(suiteName, "", this.testFiles)
+			testsResult(testsResult)
+		]
 		processingManyFiles = false
-		remoteTestNotifier.testsToRun(suiteName, "", runnedTestsInfo)
-		remoteTestNotifier.testsResult(testsResult)
 	}
 	
-	protected def List<WollokTestInfo> getRunnedTestsInfo() {
-		new ArrayList(allTests.map[new WollokTestInfo(it)])
+	protected def List<WollokTestInfo> getRunnedTestsInfo(List<WTest> tests, String fileURI) {
+		new ArrayList(tests.map[new WollokTestInfo(it, fileURI)])
 	}
 	
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteTestReporter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteTestReporter.xtend
@@ -14,6 +14,7 @@ import org.uqbar.project.wollok.wollokDsl.WTest
 import wollok.lib.AssertionException
 
 import static extension org.uqbar.project.wollok.launch.tests.WollokExceptionUtils.*
+import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 
 /**
  * WollokTestReporter implementation that sends the event to a remote
@@ -45,11 +46,11 @@ class WollokRemoteTestReporter implements WollokTestsReporter {
 	}
 
 	override reportTestAssertError(WTest test, AssertionException assertionException, int lineNumber, URI resource) {
-		testsResult.add(WollokResultTestDTO.assertionError(test.name, assertionException.message, assertionException.wollokException?.convertStackTrace, lineNumber, resource?.toString))
+		testsResult.add(WollokResultTestDTO.assertionError(test.getFullName(processingManyFiles), assertionException.message, assertionException.wollokException?.convertStackTrace, lineNumber, resource?.toString))
 	}
 
 	override reportTestOk(WTest test) {
-		testsResult.add(WollokResultTestDTO.ok(test.name))
+		testsResult.add(WollokResultTestDTO.ok(test.getFullName(processingManyFiles)))
 	}
 
 	override testsToRun(String _suiteName, WFile file, List<WTest> tests) {
@@ -59,7 +60,7 @@ class WollokRemoteTestReporter implements WollokTestsReporter {
 			this.suiteName = Messages.ALL_TEST_IN_PROJECT
 			this.testFiles.addAll(getRunnedTestsInfo(tests, fileURI))
 		} else {
-			remoteTestNotifier.testsToRun(suiteName, fileURI, getRunnedTestsInfo(tests, fileURI))
+			remoteTestNotifier.testsToRun(suiteName, fileURI, getRunnedTestsInfo(tests, fileURI), false)
 		}
 	}
 
@@ -69,7 +70,7 @@ class WollokRemoteTestReporter implements WollokTestsReporter {
 
 	override reportTestError(WTest test, Exception exception, int lineNumber, URI resource) {
 		testsResult.add(
-			WollokResultTestDTO.error(test.name, exception.convertToString, exception.convertStackTrace, lineNumber,
+			WollokResultTestDTO.error(test.getFullName(processingManyFiles), exception.convertToString, exception.convertStackTrace, lineNumber,
 				resource?.toString))
 	}
 
@@ -85,14 +86,14 @@ class WollokRemoteTestReporter implements WollokTestsReporter {
 	
 	override endProcessManyFiles() {
 		remoteTestNotifier => [
-			testsToRun(suiteName, "", this.testFiles)
+			testsToRun(suiteName, "", this.testFiles, true)
 			testsResult(testsResult)
 		]
 		processingManyFiles = false
 	}
 	
 	protected def List<WollokTestInfo> getRunnedTestsInfo(List<WTest> tests, String fileURI) {
-		new ArrayList(tests.map[new WollokTestInfo(it, fileURI)])
+		new ArrayList(tests.map[new WollokTestInfo(it, fileURI, processingManyFiles)])
 	}
 	
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteUITestNotifier.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteUITestNotifier.xtend
@@ -12,7 +12,7 @@ interface WollokRemoteUITestNotifier {
 	
 	def void testOk(String testName)
 	
-	def void testsToRun(String suiteName, String containerResource, List<WollokTestInfo> tests)
+	def void testsToRun(String suiteName, String containerResource, List<WollokTestInfo> tests, boolean processingManyFiles)
 	
 	def void testStart(String testName)
 	

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteUITestNotifier.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteUITestNotifier.xtend
@@ -1,13 +1,14 @@
 package org.uqbar.project.wollok.launch.tests
 
 import java.util.List
+import java.util.Map
 
 /**
  * @author tesonep
  */
 interface WollokRemoteUITestNotifier {
 	
-	def void assertError(String testName, String messaage, StackTraceElementDTO[] stackTrace, int lineNumber, String resource)
+	def void assertError(String testName, String message, StackTraceElementDTO[] stackTrace, int lineNumber, String resource)
 	
 	def void testOk(String testName)
 	

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteUITestNotifier.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteUITestNotifier.xtend
@@ -20,5 +20,5 @@ interface WollokRemoteUITestNotifier {
 	def void testsResult(List<WollokResultTestDTO> resultTests)
 
 	def void showFailuresAndErrorsOnly(boolean showFailuresAndErrors)
-
+	
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokTestInfo.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokTestInfo.xtend
@@ -5,6 +5,7 @@ import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.EcoreUtil2
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.uqbar.project.wollok.wollokDsl.WTest
+import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 
 /**
  * @author tesonep
@@ -14,13 +15,11 @@ class WollokTestInfo implements Serializable{
 	val String name
 	val String resource
 	val int lineNumber
-	val String fileURI
 	
-	new(WTest test, String fileURI) {
+	new(WTest test, String fileURI, boolean processingManyFiles) {
 		lineNumber = NodeModelUtils.findActualNodeFor(test).textRegionWithLineInformation.lineNumber
 		resource =  EcoreUtil2.getURI(test).toString
-		name = test.name
-		this.fileURI = fileURI
+		name = test.getFullName(processingManyFiles)
 	}
 	
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokTestInfo.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokTestInfo.xtend
@@ -14,10 +14,13 @@ class WollokTestInfo implements Serializable{
 	val String name
 	val String resource
 	val int lineNumber
+	val String fileURI
 	
-	new(WTest test) {
+	new(WTest test, String fileURI) {
 		lineNumber = NodeModelUtils.findActualNodeFor(test).textRegionWithLineInformation.lineNumber
 		resource =  EcoreUtil2.getURI(test).toString
 		name = test.name
+		this.fileURI = fileURI
 	}
+	
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokTestsReporter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokTestsReporter.xtend
@@ -26,4 +26,7 @@ interface WollokTestsReporter {
 	 */	
 	def void finished()
 	
+	/** Just for processing many files */
+	def void initProcessManyFiles()
+	def void endProcessManyFiles()
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/json/WollokJSONTestsReporter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/json/WollokJSONTestsReporter.xtend
@@ -142,5 +142,11 @@ class WollokJSONTestsReporter implements WollokTestsReporter {
 	def setWriter(JsonWriter writer) {
 		_writer = writer
 	}
+
+	override initProcessManyFiles() {
+	}
+	
+	override endProcessManyFiles() {
+	}
 	
 }

--- a/org.uqbar.project.wollok.ui.launch/plugin.properties
+++ b/org.uqbar.project.wollok.ui.launch/plugin.properties
@@ -2,6 +2,7 @@
 wollok.tests.view.name=Wollok Tests
 wollok.launch.allTests=All Wollok Tests in this project
 wollok.launch.tests=Wollok Tests
+wollok.launch.oneTest=This Test
 wollok.debug.tests=Debug Wollok Tests
 wollok.run.tests=Run Wollok Tests
 wollok.launch.replWithoutFile=Run Wollok REPL

--- a/org.uqbar.project.wollok.ui.launch/plugin.properties
+++ b/org.uqbar.project.wollok.ui.launch/plugin.properties
@@ -1,5 +1,6 @@
 # i18n here
 wollok.tests.view.name=Wollok Tests
+wollok.launch.allTests=All Wollok Tests in this project
 wollok.launch.tests=Wollok Tests
 wollok.debug.tests=Debug Wollok Tests
 wollok.run.tests=Run Wollok Tests

--- a/org.uqbar.project.wollok.ui.launch/plugin.xml
+++ b/org.uqbar.project.wollok.ui.launch/plugin.xml
@@ -24,7 +24,6 @@
    </extension>
    
    <!-- LAUNCH CONFIG FOR TESTS -->
-
 	<extension
          point="org.eclipse.debug.core.launchConfigurationTypes">
       <launchConfigurationType
@@ -161,7 +160,7 @@
       </shortcut>
             <shortcut
             class="org.uqbar.project.wollok.ui.tests.shortcut.WollokAllTestsLaunchShortcut"
-            description="Launch Wollok Tests"
+            description="Launch All Wollok Tests"
             icon="icons/wollok-icon-test_16.png"
             id="org.uqbar.project.wollok.ui.tests.shortcut"
             label="%wollok.launch.allTests"
@@ -388,5 +387,4 @@
       </menuContribution>
    </extension>
   <!-- /REPL -->
-
 </plugin>

--- a/org.uqbar.project.wollok.ui.launch/plugin.xml
+++ b/org.uqbar.project.wollok.ui.launch/plugin.xml
@@ -137,6 +137,7 @@
          </contextualLaunch>
       </shortcut>
       <!-- /REPL -->
+      <!-- TESTS -->
       <shortcut
             class="org.uqbar.project.wollok.ui.tests.shortcut.WollokTestLaunchShortcut"
             description="Launch Wollok Tests"
@@ -151,13 +152,35 @@
                <iterate
                      ifEmpty="false"
                      operator="and">
-                  <adapt type="org.eclipse.core.resources.IFile"/>
-	              <test property="org.eclipse.debug.ui.matchesPattern" value="*.wtest"/>
+                  	<adapt type="org.eclipse.core.resources.IFile"/>
+                  	<test property="org.eclipse.debug.ui.matchesPattern" value="*.wtest"/>
                </iterate>
              </with>
            </enablement>
          </contextualLaunch>
       </shortcut>
+            <shortcut
+            class="org.uqbar.project.wollok.ui.tests.shortcut.WollokAllTestsLaunchShortcut"
+            description="Launch Wollok Tests"
+            icon="icons/wollok-icon-test_16.png"
+            id="org.uqbar.project.wollok.ui.tests.shortcut"
+            label="%wollok.launch.allTests"
+            modes="run, debug">
+          <contextualLaunch>
+           <enablement>
+             <with variable="selection">
+               <count value="1"/>
+               <iterate
+                     ifEmpty="false"
+                     operator="and">
+                  	<adapt type="org.eclipse.core.resources.IResource"/>
+                  	<test property="org.eclipse.jdt.launching.isContainer"/>
+               </iterate>
+             </with>
+           </enablement>
+         </contextualLaunch>
+      </shortcut>
+      <!-- /TESTS -->
    </extension>
    <extension
          point="org.eclipse.ui.commands">

--- a/org.uqbar.project.wollok.ui.launch/plugin_es.properties
+++ b/org.uqbar.project.wollok.ui.launch/plugin_es.properties
@@ -1,5 +1,6 @@
 # i18n here
 wollok.tests.view.name=Tests de Wollok
+wollok.launch.allTests=Ejecutar todos los Tests de Wollok de este proyecto
 wollok.launch.tests=Ejecutar Tests de Wollok
 wollok.debug.tests=Debug Tests de Wollok
 wollok.run.tests=Ejecutar Tests de Wollok

--- a/org.uqbar.project.wollok.ui.launch/plugin_es.properties
+++ b/org.uqbar.project.wollok.ui.launch/plugin_es.properties
@@ -2,7 +2,8 @@
 wollok.tests.view.name=Tests de Wollok
 wollok.launch.allTests=Ejecutar todos los Tests de Wollok de este proyecto
 wollok.launch.tests=Ejecutar Tests de Wollok
-wollok.debug.tests=Debug Tests de Wollok
+wollok.launch.oneTest=Ejecutar este Test de Wollok
+wollok.debug.tests=Depurar Tests de Wollok
 wollok.run.tests=Ejecutar Tests de Wollok
 wollok.launch.replWithoutFile=Ejecutar Wollok REPL
 wollok.launch.replWithoutFile.desc=Ejecutar Wollok REPL sin archivo asociado.

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/WollokLaunchConstants.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/WollokLaunchConstants.xtend
@@ -2,6 +2,7 @@ package org.uqbar.project.wollok.ui.launch
 
 import org.eclipse.debug.core.ILaunchConfiguration
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants
 
 /**
  * 
@@ -19,6 +20,7 @@ class WollokLaunchConstants {
 	public static final val LINE_BREAKPOINT_MARKER = "org.uqbar.project.wollok.ui.launch.lineBreakpoint.marker"
 	
 	// launch configurations custom attributes
+	public static val ATTR_WOLLOK_PROJECT = "WOLLOK_PROJECT"
 	public static val ATTR_WOLLOK_FILE = "WOLLOK_FILE"
 	public static val ATTR_WOLLOK_IS_REPL = "WOLLOK_IS_REPL"
 	public static val ATTR_WOLLOK_DEBUG_PARAM = "WOLLOK_DEBUG_PARAM"
@@ -43,6 +45,10 @@ class WollokLaunchConstants {
 	
 	static def getWollokFile(ILaunchConfiguration config){
 		config.getAttribute(ATTR_WOLLOK_FILE,"")
+	}
+
+	static def getWollokProject(ILaunchConfiguration config){
+		config.getAttribute(ATTR_WOLLOK_PROJECT, "")
 	}
 	
 	def static isWollokFileExtension(String xt) {

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/shortcut/AbstractFileLaunchShortcut.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/shortcut/AbstractFileLaunchShortcut.xtend
@@ -1,8 +1,10 @@
 package org.uqbar.project.wollok.ui.launch.shortcut
 
 import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IProject
 import org.eclipse.core.runtime.IAdaptable
 import org.eclipse.debug.ui.ILaunchShortcut
+import org.eclipse.jdt.core.IPackageFragmentRoot
 import org.eclipse.jface.viewers.ISelection
 import org.eclipse.jface.viewers.IStructuredSelection
 import org.eclipse.ui.IEditorPart
@@ -13,16 +15,17 @@ import static extension org.uqbar.project.wollok.utils.WEclipseUtils.*
  * Abstract base class for ILaunchShortcuts based on files.
  * Already adapts selection and editors to IFile.
  * 
+ * Adding capability of running all tests of a project
+ * 
  * @author jfernandes
+ * @author dodain
  */
 abstract class AbstractFileLaunchShortcut implements ILaunchShortcut {
 	
 	override launch(ISelection selection, String mode) {
 		if (selection instanceof IStructuredSelection) {
 			val object = selection.firstElement
-			if (object instanceof IAdaptable) {
-				launch(object.adapt(IFile), mode)
-			}
+			doLaunch(object, mode)
 		}
 	}
 
@@ -32,4 +35,23 @@ abstract class AbstractFileLaunchShortcut implements ILaunchShortcut {
 	
 	def void launch(IFile currFile, String mode)
 	
+	def void launch(IProject currProject, String mode) {
+		throw new RuntimeException("Launcher not found for " + currProject)
+	}
+	
+	def dispatch void doLaunch(IProject currProject, String mode) {
+		launch(currProject, mode)
+	}
+	
+	def dispatch void doLaunch(IPackageFragmentRoot packageRoot, String mode) {
+		launch(packageRoot.javaProject.project, mode)
+	}
+	
+	def dispatch void doLaunch(IAdaptable adaptable, String mode) {
+		launch(adaptable.adapt(IFile), mode)		
+	}
+	
+	def dispatch void doLaunch(Object o, String mode) {
+		throw new RuntimeException("Launcher not found for " + o)
+	}
 }

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/shortcut/WollokLaunchDelegate.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/shortcut/WollokLaunchDelegate.xtend
@@ -88,7 +88,7 @@ class WollokLaunchDelegate extends JavaLaunchDelegate {
 	
 	def configureLaunchParameters(ILaunchConfiguration config, int requestPort, int eventPort){
 		val parameters = new WollokLauncherParameters
-		parameters.eventsPort = eventPort;
+		parameters.eventsPort = eventPort
 		parameters.requestsPort = requestPort
 		parameters.wollokFiles += config.wollokFile
 		parameters.hasRepl = config.hasRepl

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/WollokFileOpenerStrategy.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/WollokFileOpenerStrategy.xtend
@@ -3,7 +3,7 @@ package org.uqbar.project.wollok.ui.tests
 import java.io.File
 import org.eclipse.core.filesystem.EFS
 import org.eclipse.core.filesystem.IFileStore
-import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IProject
 import org.eclipse.emf.common.util.URI
 import org.eclipse.ui.IWorkbenchPage
 import org.eclipse.ui.PlatformUI
@@ -11,8 +11,8 @@ import org.eclipse.ui.ide.IDE
 import org.eclipse.ui.texteditor.ITextEditor
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.eclipse.xtext.ui.util.WorkspaceClasspathUriResolver
-import static org.uqbar.project.wollok.WollokConstants.*
 
+import static org.uqbar.project.wollok.WollokConstants.*
 import static extension org.uqbar.project.wollok.utils.WEclipseUtils.*
 
 @Accessors
@@ -23,11 +23,11 @@ abstract class AbstractWollokFileOpenerStrategy {
 	protected int lineNumber = 0
 	protected String fileName = ""
 	
-	def static AbstractWollokFileOpenerStrategy buildOpenerStrategy(String data, IFile testFile) {
+	def static AbstractWollokFileOpenerStrategy buildOpenerStrategy(String data, IProject project) {
 		if (data.startsWith(CLASSPATH)) {
-			new WollokClasspathFileOpenerStrategy(data, testFile)
+			new WollokClasspathFileOpenerStrategy(data, project)
 		} else {
-			new WollokFileOpenerStrategy(data, testFile)
+			new WollokFileOpenerStrategy(data)
 		}
 	}
 
@@ -48,15 +48,15 @@ abstract class AbstractWollokFileOpenerStrategy {
 
 class WollokClasspathFileOpenerStrategy extends AbstractWollokFileOpenerStrategy {
 
-	IFile testFile
+	IProject project
 	
-	new(String data, IFile testFile) {
-		this.testFile = testFile
+	new(String data, IProject project) {
+		this.project = project
 		initialize(data)
 	}
 
 	override ITextEditor getTextEditor(WollokTestResultView view) {
-		val projectName = testFile.project.name
+		val projectName = project.name
 		val context = projectName.project
 		val URI realURI = new WorkspaceClasspathUriResolver().resolve(context, URI.createURI(fileName))
 		view.openElement(realURI) as ITextEditor
@@ -65,7 +65,7 @@ class WollokClasspathFileOpenerStrategy extends AbstractWollokFileOpenerStrategy
 
 class WollokFileOpenerStrategy extends AbstractWollokFileOpenerStrategy {
 
-	new(String data, IFile testFile) {
+	new(String data) {
 		initialize(data)
 	}
 

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/WollokTestResultView.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/WollokTestResultView.xtend
@@ -41,6 +41,7 @@ import org.uqbar.project.wollok.ui.tests.model.WollokTestContainer
 import org.uqbar.project.wollok.ui.tests.model.WollokTestResult
 import org.uqbar.project.wollok.ui.tests.model.WollokTestResults
 import org.uqbar.project.wollok.ui.tests.model.WollokTestState
+import org.uqbar.project.wollok.ui.tests.shortcut.WollokAllTestsLaunchShortcut
 import org.uqbar.project.wollok.ui.tests.shortcut.WollokTestLaunchShortcut
 
 import static extension org.uqbar.project.wollok.utils.WEclipseUtils.*
@@ -77,6 +78,9 @@ class WollokTestResultView extends ViewPart implements Observer {
 
 	@Inject
 	WollokTestLaunchShortcut testLaunchShortcut
+	
+	@Inject
+	WollokAllTestsLaunchShortcut allTestsLaunchShortcut
 
 	ToolBar toolbar
 
@@ -85,7 +89,7 @@ class WollokTestResultView extends ViewPart implements Observer {
 	ToolItem debugAgain
 	
 	def canRelaunch() {
-		results != null && results.container != null && results.container.mainResource != null
+		results !== null && results.container !== null && results.container.mainResource !== null
 	}
 
 	def relaunch() {
@@ -97,7 +101,11 @@ class WollokTestResultView extends ViewPart implements Observer {
 	}
 
 	def relaunch(String mode) {
-		testLaunchShortcut.launch(testFile, mode)
+		if (results.container.processingManyFiles) {
+			allTestsLaunchShortcut.launch(results.container.project, mode)
+		} else {
+			testLaunchShortcut.launch(testFile, mode)
+		}
 	}
 
 	def testFile() {
@@ -309,7 +317,7 @@ class WollokTestResultView extends ViewPart implements Observer {
 		testTree.refresh(true)
 		testTree.expandAll
 
-		if (results.container != null) {
+		if (results.container !== null) {
 			val runned = (total - count[state == WollokTestState.PENDING])
 			totalTextBox.text = runned.toString + "/" + total.toString
 

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/WollokTestResultView.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/WollokTestResultView.xtend
@@ -345,7 +345,10 @@ class WollokTestResultView extends ViewPart implements Observer {
 	}
 
 	def dispatch openElement(WollokTestContainer container) {
-		opener.open(container.mainResource, true)
+		// @dodain - in case we are running all tests
+		if (container.mainResource !== null) {
+			opener.open(container.mainResource, true)
+		}
 	}
 
 	def dispatch openElement(WollokTestResult result) {

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/WollokTestResultView.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/WollokTestResultView.xtend
@@ -258,7 +258,7 @@ class WollokTestResultView extends ViewPart implements Observer {
 		textOutput.addSelectionListener(
 			new SelectionAdapter() {
 				override widgetSelected(SelectionEvent event) {
-					val fileOpenerStrategy = AbstractWollokFileOpenerStrategy.buildOpenerStrategy(event.text, testFile)
+					val fileOpenerStrategy = AbstractWollokFileOpenerStrategy.buildOpenerStrategy(event.text, results.container.project)
 					val ITextEditor textEditor = fileOpenerStrategy.getTextEditor(WollokTestResultView.this)
 					val String fileName = fileOpenerStrategy.fileName
 					val Integer lineNumber = fileOpenerStrategy.lineNumber
@@ -409,7 +409,7 @@ class WTestTreeContentProvider implements ITreeContentProvider {
 	var WollokTestResults results
 
 	def dispatch getChildren(WollokTestResults element) {
-		if (element.container == null)
+		if (element.container === null)
 			newArrayOfSize(0)
 		else
 			#[element.container]
@@ -424,7 +424,7 @@ class WTestTreeContentProvider implements ITreeContentProvider {
 	}
 
 	def dispatch getElements(WollokTestResults inputElement) {
-		if (inputElement.container == null)
+		if (inputElement.container === null)
 			return newArrayOfSize(0)
 		else
 			return #[inputElement.container]

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestContainer.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestContainer.xtend
@@ -3,6 +3,7 @@ package org.uqbar.project.wollok.ui.tests.model
 import java.util.List
 import org.eclipse.emf.common.util.URI
 import org.eclipse.xtend.lib.annotations.Accessors
+import static extension org.uqbar.project.wollok.utils.WEclipseUtils.*
 
 @Accessors
 class WollokTestContainer {
@@ -10,13 +11,14 @@ class WollokTestContainer {
 	var URI mainResource
 	var List<WollokTestResult> tests = newArrayList
 	var List<WollokTestResult> allTests = newArrayList
+	var boolean processingManyFiles = false
 	
 	override toString(){
 		mainResource.toString
 	}
 	
 	def hasSuiteName() {
-		suiteName != null && !suiteName.isEmpty
+		suiteName !== null && !suiteName.isEmpty
 	}
 	
 	def filterTestByState(boolean shouldShowOnlyFailuresAndErrors) {
@@ -32,5 +34,10 @@ class WollokTestContainer {
 	def testByName(String testName) {
 		this.allTests.findFirst[name == testName]
 	}
+	
+	def getProject() {
+		if (this.allTests.empty) return null
+		this.allTests.head.testResource.toIFile.project
+	}	
 	
 }

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestContainer.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestContainer.xtend
@@ -11,30 +11,26 @@ class WollokTestContainer {
 	var List<WollokTestResult> tests = newArrayList
 	var List<WollokTestResult> allTests = newArrayList
 	
-	new() {
-		super()
-	}	
-	
 	override toString(){
 		mainResource.toString
 	}
 	
 	def hasSuiteName() {
-		suiteName !== null && !suiteName.isEmpty
+		suiteName != null && !suiteName.isEmpty
 	}
 	
 	def filterTestByState(boolean shouldShowOnlyFailuresAndErrors) {
 		this.tests = newArrayList(allTests.filter [ result | result.failed || !shouldShowOnlyFailuresAndErrors ])
 	}
 	
-	def void initTests(List<WollokTestResult> tests, boolean shouldShowOnlyFailuresAndErrors) {
+	def void defineTests(List<WollokTestResult> tests, boolean shouldShowOnlyFailuresAndErrors) {
 		this.allTests = tests
 		filterTestByState(shouldShowOnlyFailuresAndErrors)
 		this.tests.forEach [ test | test.started ]
 	} 
 	
 	def testByName(String testName) {
-		allTests.findFirst[name == testName]
+		this.allTests.findFirst[name == testName]
 	}
 	
 }

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestContainer.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestContainer.xtend
@@ -11,13 +11,16 @@ class WollokTestContainer {
 	var List<WollokTestResult> tests = newArrayList
 	var List<WollokTestResult> allTests = newArrayList
 	
+	new() {
+		super()
+	}	
 	
 	override toString(){
 		mainResource.toString
 	}
 	
 	def hasSuiteName() {
-		suiteName != null && !suiteName.isEmpty
+		suiteName !== null && !suiteName.isEmpty
 	}
 	
 	def filterTestByState(boolean shouldShowOnlyFailuresAndErrors) {

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestResult.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestResult.xtend
@@ -22,11 +22,13 @@ class WollokTestResult {
 	int lineNumber
 	// for other exceptions we just get the string. This is a hack, but I need to cut the refactor (exceptions to wollok)
 	String exceptionAsString
+	String mainResource
 
 	new(WollokTestInfo testInfo) {
 		this.testInfo = testInfo
 		state = WollokTestState.PENDING
 		testResource = URI.createURI(testInfo.resource)
+		mainResource = testInfo.fileURI
 	}
 
 	def getName() {

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestResult.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestResult.xtend
@@ -28,7 +28,7 @@ class WollokTestResult {
 		this.testInfo = testInfo
 		state = WollokTestState.PENDING
 		testResource = URI.createURI(testInfo.resource)
-		mainResource = testInfo.fileURI
+		mainResource = testInfo.resource //testInfo.fileURI
 	}
 
 	def getName() {

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestResults.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestResults.xtend
@@ -36,9 +36,10 @@ class WollokTestResults extends Observable implements WollokRemoteUITestNotifier
 		this.notifyObservers
 	}
 	
-	override testsToRun(String suiteName, String containerResource, List<WollokTestInfo> tests) {
+	override testsToRun(String suiteName, String containerResource, List<WollokTestInfo> tests, boolean processingManyFiles) {
 		this.container = new WollokTestContainer
 		this.container.suiteName = suiteName
+		this.container.processingManyFiles = processingManyFiles
 		this.container.mainResource = URI.createURI(containerResource)
 		this.container.defineTests(newArrayList(tests.map[new WollokTestResult(it)]), this.shouldShowOnlyFailuresAndErrors)
 		
@@ -93,5 +94,5 @@ class WollokTestResults extends Observable implements WollokRemoteUITestNotifier
 		this.setChanged
 		this.notifyObservers
 	}
-	
+
 }

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestResults.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/model/WollokTestResults.xtend
@@ -40,7 +40,7 @@ class WollokTestResults extends Observable implements WollokRemoteUITestNotifier
 		this.container = new WollokTestContainer
 		this.container.suiteName = suiteName
 		this.container.mainResource = URI.createURI(containerResource)
-		this.container.initTests(newArrayList(tests.map[new WollokTestResult(it)]), this.shouldShowOnlyFailuresAndErrors)
+		this.container.defineTests(newArrayList(tests.map[new WollokTestResult(it)]), this.shouldShowOnlyFailuresAndErrors)
 		
 		this.setChanged
 		this.notifyObservers		
@@ -77,7 +77,7 @@ class WollokTestResults extends Observable implements WollokRemoteUITestNotifier
 	}
 	
 	override testsResult(List<WollokResultTestDTO> tests) {
-		tests.forEach [ 
+		tests.forEach [
 			val test = testByName(it.testName)
 			if (it.ok()) {
 				test.endedOk()
@@ -90,7 +90,6 @@ class WollokTestResults extends Observable implements WollokRemoteUITestNotifier
 			}
 		]
 		this.container.filterTestByState(this.shouldShowOnlyFailuresAndErrors)
-
 		this.setChanged
 		this.notifyObservers
 	}

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/shortcut/WollokAllTestsLaunchShortcut.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/shortcut/WollokAllTestsLaunchShortcut.xtend
@@ -1,0 +1,62 @@
+package org.uqbar.project.wollok.ui.tests.shortcut
+
+import java.util.List
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IProject
+import org.eclipse.jface.dialogs.MessageDialog
+import org.eclipse.swt.widgets.Display
+
+import static org.uqbar.project.wollok.ui.launch.WollokLaunchConstants.*
+import static extension org.uqbar.project.wollok.utils.WEclipseUtils.*
+
+/**
+ * 
+ * A special launcher shortcut for running all tests in a project
+ * 
+ * @author dodain
+ * 
+ */
+class WollokAllTestsLaunchShortcut extends WollokTestLaunchShortcut {
+	
+	override getOrCreateConfig(IFile currFile) {
+		val config = super.getOrCreateConfig(currFile)
+		val wc = config.getWorkingCopy
+		wc.setAttribute(ATTR_WOLLOK_FILE, currFile.testFilesAsString)
+		wc
+	}
+	
+	/**
+	 * If we are launching all tests in a project
+	 * - first: check project has valid tests
+	 * - then: take any test as a mock file and use default inherited configuration
+	 * - before launching: remove file in configuration
+	 * - finally: launch tests
+	 */
+	override launch(IProject currProject, String mode) {
+		if (!checkEclipseProject(currProject)) return;
+		activateWollokTestResultView
+		val List<IFile> testFiles = currProject.getTestFiles
+		if (testFiles.empty) {
+			// TODO: i18n
+			MessageDialog.openError(Display.current.activeShell, "No tests to run",
+				"There are no tests to run")
+			return;
+		} 
+		val currFile = testFiles.head
+		this.launch(currFile, mode)
+	}
+	
+	def List<IFile> getTestFiles(IProject project) {
+		project
+			.allMembers
+			.filter [ fileExtension !== null && fileExtension.equals(WTEST_EXTENSIONS) ]
+			.toList
+			.map [ adapt(IFile) ]
+			.toList
+	}
+	
+	def String testFilesAsString(IFile file) {
+		file.project.testFiles.fold(new StringBuilder, [ sb, it  | sb.append(it.locationURI.toURL.file).append(" ") ]).toString
+	}
+
+}

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
@@ -398,7 +398,7 @@ class WollokDslQuickfixProvider extends DefaultQuickfixProvider {
 			val newClassName = xtextDocument.get(issue.offset, issue.length)
 			val container = (e as WExpression).method.declaringContext
 			context.xtextDocument.replace(container.after, 0,
-				System.lineSeparator + CLASS + newClassName + " {" + System.lineSeparator + "}" + System.lineSeparator)
+				System.lineSeparator + CLASS + blankSpace + newClassName + " {" + System.lineSeparator + "}" + System.lineSeparator)
 		]
 
 	}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokConstants.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokConstants.xtend
@@ -15,6 +15,8 @@ import org.uqbar.project.wollok.wollokDsl.WBinaryOperation
  */
 class WollokConstants {
 	
+	public static val SOURCE_FOLDER = "src"
+	
 	public static val NATURE_ID = "org.uqbar.project.wollok.wollokNature"
 	public static val CLASS_OBJECTS_EXTENSION = "wlk"
 	public static val PROGRAM_EXTENSION = "wpgm"

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreter.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreter.xtend
@@ -126,7 +126,7 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 	override interpret(EObject rootObject, Boolean propagatingErrors) {
 		try {
 			log.debug("Starting interpreter")
-			rootObject.initStack
+			rootObject.generateStack
 			evaluator.evaluate(rootObject)
 		} catch (WollokProgramExceptionWrapper e) {
 			throw e
@@ -141,7 +141,11 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 			debugger.terminated
 	}
 
-	def void initStack(EObject rootObject) {
+	def void initStack() {
+		executionStack = new ObservableStack<XStackFrame>
+	}
+	
+	def void generateStack(EObject rootObject) {
 		val stackFrame = rootObject.createInitialStackElement
 		executionStack.push(stackFrame)
 		debugger.started

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreter.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreter.xtend
@@ -3,6 +3,7 @@ package org.uqbar.project.wollok.interpreter
 import com.google.inject.Inject
 import com.google.inject.Injector
 import java.io.Serializable
+import java.util.List
 import org.apache.commons.logging.Log
 import org.apache.commons.logging.LogFactory
 import org.eclipse.emf.ecore.EObject
@@ -20,6 +21,7 @@ import org.uqbar.project.wollok.interpreter.debugger.XDebuggerOff
 import org.uqbar.project.wollok.interpreter.stack.ObservableStack
 import org.uqbar.project.wollok.interpreter.stack.ReturnValueException
 import org.uqbar.project.wollok.interpreter.stack.XStackFrame
+import org.uqbar.project.wollok.wollokDsl.WFile
 
 import static org.uqbar.project.wollok.sdk.WollokDSK.*
 
@@ -42,7 +44,7 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 		globalVariables.put(name, value)
 		value
 	}
-	
+
 	override removeGlobalReference(String name) {
 		globalVariables.remove(name)
 	}
@@ -65,7 +67,7 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 	static var WollokInterpreter instance = null
 
 	@Accessors var Boolean interactive = false
-	
+
 	new() {
 		instance = this
 	}
@@ -95,29 +97,55 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 		}
 	}
 
-	override interpret(EObject rootObject, Boolean propagatingErrors) {
+	def interpret(List<EObject> eObjects) {
+		try {
+			interpret(eObjects, false)
+		} catch (WollokProgramExceptionWrapper e) {
+			// todo: what about "propagating errors?"
+			e.wollokException.call("printStackTrace")
+			throw e
+		}
+	}
+
+	def interpret(List<EObject> eObjects, boolean propagatingErrors) {
 		try {
 			log.debug("Starting interpreter")
-			val stackFrame = rootObject.createInitialStackElement
-			executionStack.push(stackFrame)
-			debugger.started
-
-			evaluating = rootObject
-
-			evaluator.evaluate(rootObject)
-
+//			val rootObject = eObjects.head
+//			rootObject.initStack 
+			evaluator.evaluateAll(eObjects)
 //			evaluating = null
 		} catch (WollokProgramExceptionWrapper e) {
 			throw e
-		} catch (Throwable e)
+		} catch (Throwable e) {
+			console.logError(e)
+			null
+		} finally
+			debugger.terminated
+	}
+
+	override interpret(EObject rootObject, Boolean propagatingErrors) {
+		try {
+			log.debug("Starting interpreter")
+			rootObject.initStack
+			evaluator.evaluate(rootObject)
+		} catch (WollokProgramExceptionWrapper e) {
+			throw e
+		} catch (Throwable e) {
 			if (propagatingErrors)
 				throw e
 			else {
 				console.logError(e)
 				null
 			}
-		finally
+		} finally
 			debugger.terminated
+	}
+
+	def void initStack(EObject rootObject) {
+		val stackFrame = rootObject.createInitialStackElement
+		executionStack.push(stackFrame)
+		debugger.started
+		evaluating = rootObject
 	}
 
 	def createInitialStackElement(EObject root) {
@@ -127,19 +155,19 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 	// non-thread-safe
 	boolean instantiatingStackOverFlow = false
 
-	override performOnStack(EObject executable, EvaluationContext<WollokObject> newContext, ()=>WollokObject something) {
+	override performOnStack(EObject executable, EvaluationContext<WollokObject> newContext,
+		()=>WollokObject something) {
 		stack.push(new XStackFrame(executable, newContext, WollokSourcecodeLocator.INSTANCE))
 		try
 			return something.apply
 		catch (ReturnValueException e)
 			return e.value
-		catch (StackOverflowError e){
+		catch (StackOverflowError e) {
 			instantiatingStackOverFlow = true
 			val exp = (evaluator as WollokInterpreterEvaluator).newInstance(STACK_OVERFLOW_EXCEPTION)
 			instantiatingStackOverFlow = false
 			throw new WollokProgramExceptionWrapper(exp)
-		}
-		finally
+		} finally
 			stack.pop
 	}
 
@@ -188,4 +216,5 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 		// I18N !
 		throw new UnresolvableReference('''Cannot resolve reference «variableName»''')
 	}
+
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -104,7 +104,7 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 	/* BINARY */
 	override resolveBinaryOperation(String operator) { operator.asBinaryOperation }
 
-	override evaluateAll(List<EObject> wfiles) {
+	override evaluateAll(List<EObject> eObjects) {
 		// By default it does nothing
 	}
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -74,6 +74,8 @@ import static extension org.uqbar.project.xtext.utils.XTextExtensions.sourceCode
  * for each element.
  *
  * @author jfernandes
+ * @author dodain - Added evaluating multiple files
+ * 
  */
 class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> {
 	extension WollokBasicBinaryOperations = new WollokDeclarativeNativeBasicOperations
@@ -92,7 +94,7 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 	/* HELPER METHODS */
 	/** helper method to evaluate an expression going all through the interpreter and back here. */
 	protected def eval(EObject e) { interpreter.eval(e) }
-
+	
 	protected def evalAll(Iterable<? extends EObject> all) { all.fold(null)[a, e|
 		e.eval
 	] }
@@ -101,6 +103,10 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 
 	/* BINARY */
 	override resolveBinaryOperation(String operator) { operator.asBinaryOperation }
+
+	override evaluateAll(List<EObject> wfiles) {
+		// By default it does nothing
+	}
 
 	// EVALUATIONS (as multimethods)
 	def dispatch evaluate(WFile it) {
@@ -440,5 +446,5 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 			createNamedObject(classFinder.getCachedObject(context, qualifiedName), qualifiedName)
 		}
 	}
-
+	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -436,4 +436,9 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 	def static boolean callsSuper(WMethodDeclaration it) { !abstract && !native && expression.callsSuper }
 	def static dispatch boolean callsSuper(WSuperInvocation it) { true }
 	def static dispatch boolean callsSuper(EObject it) { eAllContents.exists[ e | e.callsSuper] }
+	
+	/* Including file name for multiple tests */
+	def static getFullName(WTest test, boolean processingManyFiles) {
+		(if (processingManyFiles) (test.file.URI.lastSegment ?: "") + " - " else "") + test.name
+	}
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/WEclipseUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/WEclipseUtils.xtend
@@ -87,8 +87,12 @@ class WEclipseUtils {
 		ResourcesPlugin.workspace.root.getFileForLocation(path)
 	}
 	
+	def static toIFile(EObject o) {
+		o.eResource.URI.toIFile
+	}
+	
 	def static getProject(EObject o) {
-		o.eResource.URI.toIFile.project
+		o.toIFile.project
 	}
 	
 	def static toIFile(java.net.URI uri) {

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/WEclipseUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/WEclipseUtils.xtend
@@ -5,6 +5,9 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
+import java.util.Map
+import java.util.Set
+import org.eclipse.core.resources.IContainer
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IResource
@@ -34,6 +37,8 @@ import org.eclipse.ui.PlatformUI
 import org.eclipse.ui.texteditor.ITextEditor
 import org.eclipse.xtext.ui.editor.XtextEditor
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
+import org.uqbar.project.wollok.WollokConstants
+import org.uqbar.project.wollok.wollokDsl.WFile
 
 /**
  * Utilities on top of eclipse platform.
@@ -80,6 +85,10 @@ class WEclipseUtils {
 	def static toIFile(URI uri) {
 		var path = new Path(uri.toFileString)
 		ResourcesPlugin.workspace.root.getFileForLocation(path)
+	}
+	
+	def static getProject(EObject o) {
+		o.eResource.URI.toIFile.project
 	}
 	
 	def static toIFile(java.net.URI uri) {
@@ -156,6 +165,21 @@ class WEclipseUtils {
 		} catch (PartInitException e) {
 			e.printStackTrace
 		}
-	} 
+	}
+	 
+	def static dispatch Set<IResource> getAllMembers(IContainer container) {
+		val Map<String,IResource> result = newHashMap
+		container
+			.members
+			.filter [ fullPath.toPortableString.contains(WollokConstants.SOURCE_FOLDER) ]
+			.forEach [
+				allMembers.forEach [ result.put(it.fullPath.toPortableString, it)]
+			]
+		result.values.toSet
+	}
+
+	def static dispatch Set<IResource> getAllMembers(IFile file) {
+		#{file}
+	}
 	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/WEclipseUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/WEclipseUtils.xtend
@@ -38,7 +38,6 @@ import org.eclipse.ui.texteditor.ITextEditor
 import org.eclipse.xtext.ui.editor.XtextEditor
 import org.eclipse.xtext.ui.editor.model.XtextDocumentUtil
 import org.uqbar.project.wollok.WollokConstants
-import org.uqbar.project.wollok.wollokDsl.WFile
 
 /**
  * Utilities on top of eclipse platform.

--- a/org.uqbar.project.xinterpreter/src/org/uqbar/project/wollok/interpreter/api/XInterpreterEvaluator.xtend
+++ b/org.uqbar.project.xinterpreter/src/org/uqbar/project/wollok/interpreter/api/XInterpreterEvaluator.xtend
@@ -1,6 +1,7 @@
 package org.uqbar.project.wollok.interpreter.api
 
 import java.io.Serializable
+import java.util.List
 import org.eclipse.emf.ecore.EObject
 
 /**
@@ -20,8 +21,9 @@ import org.eclipse.emf.ecore.EObject
 interface XInterpreterEvaluator<O> extends Serializable {
 	
 	def O evaluate(EObject o)
-
+	def O evaluateAll(List<EObject> eObjects)
+	
 	// this will be deleted eventually
 	def (O,()=>O)=>O resolveBinaryOperation(String operator)
-
+	
 }


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/4549002/26083984/38126894-39af-11e7-8ccb-8f1ad4bfd972.png)

Now you can 

* run all tests from a source folder or project
* it works also relaunch button
* when you run all tests for a project, test file appears so you can choose same test name in different wollok test files.
A subtle problem: if you define same test names in different wollok test files 

```
+ test
   + clientes
         - test.wtest, test name: "testing some objects"
   + facturas
         - test.wtest, test name: "testing some objects"        
```

but it is unlikely to happen (and to test)

* root object of test results view indicates whether you are running all tests from project or all tests for a certain file
* it shows conveniently failures or all tests
* this fixes #685 , but I could not find how to define a contextual menu in outline view for WTest, so we could launch only one test

