### PR TITLE
Avoid to run type system while typing

### DIFF
--- a/org.uqbar.project.wollok.typeSystem.xsemantics.ui/src/org/uqbar/project/wollok/typeSystem/xsemantics/ui/labeling/XSemanticsWollokTypeSystemLabelExtension.xtend
+++ b/org.uqbar.project.wollok.typeSystem.xsemantics.ui/src/org/uqbar/project/wollok/typeSystem/xsemantics/ui/labeling/XSemanticsWollokTypeSystemLabelExtension.xtend
@@ -17,24 +17,19 @@ class XSemanticsWollokTypeSystemLabelExtension implements WollokTypeSystemLabelE
 		// if disabeld
 		if (!WollokTypeSystemActivator.^default.isTypeSystemEnabled(o))
 			return null
-			
-		val x = this.doResolvedType(o)
-		if (x === null) 
-			null
-		else
-			x.toString
+
+		this.doResolvedType(o) ?: "Any"
 	}
 
 	def doResolvedType(EObject o) {
 		try {
 			val typeSystem = WollokTypeSystemActivator.^default.getTypeSystem(o)
-			typeSystem.analyse(o.eResource.contents.get(0)) // analyses all the file
-			typeSystem.inferTypes
-			typeSystem.type(o)
-		}
-		catch (Exception e) {
+//			typeSystem.analyse(o.eResource.contents.get(0)) // analyses all the file
+//			typeSystem.inferTypes
+			return typeSystem.type(o)?.toString
+		} catch (Exception e) {
 			log.error("Error in type system !! " + e.message, e)
-			"Any"
+			return null
 		}
 	}
 

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/AbstractContainerWollokType.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/AbstractContainerWollokType.xtend
@@ -1,11 +1,12 @@
 package org.uqbar.project.wollok.typesystem
 
 import java.util.List
+import org.eclipse.xtend.lib.annotations.Accessors
 import org.uqbar.project.wollok.wollokDsl.WMethodContainer
 
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
-import org.eclipse.xtend.lib.annotations.Accessors
+import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
 
 /**
  * 
@@ -53,8 +54,8 @@ abstract class AbstractContainerWollokType extends BasicType implements Concrete
  		container.allMethods.map[m| typeSystem.queryMessageTypeForMethod(m)]		
  	}
  	
- 	override equals(Object obj) { 		
- 		obj instanceof AbstractContainerWollokType && (obj as AbstractContainerWollokType).container == container		
+ 	override equals(Object obj) {
+ 		obj instanceof AbstractContainerWollokType && (obj as AbstractContainerWollokType).container.URI == container.URI		
  	}		
  			
  	override hashCode() { container.hashCode }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/WollokTypeSystemActivator.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/WollokTypeSystemActivator.xtend
@@ -1,6 +1,6 @@
 package org.uqbar.project.wollok.typesystem
 
-import java.util.List
+import java.util.Collection
 import org.apache.log4j.Logger
 import org.eclipse.core.runtime.Platform
 import org.eclipse.core.runtime.Plugin
@@ -23,13 +23,13 @@ class WollokTypeSystemActivator extends Plugin {
 
 	private static WollokTypeSystemActivator plugin
 	private BundleContext context
-	private List<TypeSystem> typeSystems
+	private Collection<TypeSystem> typeSystems
 	WollokTypeSystemPreference typeSystemPreferences;
 
 	def synchronized getTypeSystems() {
 		if (typeSystems === null) {
 			val configs = Platform.extensionRegistry.getConfigurationElementsFor(TYPE_SYSTEM_IMPL_EXTENSION_POINT)
-			typeSystems = configs.map[it.createExecutableExtension("class") as TypeSystem]
+			typeSystems = configs.map[it.createExecutableExtension("class") as TypeSystem].toSet
 		}
 		return typeSystems
 	}

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstraintBasedTypeSystem.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstraintBasedTypeSystem.xtend
@@ -160,7 +160,7 @@ class ConstraintBasedTypeSystem implements TypeSystem, TypeProvider {
 	// ** Other (TBD)
 	// ************************************************************************
 	override type(EObject obj) {
-		obj.tvar.type
+		registry?.type(obj)
 	}
 
 	override issues(EObject obj) {

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstraintBasedTypeSystem.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstraintBasedTypeSystem.xtend
@@ -34,6 +34,7 @@ import org.uqbar.project.wollok.wollokDsl.WNamedObject
 import static org.uqbar.project.wollok.scoping.WollokResourceCache.*
 
 import static extension org.uqbar.project.wollok.typesystem.annotations.TypeDeclarations.*
+import org.apache.log4j.Level
 
 /**
  * @author npasserini
@@ -56,6 +57,10 @@ class ConstraintBasedTypeSystem implements TypeSystem, TypeProvider {
 	 * TODO It might be more correct to use WollokType, but right now it would only complicate things.
 	 */
 	Set<AbstractContainerWollokType> allTypes
+
+	new() {
+		Logger.getLogger("org.uqbar.project.wollok.typesystem").level = Level.DEBUG
+	}
 	
 	override def name() { "Constraints-based" }
 
@@ -193,3 +198,4 @@ class ConstraintBasedTypeSystem implements TypeSystem, TypeProvider {
 		allTypes
 	}
 }
+	

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/AbstractInferenceStrategy.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/AbstractInferenceStrategy.xtend
@@ -48,7 +48,8 @@ abstract class AbstractInferenceStrategy {
 	def walkThroughVariable(TypeVariable it) {
 		if (!hasErrors) 
 			try analiseVariable
-			catch (TypeSystemException exception) addError(exception) 
+			catch (TypeSystemException exception) addError(exception)
+			catch (Exception exception) addFatalError(exception)
 	}
 
 	abstract def void analiseVariable(TypeVariable tvar)
@@ -56,4 +57,11 @@ abstract class AbstractInferenceStrategy {
 	def allVariables() { registry.allVariables }
 	def allFiles() { registry.typeSystem.programs }
 	def tvar(EObject node) { registry.tvar(node) }
+	
+	def addFatalError(TypeVariable variable, Exception exception) {
+		val message = '''Fatal type system error: «exception.message»'''
+		
+		log.fatal(message, exception)
+		variable.addError(new TypeSystemException(message) => [ it.variable = variable ])		
+	}
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/MaxTypesFromMessages.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/MaxTypesFromMessages.xtend
@@ -29,8 +29,8 @@ class MaxTypesFromMessages extends SimpleTypeInferenceStrategy {
 		log.trace('''maxTypes = «maxTypes»''')
 		if (!maxTypes.empty && !maximalConcreteTypes.contains(maxTypes)) {
 			log.debug('''	New max(«maxTypes») type for «tvar.debugInfoInContext»''')
-			setMaximalConcreteTypes(new MaximalConcreteTypes(maxTypes.map[it as WollokType].toSet), tvar)
-			changed = true
+			val newChanges = setMaximalConcreteTypes(new MaximalConcreteTypes(maxTypes.map[it as WollokType].toSet), tvar)
+			changed = changed || newChanges
 		}
 	}
 

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/MaximalConcreteTypes.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/MaximalConcreteTypes.xtend
@@ -43,8 +43,9 @@ class MaximalConcreteTypes {
 
 		maximalConcreteTypes.removeIf[!supertype.contains(it)]
 
-		if (maximalConcreteTypes.size < originalSize)
-			state = Pending
+		val changed = maximalConcreteTypes.size < originalSize
+		if (changed) state = Pending
+		return changed
 	}
 
 	// ************************************************************************

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/SimpleTypeInfo.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/SimpleTypeInfo.xtend
@@ -63,6 +63,7 @@ class SimpleTypeInfo extends TypeInfo {
 
 		if (maximalConcreteTypes === null) {
 			maximalConcreteTypes = maxTypes.copy
+			true
 		} else {
 			maximalConcreteTypes.restrictTo(maxTypes)
 		}

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeInfo.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeInfo.xtend
@@ -51,7 +51,7 @@ abstract class TypeInfo {
 	 * @param maxType A new set of maxTypes that will be merged with current maxTypes (or assigned if no current maxTypes).
 	 * @origin The type variable from where we obtained this information, and will be target of error reports if any.
 	 */
-	def void setMaximalConcreteTypes(MaximalConcreteTypes maxTypes, TypeVariable origin)
+	def boolean setMaximalConcreteTypes(MaximalConcreteTypes maxTypes, TypeVariable origin)
 
 	// ************************************************************************
 	// ** Notifications

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariable.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariable.xtend
@@ -178,7 +178,7 @@ class TypeVariable implements ITypeVariable {
 		typeInfo.addMinType(type)
 	}
 
-	def setMaximalConcreteTypes(MaximalConcreteTypes maxTypes, TypeVariable origin) {
+	def boolean setMaximalConcreteTypes(MaximalConcreteTypes maxTypes, TypeVariable origin) {
 		if (typeInfo === null) setTypeInfo(new SimpleTypeInfo())
 		typeInfo.setMaximalConcreteTypes(maxTypes, origin)
 	}

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariablesRegistry.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariablesRegistry.xtend
@@ -1,6 +1,7 @@
 package org.uqbar.project.wollok.typesystem.constraints.variables
 
 import java.util.List
+
 import java.util.Map
 import org.apache.log4j.Logger
 import org.eclipse.emf.ecore.EObject
@@ -19,10 +20,12 @@ import static org.uqbar.project.wollok.typesystem.constraints.variables.GenericT
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.lookupMethod
 import static extension org.uqbar.project.wollok.scoping.WollokResourceCache.isCoreObject
 import static extension org.uqbar.project.wollok.typesystem.constraints.WollokModelPrintForDebug.*
+import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
+import org.eclipse.emf.common.util.URI
 
 class TypeVariablesRegistry {
-	val Map<EObject, TypeVariable> typeVariables = newHashMap
-	val Map<EObject, ClassParameterTypeVariable> typeParameters = newHashMap
+	val Map<URI, TypeVariable> typeVariables = newHashMap
+	val Map<URI, ClassParameterTypeVariable> typeParameters = newHashMap
 	val Logger log = Logger.getLogger(this.class)
 	
 
@@ -39,14 +42,14 @@ class TypeVariablesRegistry {
 	def register(TypeVariable it) {
 		// Only register variables which have an owner. Variables without an owner have are "synthetic", i.e. 
 		// they have no representation in code. Proper handling of synthetic variables is yet to be polished
-		if (owner !== null) typeVariables.put(owner, it)
+		if (owner !== null) typeVariables.put(owner.URI, it)
 		return it
 	}
 
 	def register(ClassParameterTypeVariable it) {
 		// Only register variables which have an owner. Variables without an owner have are "synthetic", i.e. 
 		// they have no representation in code. Proper handling of synthetic variables is yet to be polished
-		if (owner !== null) typeParameters.put(owner, it)
+		if (owner !== null) typeParameters.put(owner.URI, it)
 		return it
 	}
 	
@@ -132,20 +135,20 @@ class TypeVariablesRegistry {
 	 * If you want to be able to handle also type parameters, you have to use {@link #tvarOrParam}
 	 */
 	def TypeVariable tvar(EObject obj) {
-		typeVariables.get(obj) => [ if (it === null) {
+		typeVariables.get(obj.URI) => [ if (it === null) {
 			throw new TypeSystemException("Missing type information for " + obj.debugInfoInContext)
 		}]
 	}
 	
 	def ITypeVariable tvarOrParam(EObject obj) {
-		typeVariables.get(obj) ?: 
-			typeParameters.get(obj) => [ if (it === null) {
+		typeVariables.get(obj.URI) ?: 
+			typeParameters.get(obj.URI) => [ if (it === null) {
 				throw new TypeSystemException("Missing type information for " + obj.debugInfoInContext)
 			}]
 	}
 	
 	def type(EObject obj) {
-		typeVariables.get(obj)?.type
+		typeVariables.get(obj.URI)?.type
 	}
 
 	// ************************************************************************

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariablesRegistry.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariablesRegistry.xtend
@@ -143,6 +143,10 @@ class TypeVariablesRegistry {
 				throw new TypeSystemException("Missing type information for " + obj.debugInfoInContext)
 			}]
 	}
+	
+	def type(EObject obj) {
+		typeVariables.get(obj)?.type
+	}
 
 	// ************************************************************************
 	// ** Method types

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/labeling/WollokDslLabelProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/labeling/WollokDslLabelProvider.xtend
@@ -130,13 +130,13 @@ class WollokDslLabelProvider extends DefaultEObjectLabelProvider {
 	}
 
 	def text(WMethodDeclaration m) {
-		(m.name ?: "<...>") + '(' + m.parameters.map[(name) + concatResolvedType(":", it)].join(',') + ')' +
+		(m.name ?: "<...>") + '(' + m.parameters.map[(name) + concatResolvedType(": ", it)].join(', ') + ')' +
 			if(m.supposedToReturnValue) (" → " + concatResolvedType("", m)) else ""
 	}
 
 	def text(WConstructor c) {
 		c.declaringContext?.name + '(' +
-			c.parameters.map[name + concatResolvedType(":", it)].join(',') + ')'
+			c.parameters.map[name + concatResolvedType(": ", it)].join(', ') + ')'
 	}
 
 	def image(WMethodDeclaration method) {

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/NotConfigurable.java
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/NotConfigurable.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 
 /**
  * To ignore a @check method.
- * It won't be available to enabled disabled it from preferences.
+ * It won't be available to enabled / disabled it from preferences.
  * 
  * @author jfernandes
  */

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -153,7 +153,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 		wollokValidatorExtensions = configs.map[it.createExecutableExtension("class") as WollokValidatorExtension]
 	}
 
-	@Check
+	@Check(NORMAL)
 	@NotConfigurable
 	def checkValidationExtensions(WFile wfile) {
 		validatorExtensions.forEach[ ext |

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -153,8 +153,8 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 		wollokValidatorExtensions = configs.map[it.createExecutableExtension("class") as WollokValidatorExtension]
 	}
 
-	@Check(NORMAL)
 	@NotConfigurable
+	@Check
 	def checkValidationExtensions(WFile wfile) {
 		validatorExtensions.forEach[ ext |
 			if(ext.shouldRun)


### PR DESCRIPTION
This configuration changes makes type system run when a file is saved instead of running while the user types. After testing it in a few projects, performance seems reasonable.