### PR TITLE
Fix #394 - Add a Confirm Dialog

### DIFF
--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
@@ -62,7 +62,6 @@ class WollokLauncher extends WollokChecker {
 			System.exit(0)
 		}
 		catch (Exception e) {
-			println(e.message)
 			System.exit(-1)
 		}
 	}

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
@@ -62,6 +62,7 @@ class WollokLauncher extends WollokChecker {
 			System.exit(0)
 		}
 		catch (Exception e) {
+			println(e.message)
 			System.exit(-1)
 		}
 	}

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/shortcut/WollokAllTestsLaunchShortcut.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/shortcut/WollokAllTestsLaunchShortcut.xtend
@@ -5,8 +5,10 @@ import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IProject
 import org.eclipse.jface.dialogs.MessageDialog
 import org.eclipse.swt.widgets.Display
+import org.uqbar.project.wollok.Messages
 
 import static org.uqbar.project.wollok.ui.launch.WollokLaunchConstants.*
+
 import static extension org.uqbar.project.wollok.utils.WEclipseUtils.*
 
 /**
@@ -33,17 +35,16 @@ class WollokAllTestsLaunchShortcut extends WollokTestLaunchShortcut {
 	 * - finally: launch tests
 	 */
 	override launch(IProject currProject, String mode) {
-		if (!checkEclipseProject(currProject)) return;
 		activateWollokTestResultView
 		val List<IFile> testFiles = currProject.getTestFiles
 		if (testFiles.empty) {
 			// TODO: i18n
-			MessageDialog.openError(Display.current.activeShell, "No tests to run",
-				"There are no tests to run")
+			MessageDialog.openError(Display.current.activeShell, Messages.TestLauncher_NoTestToRun_Title,
+				Messages.TestLauncher_NoTestToRun_Message)
 			return;
 		} 
 		val currFile = testFiles.head
-		this.launch(currFile, mode)
+		this.doLaunch(currFile, mode)
 	}
 	
 	def List<IFile> getTestFiles(IProject project) {

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/shortcut/WollokTestLaunchShortcut.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/tests/shortcut/WollokTestLaunchShortcut.xtend
@@ -1,8 +1,6 @@
 package org.uqbar.project.wollok.ui.tests.shortcut
 
 import org.eclipse.core.resources.IFile
-import org.eclipse.core.resources.IMarker
-import org.eclipse.core.resources.IResource
 import org.eclipse.core.runtime.CoreException
 import org.eclipse.jface.dialogs.MessageDialog
 import org.eclipse.swt.widgets.Display
@@ -16,7 +14,6 @@ import org.uqbar.project.wollok.ui.tests.WollokTestResultView
 import static org.uqbar.project.wollok.ui.launch.WollokLaunchConstants.*
 
 import static extension org.uqbar.project.wollok.ui.launch.shortcut.WDebugExtensions.*
-import org.eclipse.core.resources.IProject
 
 /**
  * @author tesonep
@@ -29,18 +26,15 @@ class WollokTestLaunchShortcut extends WollokLaunchShortcut {
 		x.doSave
 	}
 
-	override launch(IFile currFile, String mode) {
+	override doLaunch(IFile currFile, String mode) {
 		try {
-			// verifying there are no errors
-			if (!checkEclipseProject(currFile.project))
-				return;
 			activateWollokTestResultView
-			super.launch(currFile, mode)
+			super.doLaunch(currFile, mode)
 		} catch (CoreException e) {
 			// TODO: i18n
-			MessageDialog.openError(Display.current.activeShell, "Launcher error",
-				"There was a problem while opening test launcher. See error log for more details.")
-		// something went wrong
+			MessageDialog.openError(Display.current.activeShell, Messages.TestLauncher_LauncherError_Title,
+				Messages.TestLauncher_LauncherError_Message)
+			// something went wrong
 		}
 	}
 	
@@ -50,13 +44,4 @@ class WollokTestLaunchShortcut extends WollokLaunchShortcut {
 			]
 	}
 
-	def checkEclipseProject(IProject project) {
-		val severity = project.findMaxProblemSeverity(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE)
-		if (severity == IMarker.SEVERITY_ERROR) {
-			MessageDialog.openError(Display.current.activeShell, Messages.TestLauncher_CompilationErrorTitle,
-				Messages.TestLauncher_SeeProblemTab)
-			return false
-		}
-		return true
-	}
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
@@ -82,6 +82,10 @@ public class Messages extends NLS {
 	
 	public static String TestLauncher_CompilationErrorTitle;
 	public static String TestLauncher_SeeProblemTab;
+	public static String TestLauncher_LauncherError_Title;
+	public static String TestLauncher_LauncherError_Message;
+	public static String TestLauncher_NoTestToRun_Title;
+	public static String TestLauncher_NoTestToRun_Message;
 	
 	public static String WollokDslValidator_WRONG_IMPORT;
 	

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
@@ -107,7 +107,12 @@ WollokDslValidator_INCONSISTENT_HIERARCHY_MIXIN_CALLING_SUPER_NOT_FULLFILLED = I
 #
 
 TestLauncher_CompilationErrorTitle = Project has compilation errors
-TestLauncher_SeeProblemTab = See Problems View, correct them and launch again.
+TestLauncher_SeeProblemTab = You can see those errors in Problems View. Do you want to launch anyway?
+TestLauncher_LauncherError_Title = "Launcher error"
+TestLauncher_LauncherError_Message = "There was a problem while opening test launcher. See error log for more details."
+TestLauncher_NoTestToRun_Title = "No tests to run"
+TestLauncher_NoTestToRun_Message = "There are no tests to run"
+
 
 #
 # CHECK GROUPS

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
@@ -99,10 +99,14 @@ WollokDslValidator_CANNOT_USE_SELF_IN_A_PROGRAM = No se puede usar 'self' en un 
 
 WollokDslValidator_DONT_USE_WKONAME_WITHIN_IT = No debe usar el nombre del objeto dentro del mismo. Use 'self'.
 
-WollokDslValidator_DONT_DUPLICATE_TEST_DESCRIPTION = Los nombres de los tests deben ser únicos. ¿Por qué tendrían la misma descripción?
+WollokDslValidator_DONT_DUPLICATE_TEST_DESCRIPTION = Los nombres de los tests deben ser únicos. ¿Por qué tendrían la misma descripci\u00F3nn?
 
 TestLauncher_CompilationErrorTitle = El proyecto tiene errores de compilación
-TestLauncher_SeeProblemTab = Abra la vista "Problemas" y corríjalos antes de volver a ejecutar los tests
+TestLauncher_SeeProblemTab = Puede verlos en la vista "Problemas". ¿Está seguro de querer disparar la ejecuci\u00F3n?
+TestLauncher_LauncherError_Title = Error de ejecuci\u00F3n
+TestLauncher_LauncherError_Message = Ocurri\u00F3 un error al abrir la ejecuci\u00F3n de los tests. Consulte el log de errores para mayor informaci\u00F3n
+TestLauncher_NoTestToRun_Title = Ho hay tests para ejecutar
+TestLauncher_NoTestToRun_Message = No hay ningún tests para ejecutar
 
 WollokDslValidator_INCONSISTENT_HIERARCHY_MIXIN_CALLING_SUPER_NOT_FULLFILLED = Jerarquia inconsistente. Existen m\u00E9todos en mixins que requieren implementaci\u00F3n en super:
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/WEclipseUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/utils/WEclipseUtils.xtend
@@ -9,6 +9,7 @@ import java.util.Map
 import java.util.Set
 import org.eclipse.core.resources.IContainer
 import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IMarker
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IResource
 import org.eclipse.core.resources.IncrementalProjectBuilder
@@ -183,6 +184,11 @@ class WEclipseUtils {
 
 	def static dispatch Set<IResource> getAllMembers(IFile file) {
 		#{file}
+	}
+
+	def static hasErrors(IProject project) {
+		val severity = project.findMaxProblemSeverity(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE)
+		severity == IMarker.SEVERITY_ERROR
 	}
 	
 }


### PR DESCRIPTION
Now you have a Confirm Dialog message.
It works for Tests and Programs, it does also work for REPL console when not using .wlk with errors.
Also i18n messages were added.