### PR TITLE
fix-#1089 wrong error message when a test is defined in a .wlk file

### DIFF
--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
@@ -57,6 +57,7 @@ public class Messages extends NLS {
 	public static String WollokDslValidator_DUPLICATED_PACKAGE;
 	public static String WollokDslValidator_PROGRAM_IN_FILE;
 	public static String WollokDslValidator_CLASSES_IN_FILE;
+	public static String WollokDslValidator_TESTS_IN_FILE;
 	public static String WollokDslValidator_NATIVE_METHOD_NO_BODY;
 	public static String WollokDslValidator_NATIVE_METHOD_NO_OVERRIDE;
 	public static String WollokDslValidator_NATIVE_METHOD_ONLY_IN_CLASSES;

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
@@ -29,6 +29,7 @@ WollokDslValidator_DONT_COMPARE_AGAINST_TRUE_OR_FALSE = Don't compare with boole
 WollokDslValidator_DO_NOT_COMPARE_FOR_EQUALITY_WKO = Do not compare for equality an Object. Send a Message
 
 WollokDslValidator_CLASSES_IN_FILE = Classes and Objects should be defined in a file with extension
+WollokDslValidator_TESTS_IN_FILE = Tests should be defined in a file with extension 
 WollokDslValidator_CLASS_NAME_MUST_START_UPPERCASE = Class name must start with uppercase
 WollokDslValidator_DUPLICATED_CLASS_IN_PACKAGE = Duplicated class name in package
 WollokDslValidator_DUPLICATED_CLASS_IN_FILE = Duplicated class name in file

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
@@ -30,6 +30,7 @@ WollokDslValidator_CATCH_ONLY_EXCEPTION = Solo se puede aplicar 'catch' a un obj
 WollokDslValidator_UNREACHABLE_CATCH = Este catch nunca se va a ejecutar debido a otro catch anterior
 
 WollokDslValidator_CLASSES_IN_FILE = Clases y objetos se deben definir en archivos con extensi\u00F3n
+WollokDslValidator_TESTS_IN_FILE = Los tests se deben definir en archivos con extensi\u00F3n 
 WollokDslValidator_CLASS_NAME_MUST_START_UPPERCASE = El nombre de clase debe comenzar en may\u00FAscula
 
 WollokDslValidator_DUPLICATED_CLASS_IN_PACKAGE = Nombre de clase duplicado en package

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -655,7 +655,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(ERROR)
 	def testInTestFile(WTest t) {
 		if(t.eResource.URI.nonXPectFileExtension != WollokConstants.TEST_EXTENSION)
-			report(WollokDslValidator_CLASSES_IN_FILE + ''' «WollokConstants.TEST_EXTENSION»''', t, WTEST__NAME)
+			report(WollokDslValidator_TESTS_IN_FILE + ''' «WollokConstants.TEST_EXTENSION»''', t, WTEST__NAME)
 	}
 
 	@Check


### PR DESCRIPTION
I've defined a constant **_wollokDslValidator_TESTS_IN_FILE_** with the content of the error message.
Also I noticed that a "CLASSES_IN_FILE check" is missing.
Should I fix it in this PR or create a new issue?
