### PR TITLE
Debug Perspective in Switch Perspective

### DIFF
--- a/org.uqbar.project.wollok.product.ui/plugin.xml
+++ b/org.uqbar.project.wollok.product.ui/plugin.xml
@@ -7,6 +7,9 @@
       <startup
             class="org.uqbar.project.wollok.product.ui.startup.RemoveWizardsStartup">
       </startup>
+      <startup
+            class="org.uqbar.project.wollok.product.ui.startup.OpenDebugPerspectiveOnStartup">
+      </startup>
    </extension>
 
 </plugin>

--- a/org.uqbar.project.wollok.product.ui/src/org/uqbar/project/wollok/product/ui/startup/OpenDebugPerspectiveOnStartup.xtend
+++ b/org.uqbar.project.wollok.product.ui/src/org/uqbar/project/wollok/product/ui/startup/OpenDebugPerspectiveOnStartup.xtend
@@ -1,0 +1,12 @@
+package org.uqbar.project.wollok.product.ui.startup
+
+import org.uqbar.project.wollok.ui.WollokUIStartup
+import org.eclipse.ui.PlatformUI
+
+class OpenDebugPerspectiveOnStartup implements WollokUIStartup {
+	val String DEBUG_PERSPECTIVE_NAME = "org.eclipse.debug.ui.DebugPerspective"
+	
+	override startup() {
+		PlatformUI.workbench.showPerspective(DEBUG_PERSPECTIVE_NAME, PlatformUI.workbench.activeWorkbenchWindow)
+	}
+}

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/perspectives/WollokCodingPerspectiveFactory.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/perspectives/WollokCodingPerspectiveFactory.xtend
@@ -47,11 +47,6 @@ class WollokCodingPerspectiveFactory implements IPerspectiveFactory {
 			addView("org.eclipse.ui.views.ContentOutline");
 		]
 		
-//		#681 - For release 1.5, static diagram will remain hidden for Wollok perspective
-//		createFolder("right", IPageLayout.BOTTOM, 0.25f, "org.eclipse.ui.views.ContentOutline") => [
-//			addView("org.uqbar.project.wollok.ui.diagrams.class");
-//		]
-		
 		addFastView("org.eclipse.team.ccvs.ui.RepositoriesView", 0.50f)
 		addFastView("org.eclipse.team.sync.views.SynchronizeView", 0.50f)
 	}


### PR DESCRIPTION
Adding the opening of the debug perspective in the startup to allow it appear in the switch perspective

Fixes #468