### PR TITLE
Replacing current to archived repository for egit

### DIFF
--- a/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
+++ b/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
@@ -46,7 +46,8 @@
 <unit id="org.eclipse.egit.mylyn.feature.group" version="4.8.0.201706111038-r"/>
 <unit id="org.eclipse.egit.feature.group" version="4.8.0.201706111038-r"/>
 <unit id="org.eclipse.egit.source.feature.group" version="4.8.0.201706111038-r"/>
-<repository location="http://download.eclipse.org/egit/updates/"/>
+<!--repository location="http://download.eclipse.org/egit/updates/"/-->
+<repository location="http://eclipse.c3sl.ufpr.br/egit/updates-4.8/"/>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>


### PR DESCRIPTION
Replaces current plugin version (4.9) with required plugin 4.8 for Wollok 1.6