### PR TITLE
Fixing indentation for method creation

### DIFF
--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
@@ -6,7 +6,6 @@ import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EReference
 import org.eclipse.xtext.nodemodel.INode
-import org.eclipse.xtext.resource.EObjectAtOffsetHelper
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.ui.editor.model.IXtextDocument
 import org.eclipse.xtext.ui.editor.model.edit.IModificationContext

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
@@ -6,6 +6,7 @@ import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EReference
 import org.eclipse.xtext.nodemodel.INode
+import org.eclipse.xtext.resource.EObjectAtOffsetHelper
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.ui.editor.model.IXtextDocument
 import org.eclipse.xtext.ui.editor.model.edit.IModificationContext
@@ -26,6 +27,7 @@ import org.uqbar.project.wollok.wollokDsl.WIfExpression
 import org.uqbar.project.wollok.wollokDsl.WMemberFeatureCall
 import org.uqbar.project.wollok.wollokDsl.WMethodContainer
 import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
+import org.uqbar.project.wollok.wollokDsl.WNamedObject
 import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
 import org.uqbar.project.wollok.wollokDsl.WVariableReference
 import org.uqbar.project.wollok.wollokDsl.WollokDslFactory
@@ -38,7 +40,6 @@ import static extension org.uqbar.project.wollok.model.WMethodContainerExtension
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
 import static extension org.uqbar.project.wollok.ui.quickfix.QuickFixUtils.*
 import static extension org.uqbar.project.wollok.utils.XTextExtensions.*
-import org.uqbar.project.wollok.wollokDsl.WNamedObject
 
 /**
  * Custom quickfixes.
@@ -518,7 +519,7 @@ class WollokDslQuickfixProvider extends DefaultQuickfixProvider {
 
 	def int findPlaceToAddMethod(WMethodContainer it) {
 		val lastMethod = members.lastOf(WMethodDeclaration)
-		if (lastMethod !== null)
+		if (lastMethod !== null) 
 			return lastMethod.after
 		val lastConstructor = members.lastOf(WConstructor)
 		if (lastConstructor !== null)
@@ -603,8 +604,14 @@ class WollokDslQuickfixProvider extends DefaultQuickfixProvider {
 		if (container.methods.empty) {
 			return 1
 		}
-		val line = document.getLineOfOffset(placeToAdd)
-		placeToAdd - document.getLineOffset(line) - 1
+		val lineInformation = document.getLineInformationOfOffset(placeToAdd)
+		var textLine = document.get(lineInformation.offset, lineInformation.length)
+		var margin = 0
+		while (textLine.startsWith("\t")) {
+			margin++
+			textLine = textLine.substring(1)
+		}
+		margin
 	}
 
 }


### PR DESCRIPTION
Well, it is not a real fix on #1110, but it fixes indentation of new methods created by Quick Fix Provider.
