### PR TITLE
Stack trace fixes

### DIFF
--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/interpreter/WollokREPLInterpreter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/interpreter/WollokREPLInterpreter.xtend
@@ -25,5 +25,5 @@ class WollokREPLInterpreter extends WollokInterpreter {
 		new XStackFrame(root, nativeLobby, WollokSourcecodeLocator.INSTANCE)
 	}
 
-	override isREPL() { true }
+	override isRootFile() { true }
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/interpreter/WollokREPLInterpreter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/interpreter/WollokREPLInterpreter.xtend
@@ -25,4 +25,5 @@ class WollokREPLInterpreter extends WollokInterpreter {
 		new XStackFrame(root, nativeLobby, WollokSourcecodeLocator.INSTANCE)
 	}
 
+	override isREPL() { true }
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherInterpreterEvaluator.xtend
@@ -34,10 +34,10 @@ class WollokLauncherInterpreterEvaluator extends WollokInterpreterEvaluator {
 		if (main !== null)
 			main.eval
 		else {
-			val isASuite = tests.empty && suite !== null
+			val _isASuite = isASuite
 			var testsToRun = tests
 			var String suiteName = null
-			if (isASuite) {
+			if (_isASuite) {
 				suiteName = suite.name
 				testsToRun = suite.tests
 			}
@@ -45,7 +45,7 @@ class WollokLauncherInterpreterEvaluator extends WollokInterpreterEvaluator {
 			try {
 				testsToRun.fold(null) [ a, _test |
 					resetGlobalState
-					if (isASuite) {
+					if (_isASuite) {
 						_test.evalInSuite(suite)
 					} else {
 						_test.eval

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokExceptionUtils.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokExceptionUtils.xtend
@@ -13,6 +13,8 @@ import static org.uqbar.project.wollok.sdk.WollokDSK.*
 
 import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions.*
 
+import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
+
 class WollokExceptionUtils {
 
 
@@ -31,22 +33,6 @@ class WollokExceptionUtils {
 		wollokException.internalStackTraceToDTO
 	}
 
-	private static def internalStackTraceToDTO(WollokObject fullStackTrace) {
-		val stackTrace = fullStackTrace.call("getFullStackTrace").wollokToJava(List) as List<WollokObject>
-		stackTrace.map [ wo |
-			val contextDescription = wo.call("contextDescription").wollokToJava(String) as String
-			val location = wo.call("location").wollokToJava(String) as String
-			val data = location.split(",")
-			val fileName = data.get(0)
-			var Integer lineNumber = 0
-			try {
-				lineNumber = new Integer(data.get(1))
-			} catch (NumberFormatException e) {
-			}
-			new StackTraceElementDTO(contextDescription, fileName, lineNumber)
-		]
-	}
-
 	/**
 	 * Converts an exception to a String
 	 */
@@ -54,7 +40,7 @@ class WollokExceptionUtils {
 		val wollokException = exception.wollokException
 		val className = wollokException.call("className").wollokToJava(String) as String
 		val message = exception.wollokMessage
-		val concatMessage = if (message != null) ": " + message else "" 
+		val concatMessage = if (message !== null) ": " + message else "" 
 		return className + concatMessage
 	}
 
@@ -72,20 +58,20 @@ class WollokExceptionUtils {
 	 * Prepares an exception for a RMI call
 	 */
 	def static dispatch void prepareExceptionForTrip(Throwable e) {
-		if (e.cause != null)
+		if (e.cause !== null)
 			e.cause.prepareExceptionForTrip
 	}
 
 	def static dispatch void prepareExceptionForTrip(WollokInterpreterException e) {
 		e.sourceElement = null
 
-		if (e.cause != null)
+		if (e.cause !== null)
 			e.cause.prepareExceptionForTrip
 	}
 
 	def static dispatch void prepareExceptionForTrip(WollokProgramExceptionWrapper e) {
 		e.URI = null
-		if (e.cause != null)
+		if (e.cause !== null)
 			e.cause.prepareExceptionForTrip
 	}
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/StackTraceElementDTO.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/StackTraceElementDTO.xtend
@@ -1,9 +1,7 @@
 package org.uqbar.project.wollok.errorHandling
 
 import java.io.Serializable
-import java.util.List
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.uqbar.project.wollok.WollokConstants
 
 import static org.uqbar.project.wollok.WollokConstants.*
 
@@ -13,8 +11,6 @@ class StackTraceElementDTO implements Serializable {
 	Integer lineNumber
 	String fileName
 
-	public static List<String> REPL_STACK_WORDS = #[WollokConstants.SYNTHETIC_FILE, WollokConstants.REPL_FILE]
-		
 	new(String contextDescription, String fileName, int lineNumber) {
 		this.contextDescription = contextDescription
 		this.fileName = fileName
@@ -25,11 +21,11 @@ class StackTraceElementDTO implements Serializable {
 		val result = new StringBuffer
 		result.append("   ")
 		result.append("at ") 
-		if (contextDescription != null) {
+		if (contextDescription !== null) {
 			result.append(contextDescription)
 			result.append(" ")
 		}
-		if (fileName != null && !fileName.isEmpty) {
+		if (fileName !== null && !fileName.isEmpty) {
 			result.append("[<a href=\"" + fileName + STACKELEMENT_SEPARATOR + lineNumber + "\">" + fileName.location(lineNumber) + "</a>]\n")
 		}
 		result.toString
@@ -50,18 +46,10 @@ class StackTraceElementDTO implements Serializable {
 		new StackTraceElement(contextDescription ?: "","", fileName, lineNumber)
 	}
 	
-	def shouldBeFiltered() {
-		if (fileName === null || fileName.trim.equals("")) return true;
-		REPL_STACK_WORDS.map [ toLowerCase ].exists [ word |
-			fileName?.toLowerCase.contains(word)
-		]
-	}
-	
-	
-	def hasFileName() { fileName != null && !fileName.isEmpty }
+	def hasFileName() { fileName !== null && !fileName.isEmpty }
 	
 	def safeCompare(String string, String string2) {
-		(string == null && string2 == null) || (string !== null && string.equals(string2))
+		(string === null && string2 === null) || (string !== null && string.equals(string2))
 	}
 	
 	override equals(Object obj) {
@@ -77,5 +65,30 @@ class StackTraceElementDTO implements Serializable {
 	override hashCode() {
 		((fileName ?: "") + (contextDescription ?: "") + lineNumber.toString).hashCode
  	}
+ 	
+ 	def getContextForStackTrace() {
+ 		val result = new StringBuffer => [
+			append("   ")
+			append("at")
+			append(" ")
+			if (contextDescription !== null) {
+				append(contextDescription)
+				append(" ")
+			}
+		]
+		result.toString
+ 	}
+ 	
+ 	def getLinkForStackTrace() {
+ 		val result = new StringBuffer => [
+			if (hasFileName) {
+				append("(" + fileName + ":" + lineNumber + ")")
+			}
+ 		]
+		result.toString 			
+ 	}
 	
+	def getElementForStackTrace() {
+		contextForStackTrace + linkForStackTrace
+	}
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/WollokExceptionExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/WollokExceptionExtensions.xtend
@@ -19,7 +19,6 @@ import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJav
  */
 class WollokExceptionExtensions {
 
-
 	/**
 	 * Converts a StackTraceElementDTO to a List of parseable Strings for a RMI call
 	 */
@@ -35,7 +34,7 @@ class WollokExceptionExtensions {
 		wollokException.internalStackTraceToDTO
 	}
 
-	private static def internalStackTraceToDTO(WollokObject fullStackTrace) {
+	def static internalStackTraceToDTO(WollokObject fullStackTrace) {
 		val stackTrace = fullStackTrace.call("getFullStackTrace").wollokToJava(List) as List<WollokObject>
 		val result = newArrayList 
 		stackTrace.forEach [ wo |
@@ -154,7 +153,7 @@ class WollokExceptionExtensions {
 	}
 	
 	def static String printStackTrace(StackTraceElementDTO[] stackTrace) {
-		stackTrace.reverse.fold("", [ acum, ste | acum + ste.toLink ])
+		stackTrace.fold("", [ acum, ste | acum + ste.toLink ])
 	}
 	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreter.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreter.xtend
@@ -23,6 +23,7 @@ import org.uqbar.project.wollok.interpreter.stack.XStackFrame
 import org.uqbar.project.wollok.interpreter.threads.WThread
 
 import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
+import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
 
 /**
  * XInterpreter impl for Wollok language.
@@ -78,7 +79,6 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 			interpret(rootObject, false)
 		} catch (WollokProgramExceptionWrapper e) {
 			// todo: what about "propagating errors?"
-			//e.wollokException.call("printStackTrace")
 			e.printStackTraceInConsole
 			throw e
 		}
@@ -89,7 +89,6 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 			interpret(eObjects, folder, false)
 		} catch (WollokProgramExceptionWrapper e) {
 			// todo: what about "propagating errors?"
-			//e.wollokException.call("printStackTrace")
 			e.printStackTraceInConsole
 			throw e
 		}
@@ -240,5 +239,5 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 		globalVariables.remove(name)
 	}
 
-	def isREPL() { false }
+	def isRootFile() { rootContext.isASuite	}
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreter.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreter.xtend
@@ -22,6 +22,8 @@ import org.uqbar.project.wollok.interpreter.stack.ReturnValueException
 import org.uqbar.project.wollok.interpreter.stack.XStackFrame
 import org.uqbar.project.wollok.interpreter.threads.WThread
 
+import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
+
 /**
  * XInterpreter impl for Wollok language.
  * Control's the execution flow and stack.
@@ -76,17 +78,19 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 			interpret(rootObject, false)
 		} catch (WollokProgramExceptionWrapper e) {
 			// todo: what about "propagating errors?"
-			e.wollokException.call("printStackTrace")
+			//e.wollokException.call("printStackTrace")
+			e.printStackTraceInConsole
 			throw e
 		}
 	}
-
+	
 	def interpret(List<EObject> eObjects, String folder) {
 		try {
 			interpret(eObjects, folder, false)
 		} catch (WollokProgramExceptionWrapper e) {
 			// todo: what about "propagating errors?"
-			e.wollokException.call("printStackTrace")
+			//e.wollokException.call("printStackTrace")
+			e.printStackTraceInConsole
 			throw e
 		}
 	}
@@ -120,6 +124,17 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 			}
 		} finally
 			debugger.terminated
+	}
+
+	def void printStackTraceInConsole(WollokProgramExceptionWrapper e) {
+		println((e.exceptionClassName + ": " + e.wollokMessage))
+		val errorLine = e.wollokException
+			.convertStackTrace
+			.toList
+			.map [ stackDTO | stackDTO.elementForStackTrace ]
+			.join(System.lineSeparator)
+		
+		println(errorLine)
 	}
 
 	def evalBinary(WollokObject a, String operand, WollokObject b) {
@@ -225,4 +240,5 @@ class WollokInterpreter implements XInterpreter<EObject>, IWollokInterpreter, Se
 		globalVariables.remove(name)
 	}
 
+	def isREPL() { false }
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokNativeLobby.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokNativeLobby.xtend
@@ -82,6 +82,6 @@ class WollokNativeLobby extends AbstractWollokDeclarativeNativeObject implements
 	
 	override toString() { "Lobby" }
 
-	override showableInStackTrace() { !interpreter.isREPL }
+	override showableInStackTrace() { !interpreter.isRootFile }
 	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokNativeLobby.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokNativeLobby.xtend
@@ -82,4 +82,6 @@ class WollokNativeLobby extends AbstractWollokDeclarativeNativeObject implements
 	
 	override toString() { "Lobby" }
 
+	override showableInStackTrace() { !interpreter.isREPL }
+	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokObject.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/core/WollokObject.xtend
@@ -252,7 +252,8 @@ class WollokObject extends AbstractWollokCallable implements EvaluationContext<W
 			throw throwMessageNotUnderstood(this, message, parameters)
 		method.call(parameters)
 	}
-	
+
+	override showableInStackTrace() { true }	
 }
 
 /**

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/nativeobj/AbstractWollokDeclarativeNativeObject.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/nativeobj/AbstractWollokDeclarativeNativeObject.xtend
@@ -109,5 +109,7 @@ abstract class AbstractWollokDeclarativeNativeObject implements WCallable {
 	
 	def newInstance(Number naitive) {
 		(interpreter.evaluator as WollokInterpreterEvaluator).getOrCreateNumber(naitive.toString)
-	} 
+	}
+	
+	def showableInStackTrace() { true } 
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
@@ -599,4 +599,7 @@ class WollokModelExtensions {
 		if (isMultiOpAssignment) feature.substring(0, 1)
 		else throw new UnsupportedOperationException("Binary operation is not a compound assignment.")
 	}
+	
+	def static dispatch isASuite(EObject o) { false }
+	def static dispatch isASuite(WFile it) { tests.empty && suite !== null }
 }

--- a/org.uqbar.project.wollok/src/wollok/lang/Exception.xtend
+++ b/org.uqbar.project.wollok/src/wollok/lang/Exception.xtend
@@ -23,17 +23,23 @@ class Exception {
 	
 	new(WollokObject object, WollokInterpreter interpreter) {
 		exceptionObject = object
-		stackTrace = interpreter.currentThread.stack.map[f| f.currentLocation].clone
+		stackTrace = interpreter
+			.currentThread
+			.stack
+			.filter [ frame | frame.context.showableInStackTrace ]
+			.map[f| f.currentLocation ]
+			.clone
+			.reverse
 	}
 	
 	def getStackTrace() {
-		stackTrace.reverse.map[ 
+		stackTrace.map[ 
 			exceptionObject.call("createStackTraceElement", contextDescription.javaToWollok, location.toString.javaToWollok)
 		].toList
 	}
 
 	def getFullStackTrace() {
-		stackTrace.reverse.map[ 
+		stackTrace.map[ 
 			exceptionObject.call("createStackTraceElement", contextDescription.javaToWollok, fullLocation.toString.javaToWollok)
 		].toList
 	}

--- a/org.uqbar.project.xinterpreter/src/org/uqbar/project/wollok/interpreter/context/CompositeEvaluationContext.xtend
+++ b/org.uqbar.project.xinterpreter/src/org/uqbar/project/wollok/interpreter/context/CompositeEvaluationContext.xtend
@@ -64,5 +64,7 @@ class CompositeEvaluationContext<O> implements EvaluationContext<O> {
 	def dispatch asText(CompositeEvaluationContext it) { toString }
 	def dispatch asText(MapBasedEvaluationContext it) { toString }
 	def dispatch asText(EvaluationContext it) { class.simpleName }
+	
+	override showableInStackTrace() { true }
 
 }

--- a/org.uqbar.project.xinterpreter/src/org/uqbar/project/wollok/interpreter/context/EvaluationContext.xtend
+++ b/org.uqbar.project.xinterpreter/src/org/uqbar/project/wollok/interpreter/context/EvaluationContext.xtend
@@ -25,6 +25,7 @@ interface EvaluationContext<O> extends Serializable {
 	def Iterable<WVariable> allReferenceNames()
 	
 	def O getThisObject()
+	def boolean showableInStackTrace()
 }
 
 /**

--- a/org.uqbar.project.xinterpreter/src/org/uqbar/project/wollok/interpreter/context/MapBasedEvaluationContext.xtend
+++ b/org.uqbar.project.xinterpreter/src/org/uqbar/project/wollok/interpreter/context/MapBasedEvaluationContext.xtend
@@ -52,5 +52,6 @@ class MapBasedEvaluationContext<O> implements EvaluationContext<O> {
 	override toString() {
 		class.simpleName + "{" + values.entrySet.map[key + ":" + (if(value===null)"null" else value.class)].join(',') + '}'
 	}
-	
+
+	override showableInStackTrace() { true }	
 }


### PR DESCRIPTION
Today if you have this test:

```javascript
class Ave {
	method volar() {
		const x = 1 / 0
	}
}

test "testX" {
	assert.that(true)
}
test "use empty"{
	new Ave().volar()
	assert.equals(true)
}
```

- Stacktrace is reversed
![image](https://user-images.githubusercontent.com/4549002/30933597-62eaf462-a3a1-11e7-8500-99ad35bf47f6.png)

- If you have isolated tests everything works fine, but if you have a describe, then its file definition is printed in stack trace (see the line test.wtest:1, which points to file definition):
![image](https://user-images.githubusercontent.com/4549002/30933667-9c44c67a-a3a1-11e7-9c17-c2a15d452431.png)

- A program like this

```javascript
import example.*

program abc {
	console.println('Hello Wollok')
	new Ave().volar()
}
```
produces this output:

```bash
Hello Wollok
wollok.lang.Exception: / by zero
	at wollok.lang.Integer./(other) [/lang.wlk:1094]
	at example.Ave.volar() [/example.wlk:5]
	at  [/program.wpgm:6]
```

So stack trace is also reversed, but also links to source files does not work, because "/lang.wlk" does not exist.

- In a REPL stack trace is reversed and also a strange "objects.wlk:1" is shown:

```bash
>>> new Ave().volar()
wollok.lang.Exception: / by zero
   at (/home/fernando/Desktop/IDEs/workspace/dadaisIssue1276/src/example.wlk:1)
   at example.Ave.volar() (/home/fernando/Desktop/IDEs/workspace/dadaisIssue1276/src/example.wlk:5)
   at wollok.lang.Integer./(other) (classpath:/wollok/lang.wlk:1094)
```

Also an assert message produces a strange output:

```bash
>>> new Ave().volar()
wollok.lang.Exception: / by zero
   at (/home/fernando/Desktop/IDEs/workspace/dadaisIssue1276/src/example.wlk:1)
   at example.Ave.volar() (/home/fernando/Desktop/IDEs/workspace/dadaisIssue1276/src/example.wlk:5)
   at wollok.lang.Integer./(other) (classpath:/wollok/lang.wlk:1094)
```

"example.wlk:1" is the file definition being run in REPL.