### PR TITLE
Fix #1083

### DIFF
--- a/org.uqbar.project.wollok.ui/plugin.xml
+++ b/org.uqbar.project.wollok.ui/plugin.xml
@@ -434,6 +434,32 @@
             </attribute>
         </markerResolutionGenerator>
     </extension>
+    
+    <!-- Rename Resource -->
+	<extension
+		point="org.eclipse.ltk.core.refactoring.renameParticipants">
+ 		<renameParticipant
+            class="org.uqbar.project.wollok.ui.WollokDslExecutableExtensionFactory:org.uqbar.project.wollok.renaming.WollokResourceRenameParticipant"
+            id="dsl.ui.refactoring.resourceRenameParticipant"
+            name="Wollok Rename Participant">
+	         <enablement>
+	         	<with variable="element">
+		         <or>
+		           <instanceof
+	                  value="org.eclipse.core.resources.IFile">
+	               </instanceof>
+		           <instanceof
+	                  value="org.eclipse.core.resources.IProject">
+	               </instanceof>
+		           <instanceof
+	                  value="org.eclipse.jdt.core.IPackageFragment">
+	               </instanceof>
+		         </or>
+		         </with>
+	         </enablement>
+      </renameParticipant>
+	</extension>
+    
    	<!-- Rename Refactoring -->
 	<extension point="org.eclipse.ui.handlers">
 		<handler 

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/renaming/WollokResourceRenameParticipant.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/renaming/WollokResourceRenameParticipant.xtend
@@ -1,0 +1,15 @@
+package org.uqbar.project.wollok.renaming
+
+import com.google.inject.Inject
+import org.eclipse.xtext.common.types.ui.refactoring.participant.JdtRenameParticipant
+import org.uqbar.project.wollok.scoping.WollokResourceCache
+import org.uqbar.project.wollok.scoping.cache.WollokGlobalScopeCache
+
+class WollokResourceRenameParticipant extends JdtRenameParticipant {
+	
+	override protected initialize(Object originalTargetElement) {
+		WollokResourceCache.clearResourceCache
+		super.initialize(originalTargetElement)
+	}
+	
+}

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/WollokDslUiModule.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/WollokDslUiModule.xtend
@@ -51,44 +51,42 @@ class WollokDslUiModule extends AbstractWollokDslUiModule {
 	}
 	
 	override configure(Binder binder) {
-		super.configure(binder);
+		super.configure(binder)
 
-		binder.bind(EObjectAtOffsetHelper).to(WollokEObjectAtOffsetHelper);
-		binder.bind(IEObjectHoverProvider).to(WollokEObjectHoverProvider);
+		binder.bind(EObjectAtOffsetHelper).to(WollokEObjectAtOffsetHelper)
+		binder.bind(IEObjectHoverProvider).to(WollokEObjectHoverProvider)
 		binder.bind(WollokLibraries).to(WollokUILibraries)
 	}
 	
-	
-		
 	override bindITemplateProposalProvider() {
-		WollokTemplateProposalProvider;
+		WollokTemplateProposalProvider
 	}
 	
 	def Class<? extends IHighlightingConfiguration> bindIHighlightingConfiguration () {
-		WollokHighlightingConfiguration;
+		WollokHighlightingConfiguration
 	}
 	
 	def configureOverrideIndicatorSupport(Binder binder) {
-		binder.bind(IXtextEditorCallback).annotatedWith(Names.named("OverrideIndicatorModelListener")).to(WOverrideIndicatorModelListener);
-		binder.bind(IActionContributor).annotatedWith(Names.named("OverrideIndicatorRulerAction")).to(WOverrideRulerAction);
+		binder.bind(IXtextEditorCallback).annotatedWith(Names.named("OverrideIndicatorModelListener")).to(WOverrideIndicatorModelListener)
+		binder.bind(IActionContributor).annotatedWith(Names.named("OverrideIndicatorRulerAction")).to(WOverrideRulerAction)
 		
-		binder.bind(IHighlightingConfiguration).to(WollokHighlightingConfiguration);
-		binder.bind(ISemanticHighlightingCalculator).to(WollokHighlightingCalculator);
+		binder.bind(IHighlightingConfiguration).to(WollokHighlightingConfiguration)
+		binder.bind(ISemanticHighlightingCalculator).to(WollokHighlightingCalculator)
 		
 		// Hacks to be able to reuse the logic to extract method from refactoring
-		binder.bind(IJvmModelAssociations).to(DummyJvmModelAssociations); 
-		binder.bind(IJvmTypeProvider.Factory).to(DummyJvmTypeProviderFactory);
-		binder.bind(TypesFactory).toInstance(TypesFactory.eINSTANCE);
+		binder.bind(IJvmModelAssociations).to(DummyJvmModelAssociations) 
+		binder.bind(IJvmTypeProvider.Factory).to(DummyJvmTypeProviderFactory)
+		binder.bind(TypesFactory).toInstance(TypesFactory.eINSTANCE)
 		
 	}
 	
 	
 	def Class<? extends IProjectCreator> bindIProjectCreator() {
-		WollokProjectCreator;
+		WollokProjectCreator
 	}
 	
 	override provideIAllContainersState() {
-		Access.getWorkspaceProjectsState();
+		Access.getWorkspaceProjectsState()
 	}
 
 	def Class<? extends PluginProjectFactory>bindPluginProjectFactory(){
@@ -114,7 +112,5 @@ class WollokDslUiModule extends AbstractWollokDslUiModule {
 	def Class<? extends AbstractAntlrTokenToAttributeIdMapper> bindAbstractAntlrTokenToAttributeIdMapper(){
 		WollokAntlrTokenToAttributeIdMapper
 	}
-	
-	
-	
+
 }

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/editor/hyperlinking/WollokEObjectAtOffsetHelper.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/editor/hyperlinking/WollokEObjectAtOffsetHelper.xtend
@@ -38,8 +38,8 @@ class WollokEObjectAtOffsetHelper extends EObjectAtOffsetHelper {
 	WollokGlobalScopeProvider scopeProvider
 
 	override protected findCrossReferenceNode(INode node) {
-		val semantic = node.semanticElement
-		if (semantic.isCrossReference(node)) {
+		val semantic = node?.semanticElement
+		if (semantic !== null && semantic.isCrossReference(node)) {
 			node
 		} else {
 			super.findCrossReferenceNode(node)

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/GenerateWollokDsl.mwe2
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/GenerateWollokDsl.mwe2
@@ -97,6 +97,11 @@ Workflow {
 			serializer = {
 				generateStub = false
 			}
+			
+			// rename refactoring
+			fragment = ui.refactoring.RefactorElementNameFragment2 auto-inject {
+				useJdtRefactoring = true
+			}
 		}
 	}
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokGlobalScopeProvider.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokGlobalScopeProvider.xtend
@@ -70,7 +70,7 @@ class WollokGlobalScopeProvider extends DefaultGlobalScopeProvider {
 	def synchronized calculateImports(Resource context) {
 		val importsCache = new OnChangeEvictingCache().getOrCreate(context)
 		var result = importsCache.get("ImportsInResource")
-
+		
 		if (result === null) {
 			val rootObject = context.contents.get(0)
 			// dodain - forcing to refresh global cache when resource changes

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokResourceDescriptionStrategy.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokResourceDescriptionStrategy.xtend
@@ -8,6 +8,8 @@ import org.eclipse.xtext.util.IAcceptor
 import org.uqbar.project.wollok.wollokDsl.WFile
 import org.uqbar.project.wollok.wollokDsl.WMethodContainer
 import org.uqbar.project.wollok.wollokDsl.WPackage
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.resource.IReferenceDescription
 
 /**
  * Customizes the strategy in order to avoid exporting all "named" objects
@@ -31,6 +33,18 @@ class WollokResourceDescriptionStrategy extends DefaultResourceDescriptionStrate
 		}
 		else
 			false
+	}
+
+	override createReferenceDescriptions(EObject from, URI exportedContainerURI, IAcceptor<IReferenceDescription> acceptor) {
+		try {
+			return super.createReferenceDescriptions(from, exportedContainerURI, acceptor)
+		} catch (Exception e) {
+			e.printStackTrace
+			println(e)
+			println(from)
+			println("URI: " + exportedContainerURI)
+			return true
+		} 
 	}
 	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokResourceDescriptionStrategy.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/scoping/WollokResourceDescriptionStrategy.xtend
@@ -1,15 +1,17 @@
 package org.uqbar.project.wollok.scoping
 
 import com.google.inject.Singleton
+import org.apache.commons.logging.Log
+import org.apache.commons.logging.LogFactory
+import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.resource.IEObjectDescription
+import org.eclipse.xtext.resource.IReferenceDescription
 import org.eclipse.xtext.resource.impl.DefaultResourceDescriptionStrategy
 import org.eclipse.xtext.util.IAcceptor
 import org.uqbar.project.wollok.wollokDsl.WFile
 import org.uqbar.project.wollok.wollokDsl.WMethodContainer
 import org.uqbar.project.wollok.wollokDsl.WPackage
-import org.eclipse.emf.common.util.URI
-import org.eclipse.xtext.resource.IReferenceDescription
 
 /**
  * Customizes the strategy in order to avoid exporting all "named" objects
@@ -21,6 +23,7 @@ import org.eclipse.xtext.resource.IReferenceDescription
  */
 @Singleton
 class WollokResourceDescriptionStrategy extends DefaultResourceDescriptionStrategy {
+	static Log log = LogFactory.getLog(WollokResourceDescriptionStrategy)
 	
 	override createEObjectDescriptions(EObject eObject, IAcceptor<IEObjectDescription> acceptor) {
 		if (eObject instanceof WFile)
@@ -39,12 +42,9 @@ class WollokResourceDescriptionStrategy extends DefaultResourceDescriptionStrate
 		try {
 			return super.createReferenceDescriptions(from, exportedContainerURI, acceptor)
 		} catch (Exception e) {
-			e.printStackTrace
-			println(e)
-			println(from)
-			println("URI: " + exportedContainerURI)
+			log.error("Outdated references for " + from + ":" + exportedContainerURI, e)
 			return true
-		} 
+		}
 	}
 	
 }


### PR DESCRIPTION
I think this PR fixes annoying #1083 .

This was what I did

- add a rename participant, so when it initializes it clears Wollok resource cache
- avoid error in editor when renaming whole project (a NPE was thrown in WollokEObjectAtOffsetHelper)
- and finally, instead of an error popup, Wollok now logs an error silently (I know this is not the best option, but as far as I tested it did never happen).
