### PR TITLE
Saving a file triggers the analysis of related files.

### DIFF
--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/WollokDslUiModule.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/WollokDslUiModule.xtend
@@ -21,6 +21,7 @@ import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration
 import org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculator
 import org.eclipse.xtext.ui.shared.Access
 import org.eclipse.xtext.ui.util.PluginProjectFactory
+import org.eclipse.xtext.ui.validation.IResourceUIValidatorExtension
 import org.eclipse.xtext.ui.wizard.IProjectCreator
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations
 import org.uqbar.project.wollok.libraries.WollokLibraries
@@ -37,6 +38,7 @@ import org.uqbar.project.wollok.ui.highlight.WollokHighlightingCalculator
 import org.uqbar.project.wollok.ui.highlight.WollokHighlightingConfiguration
 import org.uqbar.project.wollok.ui.hover.WollokEObjectHoverProvider
 import org.uqbar.project.wollok.ui.libraries.WollokUILibraries
+import org.uqbar.project.wollok.ui.validator.WollokResourceUIValidatorExtension
 import org.uqbar.project.wollok.ui.wizard.WollokProjectCreator
 import org.uqbar.project.wollok.ui.wizard.WollokProjectFactory
 import org.uqbar.project.wollok.utils.DummyJvmModelAssociations
@@ -113,4 +115,7 @@ class WollokDslUiModule extends AbstractWollokDslUiModule {
 		WollokAntlrTokenToAttributeIdMapper
 	}
 
+	def Class<? extends IResourceUIValidatorExtension> bindResourceUIValidatorExtension(){
+		WollokResourceUIValidatorExtension
+	}
 }

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/validator/WollokResourceUIValidatorExtension.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/validator/WollokResourceUIValidatorExtension.xtend
@@ -1,0 +1,45 @@
+package org.uqbar.project.wollok.ui.validator
+
+import com.google.inject.Inject
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.OperationCanceledException
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.xtext.resource.IResourceDescriptionsProvider
+import org.eclipse.xtext.ui.validation.DefaultResourceUIValidatorExtension
+import org.eclipse.xtext.ui.validation.IResourceUIValidatorExtension
+import org.eclipse.xtext.validation.CheckMode
+import org.eclipse.emf.common.util.URI
+
+import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
+
+class WollokResourceUIValidatorExtension extends DefaultResourceUIValidatorExtension implements IResourceUIValidatorExtension {
+	
+	@Inject IResourceDescriptionsProvider resourceDescriptionsProvider
+	
+	override updateValidationMarkers(IFile file, Resource resource, CheckMode mode, IProgressMonitor monitor) throws OperationCanceledException {
+
+		val filesToUpdate = <URI>newHashSet()
+
+		if (!shouldProcess(file)) {
+			return
+		}
+		
+		resourceDescriptionsProvider.getResourceDescriptions(resource.resourceSet).allResourceDescriptions.forEach[it.referenceDescriptions.forEach[x | 			
+			if(x.targetEObjectUri.trimQuery.trimFragment == resource.URI.trimQuery.trimFragment){
+				filesToUpdate.add(x.sourceEObjectUri.trimQuery.trimFragment)
+			}
+		]]
+
+		addMarkers(file, resource, mode, monitor);
+		
+		filesToUpdate.forEach[ uri | 
+			val res = resource.resourceSet.getResource(uri, true)
+			val f = res.IFile
+			if(shouldProcess(f)){
+				addMarkers(f, res, mode, monitor)
+			}
+		]
+	}
+	
+}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
@@ -209,15 +209,15 @@ class WollokModelExtensions {
 	def static dispatch constructorsFor(WSelfDelegatingConstructorCall dc, WClass c) {	c.constructors }
 	def static dispatch constructorsFor(WSuperDelegatingConstructorCall dc, WClass c) { c.parent.constructors }
 	
-	def static dispatch constructorName(WConstructor c, WSelfDelegatingConstructorCall dc) {
+	def static dispatch String constructorName(WConstructor c, WSelfDelegatingConstructorCall dc) {
 		constructorName(c, "self")
 	}
 	
-	def static dispatch constructorName(WConstructor c, WSuperDelegatingConstructorCall dc) {
+	def static dispatch String constructorName(WConstructor c, WSuperDelegatingConstructorCall dc) {
 		constructorName(c, "super")
 	}
 	
-	def static constructorName(WConstructor c, String constructorCall) {
+	def static dispatch String constructorName(WConstructor c, String constructorCall) {
 		(constructorCall ?: "constructor") + "(" + c.parameters.map [ name ].join(",") + ")"
 	}
 	
@@ -356,12 +356,16 @@ class WollokModelExtensions {
 	def static dispatch isTransparent(WBinaryOperation o) { true }
 
 	def static IFile getIFile(EObject obj) {
-		val platformString = obj.eResource.URI.toPlatformString(true)
+		getIFile(obj.eResource)
+	}
+	
+	def static IFile getIFile(Resource resource){
+		val platformString = resource.URI.toPlatformString(true)
 		if (platformString === null) {
 			// could be a synthetic file
 			return null;
 		}
-		ResourcesPlugin.workspace.root.getFile(new Path(platformString))
+		ResourcesPlugin.workspace.root.getFile(new Path(platformString))		
 	}
 
 	// ******************************


### PR DESCRIPTION
When saving a file the problems markers are processed for that file and the files related to the saved one.

Fixes #1294 