### PR TITLE
fix #1052 exponentiation precedence 

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -379,6 +379,15 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	}
 	
 	@Test
+	def void exponentiationPrecedence() {
+		'''
+		assert.equals(24, 3 * 2 ** 3)
+		assert.equals(36, 4.0 * 3 ** 2)
+		assert.equals(5, 1 + 2 ** 2)
+		'''.test
+	}
+	
+	@Test
 	def void integerRoundUp() {
 		'''
 		assert.equals(5, (10/2).roundUp(2))

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokDsl.xtext
@@ -88,7 +88,7 @@ WMethodDeclaration:
 
 WMethodName:
 	// TODO: 2 esto deberia tener un @check el método con +, o - necesita tener un solo argumento
-	ID | OpAdd | OpMulti | OpEquality | OpOther | OpCompare | OpAnd | OpOr
+	ID | OpAdd | OpMulti | OpEquality | OpOther | OpCompare | OpAnd | OpOr | OpPower
 ;
 
 WParameter:
@@ -189,12 +189,19 @@ WAdditiveExpression returns WExpression:
 
 OpAdd:
 	'+' | '-';
-
+ 
 WMultiplicativeExpression returns WExpression:
-	WUnaryOperation (=>({WBinaryOperation.leftOperand=current} feature=OpMulti) rightOperand=WUnaryOperation)*;
+	WExponentiativeExpression (=>({WBinaryOperation.leftOperand=current} feature=OpMulti) rightOperand=WExponentiativeExpression)*; 
 
+	
 OpMulti:
-	'*' | '**' | '/' | '%';
+	'*' | '/' | '%';
+
+WExponentiativeExpression returns WExpression:
+	WUnaryOperation (=>({WBinaryOperation.leftOperand=current} feature=OpPower) rightOperand=WExponentiativeExpression)?;
+
+OpPower:
+	'**';
 
 WUnaryOperation returns WExpression:
 	{WUnaryOperation} feature=OpUnary operand=WUnaryOperation


### PR DESCRIPTION
In order to fix the precedence bug I added a new rule to the grammar:
```
WExponentiativeExpression returns WExpression:
	WUnaryOperation (=>({WBinaryOperation.leftOperand=current} feature=OpPower) rightOperand=WExponentiativeExpression)?;

OpPower:
	'**';
```

Now `a * b ** c` equals `a * (b**c)` as expected.

