### PR TITLE
Fixed performance issue for describe & problem when closing static di…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: precise
 jdk:
 - oraclejdk8
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
 - mv settings.xml ~/.m2/settings.xml
 script:
 # Creates the correct profile to run
+- export MAVEN_OPTS=-Xmx2048m
 - cd org.uqbar.project.wollok.releng/
 - export PROFILES=normalProfile
 - if [ $TRAVIS_PULL_REQUEST == "false" -a $TRAVIS_BRANCH == "dev" ] ; then export

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
 - oraclejdk8
-- sudo: required
 before_install:
 - openssl aes-256-cbc -K $encrypted_d4a7eb0181c9_key -iv $encrypted_d4a7eb0181c9_iv
   -in settings.xml.enc -out settings.xml -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 dist: precise
+sudo: true
 jdk:
 - oraclejdk8
 before_install:
@@ -17,6 +18,7 @@ script:
 - echo "Running with profiles $PROFILES"
 
 # Maven build
+- export MAVEN_OPTS=-Xmx2048m
 - mvn -e -U -DupdateSiteFolder=$UPDATE_SITE -DTRAVIS_JOB_ID=$TRAVIS_JOB_ID clean install
   jacoco:report coveralls:report -P $PROFILES
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
 - oraclejdk8
-- dist: precise
 - sudo: required
 before_install:
 - openssl aes-256-cbc -K $encrypted_d4a7eb0181c9_key -iv $encrypted_d4a7eb0181c9_iv

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
 - oraclejdk8
 - dist: precise
+- sudo: required
 before_install:
 - openssl aes-256-cbc -K $encrypted_d4a7eb0181c9_key -iv $encrypted_d4a7eb0181c9_iv
   -in settings.xml.enc -out settings.xml -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
 - mv settings.xml ~/.m2/settings.xml
 script:
 # Creates the correct profile to run
-- export MAVEN_OPTS=-Xmx2048m
 - cd org.uqbar.project.wollok.releng/
 - export PROFILES=normalProfile
 - if [ $TRAVIS_PULL_REQUEST == "false" -a $TRAVIS_BRANCH == "dev" ] ; then export

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
 - oraclejdk8
+- dist: precise
 before_install:
 - openssl aes-256-cbc -K $encrypted_d4a7eb0181c9_key -iv $encrypted_d4a7eb0181c9_iv
   -in settings.xml.enc -out settings.xml -d

--- a/org.uqbar.project.wollok.ui.diagrams/src/org/uqbar/project/wollok/ui/diagrams/classes/StaticDiagramConfiguration.xtend
+++ b/org.uqbar.project.wollok.ui.diagrams/src/org/uqbar/project/wollok/ui/diagrams/classes/StaticDiagramConfiguration.xtend
@@ -435,6 +435,10 @@ class StaticDiagramConfiguration extends Observable implements Serializable {
 		}
 	}
 	
+	def resourceIsForStaticDiagram() {
+		originalFileName.endsWith(WollokConstants.CLASS_OBJECTS_EXTENSION)
+	}
+	
 }
 
 @Data

--- a/org.uqbar.project.wollok.ui.diagrams/src/org/uqbar/project/wollok/ui/diagrams/classes/StaticDiagramView.xtend
+++ b/org.uqbar.project.wollok.ui.diagrams/src/org/uqbar/project/wollok/ui/diagrams/classes/StaticDiagramView.xtend
@@ -161,6 +161,14 @@ class StaticDiagramView extends ViewPart implements ISelectionListener, ISourceV
 	}
 	
 	def createDiagramModel() {
+		// dodain - Enhanced performance
+		// Don't create diagram if you are editing a file 
+		//     that is not supposed to be synchronized with a static diagram (eg: tests files)
+		// or if static diagram was disposed
+		if (!configuration.resourceIsForStaticDiagram || splitter.isDisposed) {
+			return new StaticDiagram(configuration, #[])
+		}
+		
 		new StaticDiagram(configuration, xtextDocument.readOnly[ allElements ].toList) => [
 			
 			// all objects

--- a/org.uqbar.project.wollok.ui.diagrams/src/org/uqbar/project/wollok/ui/diagrams/classes/actionbar/StaticDiagramToolbarActions.xtend
+++ b/org.uqbar.project.wollok.ui.diagrams/src/org/uqbar/project/wollok/ui/diagrams/classes/actionbar/StaticDiagramToolbarActions.xtend
@@ -209,7 +209,7 @@ class ShowFileAction extends ControlContribution implements Observer {
 	}
 
 	override update(Observable o, Object event) {
-		if ((event?.equals(StaticDiagramConfiguration.CONFIGURATION_CHANGED)) && (label !== null)) {
+		if ((event?.equals(StaticDiagramConfiguration.CONFIGURATION_CHANGED)) && (label !== null) && !(label.disposed)) {
 			label.text = "  " + configuration.originalFileName + "  "
 			label.parent.requestLayout
 		}


### PR DESCRIPTION
…agram view

Refreshing an empty static diagram for a describe test file was lasting up to 16 seconds!! every time user was editing a file.

Now it prevents doing this (we should check why describe has such this performance issues in Outline view, for example), and also when static diagram is closed it does not update its view. 

Also if you close static diagram view an error message appeared while refreshing resource label. This was fixed.

Please @tesonep  consider merging it for 1.6.1 because it is important for students!