### PR TITLE
Improving performance in imports

### DIFF
--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokConstants.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokConstants.xtend
@@ -57,6 +57,7 @@ class WollokConstants {
 	public static val FIXTURE = "fixture" 
 	
 	public static val ROOT_CLASS = "Object"
+	public static val FQN_ROOT_CLASS = "wollok.lang.Object"
 	
 	public static val MULTIOPS_REGEXP = "[+\\-*/%]="
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokDslScopeProvider.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokDslScopeProvider.xtend
@@ -18,6 +18,7 @@ import org.uqbar.project.wollok.wollokDsl.WClosure
 import org.uqbar.project.wollok.wollokDsl.WConstructor
 import org.uqbar.project.wollok.wollokDsl.WExpression
 import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
+import org.uqbar.project.wollok.wollokDsl.WMixin
 import org.uqbar.project.wollok.wollokDsl.WNamed
 import org.uqbar.project.wollok.wollokDsl.WNamedObject
 import org.uqbar.project.wollok.wollokDsl.WObjectLiteral
@@ -26,7 +27,6 @@ import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
 
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
 import static extension org.uqbar.project.wollok.utils.XTextExtensions.*
-import org.uqbar.project.wollok.wollokDsl.WMixin
 
 /**
  * This class contains custom scoping description.
@@ -54,7 +54,7 @@ class WollokDslScopeProvider extends AbstractDeclarativeScopeProvider {
 	}
 	
 	def dispatch IScope scope(WClass clazz) {
-		val scope = if (clazz.parent != null)
+		val scope = if (clazz.parent !== null)
 			clazz.parent.scope + clazz.declaredVariables
 		else
 			clazz.declaredVariables.asScope

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokImportedNamespaceAwareLocalScopeProvider.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokImportedNamespaceAwareLocalScopeProvider.xtend
@@ -1,16 +1,23 @@
 package org.uqbar.project.wollok.scoping
 
 import com.google.inject.Inject
+import java.util.Iterator
 import java.util.List
 import org.eclipse.emf.ecore.EClass
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EReference
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.ecore.util.EcoreUtil
 import org.eclipse.xtext.naming.IQualifiedNameConverter
+import org.eclipse.xtext.naming.IQualifiedNameProvider
 import org.eclipse.xtext.resource.ISelectable
 import org.eclipse.xtext.scoping.IScope
+import org.eclipse.xtext.scoping.Scopes
+import org.eclipse.xtext.scoping.impl.AbstractGlobalScopeDelegatingScopeProvider
 import org.eclipse.xtext.scoping.impl.ImportNormalizer
-import org.eclipse.xtext.scoping.impl.ImportedNamespaceAwareLocalScopeProvider
+import org.eclipse.xtext.scoping.impl.MultimapBasedSelectable
 import org.eclipse.xtext.util.OnChangeEvictingCache
+import org.eclipse.xtext.util.Strings
 
 import static java.util.Collections.singletonList
 
@@ -21,49 +28,62 @@ import static extension org.uqbar.project.wollok.scoping.WollokScopeExtensions.*
  * @author tesonep
  * @author jfernandes
  */
-class WollokImportedNamespaceAwareLocalScopeProvider extends ImportedNamespaceAwareLocalScopeProvider {
+class WollokImportedNamespaceAwareLocalScopeProvider extends AbstractGlobalScopeDelegatingScopeProvider {
 	
 	@Inject
 	IQualifiedNameConverter qualifiedNameConverter
 	
-	override protected getImplicitImports(boolean ignoreCase) {
-		val implicits = super.getImplicitImports(ignoreCase)
+	@Inject
+	IQualifiedNameProvider qualifiedNameProvider;
+
+	
+	override getScope(EObject context, EReference reference) {
+		var IScope result;
+		
+		if (context.eContainer() !== null) {
+			result = getScope(context.eContainer(), reference);
+		} else {
+			result = getResourceScope(context.eResource(), reference);
+		}
+		return getLocalElementsScope(result, context, reference);
+	}
+	
+	def protected getResourceScope(Resource context, EReference reference){
+		val globalScope = getGlobalScope(context, reference)
+		val normalizers = getImportedNamespaceResolvers(context, reference)
+		
+		createImportScope(globalScope, normalizers, getAllDescriptions(context), reference.EReferenceType)
+	}	
+		
+	
+	def protected getImplicitImports() {
 		val r = newArrayList
-		r.add(new ImportNormalizer(qualifiedNameConverter.toQualifiedName("wollok.lib"), true, ignoreCase))
-		r.add(new ImportNormalizer(qualifiedNameConverter.toQualifiedName("wollok.lang"), true, ignoreCase))
-		r.addAll(implicits)
+		r.add(new ImportNormalizer(qualifiedNameConverter.toQualifiedName("wollok.lib"), true, false))
+		r.add(new ImportNormalizer(qualifiedNameConverter.toQualifiedName("wollok.lang"), true, false))
 		r
 	}
 	
-	/*
-	 * I override this to allow the relative imports, the original version only uses absolute imports.
-	 */
-	override protected getImportedNamespaceResolvers(EObject context, boolean ignoreCase) {
-		throw new RuntimeException("It should never reach here")
-	}
-	
-	def getImportedNamespaceResolvers(EObject context, boolean ignoreCase, IScope scope, EReference reference) {
-		val cache = new OnChangeEvictingCache().getOrCreate(context.eResource);
+	def getImportedNamespaceResolvers(Resource context, EReference reference) {
+		val cache = new OnChangeEvictingCache().getOrCreate(context);
 		var result = cache.get("ImportedNamespaceResolvers")
 		
 		if(result === null){
-//			val globalScope = globalScopeProvider.getScope()
-			result = doGetImportedNamespaceResolvers(context, ignoreCase, getGlobalScope(context.eResource, reference))
+			result = doGetImportedNamespaceResolvers(context.contents.get(0), getGlobalScope(context, reference))
 			cache.set("ImportedNamespaceResolvers", result)
 		}
 		
 		result
 	}
 	
-	def doGetImportedNamespaceResolvers(EObject context, boolean ignoreCase, IScope globalScope) {
-		val result = <ImportNormalizer>newArrayList()
-			
+	def doGetImportedNamespaceResolvers(EObject context, IScope globalScope) {
+		val result = getImplicitImports()
+					
 		val namespaces = context.allImports.map [ #[importedNamespace] + this.allRelativeImports(importedNamespace, context)].flatten.toSet
 
 		namespaces.filter [ ns | 
 			globalScope.containsImport(ns)
 		].forEach [
-			val normalizer = createImportedNamespaceResolver(it, ignoreCase)
+			val normalizer = createImportedNamespaceResolver(it)
 			if (normalizer !== null) {
 				result.add(normalizer)
 			}
@@ -71,36 +91,65 @@ class WollokImportedNamespaceAwareLocalScopeProvider extends ImportedNamespaceAw
 
 		result
 	}
-	
-	override protected getLocalElementsScope(IScope parent, EObject context, EReference reference) {
-		var result = parent;
-		var allDescriptions = getAllDescriptions(context.eResource());
-		var name = getQualifiedNameOfLocalElement(context);
-		var ignoreCase = isIgnoreCase(reference);
-		val List<ImportNormalizer> namespaceResolvers = getImportedNamespaceResolvers(context, ignoreCase, result, reference);
-		if (!namespaceResolvers.isEmpty()) {
-			if (isRelativeImport() && name!==null && !name.isEmpty()) {
-				val localNormalizer = doCreateImportNormalizer(name, true, ignoreCase); 
-				result = createImportScope(result, singletonList(localNormalizer), allDescriptions, reference.getEReferenceType(), isIgnoreCase(reference));
-			}
-			result = createImportScope(result, namespaceResolvers, null, reference.getEReferenceType(), isIgnoreCase(reference));
+
+	/**
+	 * Create a new {@link ImportNormalizer} for the given namespace.
+	 * @param namespace the namespace.
+	 * @param ignoreCase <code>true</code> if the resolver should be case insensitive.
+	 * @return a new {@link ImportNormalizer} or <code>null</code> if the namespace cannot be converted to a valid
+	 * qualified name.
+	 */
+	protected def ImportNormalizer createImportedNamespaceResolver(String namespace) {
+		if (Strings.isEmpty(namespace))
+			return null;
+		val importedNamespace = qualifiedNameConverter.toQualifiedName(namespace);
+		if (importedNamespace === null || importedNamespace.isEmpty()) {
+			return null;
 		}
+		val hasWildCard = importedNamespace.getLastSegment().equals("*")
+
+		if (hasWildCard) {
+			if (importedNamespace.getSegmentCount() <= 1)
+				return null;
+			return new ImportNormalizer(importedNamespace.skipLast(1), true, false);
+		} else {
+			return new ImportNormalizer(importedNamespace, false, false);
+		}
+	}
+
+	
+	def protected getLocalElementsScope(IScope parent, EObject context, EReference reference) {
+		var result = parent;
+		var name = qualifiedNameProvider.getFullyQualifiedName(context);
+		var ignoreCase = isIgnoreCase(reference);
+
 		if (name!==null) {
-			val localNormalizer = doCreateImportNormalizer(name, true, ignoreCase); 
-			result = createImportScope(result, singletonList(localNormalizer), allDescriptions, reference.getEReferenceType(), isIgnoreCase(reference));
+			val localNormalizer = new ImportNormalizer(name, true, ignoreCase); 
+			result = createImportScope(result, singletonList(localNormalizer), null, reference.EReferenceType);
 		}
 		return result;
 	}
 	
-	override protected createImportScope(IScope parent, List<ImportNormalizer> namespaceResolvers, ISelectable importFrom, EClass type, boolean ignoreCase) {
+	protected def getAllDescriptions(Resource resource) {
+		val Iterable<EObject> allContents = new Iterable<EObject>(){
+			override Iterator<EObject> iterator() {
+				EcoreUtil.getAllContents(resource, false);
+			}
+		}; 
+		val allDescriptions = Scopes.scopedElementsFor(allContents, qualifiedNameProvider);
+		return new MultimapBasedSelectable(allDescriptions);
+	}
+
+
+	def protected createImportScope(IScope parent, List<ImportNormalizer> namespaceResolvers, ISelectable importFrom, EClass type) {
 		if(parent instanceof WollokImportScope){
 			val parentImport = parent as WollokImportScope
 
-			if(parentImport.normalizers == namespaceResolvers && importFrom == parentImport.rawImportFrom && type == parentImport.type)
+			if(parentImport.normalizers == namespaceResolvers && importFrom === null && parentImport.type == type)
 				return parentImport
 		}
 		
-		new WollokImportScope(namespaceResolvers, parent, importFrom, type, ignoreCase)
+		new WollokImportScope(namespaceResolvers, parent, importFrom, type)
 	}
 
 	def Iterable<String> allRelativeImports(String importedNamespace, EObject context){

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokQualifiedNameProvider.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokQualifiedNameProvider.xtend
@@ -22,7 +22,7 @@ class WollokQualifiedNameProvider extends DefaultDeclarativeQualifiedNameProvide
 		do {
 			container = container.eContainer
 			fqn = container.fullyQualifiedName
-		} while (fqn == null)
+		} while (fqn === null)
 		
 		val idx = container.eAllContents.indexed.findFirst[ it.value == obj ].key
 		

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/serializer/WollokDslSyntacticSequencerWithSyntheticLinking.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/serializer/WollokDslSyntacticSequencerWithSyntheticLinking.xtend
@@ -3,9 +3,10 @@ package org.uqbar.project.wollok.serializer
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.RuleCall
 import org.eclipse.xtext.nodemodel.ICompositeNode
+import org.uqbar.project.wollok.WollokConstants
+import org.uqbar.project.wollok.linking.WollokLinker
 import org.uqbar.project.wollok.wollokDsl.WClass
 import org.uqbar.project.wollok.wollokDsl.WNamedObject
-import org.uqbar.project.wollok.linking.WollokLinker
 
 /**
  * This syntactic sequencer is aware of synthetic links and ignores them during serialization
@@ -24,6 +25,6 @@ class WollokDslSyntacticSequencerWithSyntheticLinking extends WollokDslSyntactic
 	 * @see WollokLinker
 	 */	
 	def isSynthetic(ICompositeNode node, String token, EObject value) {
-		node == null && token == "Object" && (value instanceof WClass || value instanceof WNamedObject)
+		node === null && (token == WollokConstants.ROOT_CLASS || token == WollokConstants.FQN_ROOT_CLASS) && (value instanceof WClass || value instanceof WNamedObject)
 	}
 }


### PR DESCRIPTION
I have reimplemented a custom Importing Scope schema. 
Having so permited us to know completely what are the rules to look up of the elements and it is simpler than the one implemented in Xtext, as the one implemented in xtext is more general and permits use cases that we don't need.