### PR TITLE
Game general background

### DIFF
--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/Image.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/Image.xtend
@@ -1,10 +1,7 @@
 package org.uqbar.project.wollok.game
 
-import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.graphics.Texture
-import com.badlogic.gdx.graphics.Texture.TextureFilter
-import org.uqbar.project.wollok.game.gameboard.Gameboard
 import org.eclipse.xtend.lib.annotations.Accessors
+import org.uqbar.project.wollok.game.gameboard.Gameboard
 
 @Accessors
 class Image {
@@ -12,7 +9,6 @@ class Image {
 	var int height = Gameboard.CELLZISE
 	String path
 	protected String currentPath
-	Texture texture
 	
 	new() { 
 		this.currentPath = path
@@ -23,21 +19,6 @@ class Image {
 	}
 	
 	def getPath() { path }
-	
-	
-	def getTexture() {
-		if (this.texture == null || this.currentPath != this.path) {
-			var file = Gdx.files.internal(this.getPath())
-			
-			if (!file.exists) return null			
-				
-			this.texture = new Texture(file)
-			this.texture.setFilter(TextureFilter.Linear, TextureFilter.Linear)
-			this.currentPath = this.getPath()
-		}
-		
-		return this.texture
-	}
 	
 	override public int hashCode() {
 		val prime = 31

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/Image.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/Image.xtend
@@ -3,9 +3,13 @@ package org.uqbar.project.wollok.game
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.Texture
 import com.badlogic.gdx.graphics.Texture.TextureFilter
+import org.uqbar.project.wollok.game.gameboard.Gameboard
+import org.eclipse.xtend.lib.annotations.Accessors
 
+@Accessors
 class Image {
-	
+	var int width = Gameboard.CELLZISE
+	var int height = Gameboard.CELLZISE
 	String path
 	protected String currentPath
 	Texture texture

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/Image.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/Image.xtend
@@ -1,24 +1,17 @@
 package org.uqbar.project.wollok.game
 
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.uqbar.project.wollok.game.gameboard.Gameboard
 
 @Accessors
 class Image {
-	var int width = Gameboard.CELLZISE
-	var int height = Gameboard.CELLZISE
+	ImageSize size = new TextureSize
 	String path
-	protected String currentPath
 	
-	new() { 
-		this.currentPath = path
-	}
+	new () { }
 	
 	new(String path) {
 		this.path = path
 	}
-	
-	def getPath() { path }
 	
 	override public int hashCode() {
 		val prime = 31

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/ImageSize.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/ImageSize.xtend
@@ -3,13 +3,13 @@ package org.uqbar.project.wollok.game
 import org.uqbar.project.wollok.game.gameboard.Gameboard
 
 interface ImageSize {
-	def int width(int textureWidth)
-	def int height(int textureHeight)
+	def int width(int originalWidth)
+	def int height(int originalHeight)
 }
 
 class TextureSize implements ImageSize {
-	override width(int textureWidth) { textureWidth	}	
-	override height(int textureHeight) { textureHeight }	
+	override width(int originalWidth) { originalWidth }	
+	override height(int originalHeight) { originalHeight }	
 }
 
 class CellSize implements ImageSize {
@@ -17,8 +17,8 @@ class CellSize implements ImageSize {
 	
 	new (int size) { this.size = size }
 	
-	override width(int textureWidth) { size }	
-	override height(int textureHeight) { size }
+	override width(int originalWidth) { size }	
+	override height(int originalHeight) { size }
 }
 
 class GameSize implements ImageSize {
@@ -26,6 +26,6 @@ class GameSize implements ImageSize {
 	
 	new (Gameboard game) { this.game = game }
 	
-	override width(int textureWidth) { game.pixelWidth }	
-	override height(int textureHeight) { game.pixelHeight }
+	override width(int originalWidth) { game.pixelWidth }	
+	override height(int originalHeight) { game.pixelHeight }
 }

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/ImageSize.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/ImageSize.xtend
@@ -1,0 +1,31 @@
+package org.uqbar.project.wollok.game
+
+import org.uqbar.project.wollok.game.gameboard.Gameboard
+
+interface ImageSize {
+	def int width(int textureWidth)
+	def int height(int textureHeight)
+}
+
+class TextureSize implements ImageSize {
+	override width(int textureWidth) { textureWidth	}	
+	override height(int textureHeight) { textureHeight }	
+}
+
+class CellSize implements ImageSize {
+	int size
+	
+	new (int size) { this.size = size }
+	
+	override width(int textureWidth) { size }	
+	override height(int textureHeight) { size }
+}
+
+class GameSize implements ImageSize {
+	Gameboard game
+	
+	new (Gameboard game) { this.game = game }
+	
+	override width(int textureWidth) { game.pixelWidth }	
+	override height(int textureHeight) { game.pixelHeight }
+}

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
@@ -3,6 +3,7 @@ package org.uqbar.project.wollok.game.gameboard
 import java.util.List
 import org.uqbar.project.wollok.game.WGPosition
 import org.uqbar.project.wollok.game.Image
+import javax.swing.text.Position.Bias
 
 interface Background {	
 	def void draw(Window window)
@@ -10,7 +11,7 @@ interface Background {
 }
 
 class CellsBackground implements Background {
-	List<Cell> cells = newArrayList
+	val List<Cell> cells = newArrayList
 	
 	new(String image, int height, int width) {
 		for (var i = 0; i < width ; i++) {
@@ -25,3 +26,17 @@ class CellsBackground implements Background {
 	}
 	
 }
+
+class FullBackground implements Background {
+	val origin = new WGPosition(0,0)
+	val Image image
+	
+	new(String path) {
+		image = new Image(path)
+	}
+	
+	override draw(Window window) {
+		window.draw(image, origin)
+	}
+	
+} 

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
@@ -3,15 +3,18 @@ package org.uqbar.project.wollok.game.gameboard
 import java.util.List
 import org.uqbar.project.wollok.game.Image
 import org.uqbar.project.wollok.game.WGPosition
+import org.uqbar.project.wollok.game.GameSize
+import org.eclipse.xtend.lib.annotations.Accessors
 
 interface Background {	
 	def void draw(Window window)	
 }
 
+@Accessors
 class CellsBackground implements Background {
 	val List<Cell> cells = newArrayList
 	
-	new(String image, int height, int width) {
+	new(String image, Gameboard it) {
 		for (var i = 0; i < width ; i++) {
 			for (var j = 0; j < height; j++) {
 				cells.add(new Cell(new WGPosition(i, j), new Image(image)));
@@ -25,16 +28,16 @@ class CellsBackground implements Background {
 	
 }
 
+@Accessors
 class FullBackground implements Background {
-	val origin = new WGPosition(0,0)
 	val Image image
 	
-	new(String path) {
-		image = new Image(path)
+	new(String path, Gameboard game) {
+		image = new Image(path) => [ size = new GameSize(game)]
 	}
 	
 	override draw(Window window) {
-		window.fullDraw(image, origin)
+		window.draw(image)
 	}
 	
 } 

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
@@ -34,7 +34,7 @@ class FullBackground implements Background {
 	}
 	
 	override draw(Window window) {
-		window.draw(image, origin)
+		window.fullDraw(image, origin)
 	}
 	
 } 

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
@@ -1,0 +1,27 @@
+package org.uqbar.project.wollok.game.gameboard
+
+import java.util.List
+import org.uqbar.project.wollok.game.WGPosition
+import org.uqbar.project.wollok.game.Image
+
+interface Background {	
+	def void draw(Window window)
+	
+}
+
+class CellsBackground implements Background {
+	List<Cell> cells = newArrayList
+	
+	new(String image, int height, int width) {
+		for (var i = 0; i < width ; i++) {
+			for (var j = 0; j < height; j++) {
+				cells.add(new Cell(new WGPosition(i, j), new Image(image)));
+			}
+		}
+	}
+	
+	override draw(Window window) {
+		cells.forEach[ it.draw(window) ]
+	}
+	
+}

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Background.xtend
@@ -1,13 +1,11 @@
 package org.uqbar.project.wollok.game.gameboard
 
 import java.util.List
-import org.uqbar.project.wollok.game.WGPosition
 import org.uqbar.project.wollok.game.Image
-import javax.swing.text.Position.Bias
+import org.uqbar.project.wollok.game.WGPosition
 
 interface Background {	
-	def void draw(Window window)
-	
+	def void draw(Window window)	
 }
 
 class CellsBackground implements Background {

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Cell.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Cell.xtend
@@ -1,8 +1,9 @@
 package org.uqbar.project.wollok.game.gameboard
 
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.uqbar.project.wollok.game.CellSize
 import org.uqbar.project.wollok.game.Image
 import org.uqbar.project.wollok.game.Position
-import org.eclipse.xtend.lib.annotations.Accessors
 
 @Accessors
 class Cell {
@@ -11,7 +12,7 @@ class Cell {
 
 	new(Position position, Image image) {
 		this.position = position
-		this.image = image
+		this.image = image => [ size = new CellSize(Gameboard.CELLZISE) ]
 	}
 	
 	def draw(Window window) {

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
@@ -53,9 +53,9 @@ class Gameboard {
 	
 	def createBackgroud() {
 		if (boardGround !== null)
-		 	new FullBackground(boardGround)
+		 	new FullBackground(boardGround, this)
 		else 
-			new CellsBackground(ground, height, width)
+			new CellsBackground(ground, this)
 	}
 	
 	def void stop() {

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
@@ -24,7 +24,7 @@ class Gameboard {
 	String ground
 	int height
 	int width
-	List<Cell> cells = newArrayList
+	Background background
 	List<VisualComponent> components = newArrayList
 	List<GameboardListener> listeners = newArrayList
 	VisualComponent character
@@ -48,8 +48,12 @@ class Gameboard {
 	}
 
 	def void start(Boolean fromREPL) {
-		createCells(ground)
+		background = createBackgroud()
 		Application.instance.start(this, fromREPL)
+	}
+	
+	def createBackgroud() {
+		new CellsBackground(ground, height, width)
 	}
 	
 	def void stop() {
@@ -73,17 +77,8 @@ class Gameboard {
 			} 
 		}
 
-		cells.forEach[ it.draw(window) ]
+		background.draw(window)
 		components.forEach[it.draw(window)]
-	}
-
-	def createCells(String groundImage) {
-		cells.clear
-		for (var i = 0; i < width ; i++) {
-			for (var j = 0; j < height; j++) {
-				cells.add(new Cell(new WGPosition(i, j), new Image(groundImage)));
-			}
-		}
 	}
 
 	def pixelHeight() {

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
@@ -22,6 +22,7 @@ class Gameboard {
 	
 	String title
 	String ground
+	String boardGround
 	int height
 	int width
 	Background background
@@ -53,7 +54,10 @@ class Gameboard {
 	}
 	
 	def createBackgroud() {
-		new CellsBackground(ground, height, width)
+		if (boardGround !== null)
+		 	new FullBackground(boardGround)
+		else 
+			new CellsBackground(ground, height, width)
 	}
 	
 	def void stop() {

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
@@ -4,10 +4,8 @@ import java.util.Collection
 import java.util.List
 import org.apache.log4j.Logger
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.uqbar.project.wollok.game.Image
 import org.uqbar.project.wollok.game.Position
 import org.uqbar.project.wollok.game.VisualComponent
-import org.uqbar.project.wollok.game.WGPosition
 import org.uqbar.project.wollok.game.helpers.Application
 import org.uqbar.project.wollok.game.listeners.ArrowListener
 import org.uqbar.project.wollok.game.listeners.GameboardListener

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
@@ -11,6 +11,8 @@ import com.badlogic.gdx.graphics.g2d.NinePatch
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import org.uqbar.project.wollok.game.Image
 import org.uqbar.project.wollok.game.Position
+import java.util.Map
+import com.badlogic.gdx.graphics.Texture.TextureFilter
 
 class Window {
 	val patch = new NinePatch(new Texture(Gdx.files.internal("speech.png")), 30, 60, 40, 50)
@@ -20,7 +22,9 @@ class Window {
 	val batch = new SpriteBatch()
 	val font = new BitmapFont()
 	val glyphLayout = new GlyphLayout()
-	OrthographicCamera camera
+	val OrthographicCamera camera
+	
+	val Map<String, Texture> textures = newHashMap
 	
 	new(OrthographicCamera camera) {
 		this.camera = camera
@@ -31,7 +35,7 @@ class Window {
 	}
 	
 	def fullDraw(Image image, Position position) {
-		batch.draw(image.texture, position.xinPixels, position.yinPixels, Gdx.graphics.width, Gdx.graphics.height)
+		drawIn(image, position.xinPixels, position.yinPixels, Gdx.graphics.width, Gdx.graphics.height)
 	}
 	
 	def drawIn(Image image, int x, int y, int width, int heigth) {
@@ -95,5 +99,24 @@ class Window {
 		batch.dispose()
 	}
 
+	def Texture texture(Image it) {
+		val texture = textures.get(path)
+		if (texture === null && !textures.containsKey(path)) {
+			path.addTexture
+			it.texture
+		} 
+		else texture
+	}
 	
+	def addTexture(String path) {
+		val file = Gdx.files.internal(path)
+			
+		if (!file.exists) 
+			textures.put(path, null)
+		else {			
+			val texture = new Texture(file)
+			texture.setFilter(TextureFilter.Linear, TextureFilter.Linear)
+			textures.put(path, texture)
+		}
+	}
 }

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
@@ -27,19 +27,23 @@ class Window {
 	}
 	
 	def draw(Image image, Position position) {
-		drawIn(image, position.xinPixels, position.yinPixels)
+		drawIn(image, position.xinPixels, position.yinPixels, image.width, image.height)
 	}
 	
-	def drawIn(Image image, int x, int y) {
+	def fullDraw(Image image, Position position) {
+		batch.draw(image.texture, position.xinPixels, position.yinPixels, Gdx.graphics.width, Gdx.graphics.height)
+	}
+	
+	def drawIn(Image image, int x, int y, int width, int heigth) {
 		val texture = image.texture
 		if (texture != null) //TODO: Think a better implementation
-			batch.draw(texture, x, y)
+			batch.draw(texture, x, y, width, heigth)
 		else
-			drawNotFoundImage(x, y)
+			drawNotFoundImage(x, y, width, heigth)
 	}
 	
-	def drawNotFoundImage(int x, int y) {
-		batch.draw(defaultImage, x, y)
+	def drawNotFoundImage(int x, int y, int width, int heigth) {
+		batch.draw(defaultImage, x, y, width, heigth)
 		write(notFoundText, Color.BLACK, x - 80, y + 50)
 	}
 	

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
@@ -13,6 +13,8 @@ import org.uqbar.project.wollok.game.Image
 import org.uqbar.project.wollok.game.Position
 import java.util.Map
 import com.badlogic.gdx.graphics.Texture.TextureFilter
+import org.uqbar.project.wollok.game.WGPosition
+import org.uqbar.project.wollok.game.ImageSize
 
 class Window {
 	val patch = new NinePatch(new Texture(Gdx.files.internal("speech.png")), 30, 60, 40, 50)
@@ -30,25 +32,25 @@ class Window {
 		this.camera = camera
 	}
 	
-	def draw(Image image, Position position) {
-		drawIn(image, position.xinPixels, position.yinPixels, image.width, image.height)
+	def draw(Image it) {
+		draw(new WGPosition)
 	}
 	
-	def fullDraw(Image image, Position position) {
-		drawIn(image, position.xinPixels, position.yinPixels, Gdx.graphics.width, Gdx.graphics.height)
-	}
-	
-	def drawIn(Image image, int x, int y, int width, int heigth) {
-		val texture = image.texture
-		if (texture != null) //TODO: Think a better implementation
-			batch.draw(texture, x, y, width, heigth)
+	def draw(Image it, Position position) {
+		val t = texture  
+		if (t !== null)
+			doDraw(t, position, size)
 		else
-			drawNotFoundImage(x, y, width, heigth)
+			drawNotFoundImage(it, position)
 	}
 	
-	def drawNotFoundImage(int x, int y, int width, int heigth) {
-		batch.draw(defaultImage, x, y, width, heigth)
-		write(notFoundText, Color.BLACK, x - 80, y + 50)
+	def drawNotFoundImage(Image image, Position it) {
+		doDraw(defaultImage, it, image.size)
+		write(notFoundText, Color.BLACK, xinPixels - 80, yinPixels + 50)
+	}
+	
+	def doDraw(Texture texture, Position it, ImageSize size) {
+		batch.draw(texture, xinPixels, yinPixels, size.width(texture.width), size.height(texture.height))
 	}
 	
 	def writeAttributes(String text, Position position, Color color) {

--- a/org.uqbar.project.wollok.lib/src/org/uqbar/project/wollok/lib/WImage.xtend
+++ b/org.uqbar.project.wollok.lib/src/org/uqbar/project/wollok/lib/WImage.xtend
@@ -10,7 +10,6 @@ class WImage extends Image {
 	
 	new(WollokObject wObject) {
 		this.object = wObject
-		this.currentPath = this.getPath()
 	}
 	
 	override getPath() { 

--- a/org.uqbar.project.wollok.lib/src/wollok/lib.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib.wlk
@@ -335,9 +335,14 @@ object game {
 	method height() native
 
 	/**
-	 * Sets cells image.
+	 * Sets cells background image.
 	 */			
 	method ground(image) native
+	
+	/**
+	 * Sets full background image.
+	 */			
+	method boardGround(image) native
 	
 	/** 
 	* @private

--- a/org.uqbar.project.wollok.lib/src/wollok/lib/GameObject.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib/GameObject.xtend
@@ -115,8 +115,6 @@ class GameObject {
 	}
 	
 	def ground(String image) { board.ground = image }
-	def ground(WollokObject image) {
-		board.createCells(image.asString)
-	}
+	def boardGround(String image) { board.boardGround = image }
 	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/BackgroundTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/BackgroundTest.xtend
@@ -1,27 +1,28 @@
 package org.uqbar.project.wollok.tests.game
 
 import org.junit.Test
-import org.uqbar.project.wollok.game.WGPosition
+import org.uqbar.project.wollok.game.GameSize
 import org.uqbar.project.wollok.game.gameboard.CellsBackground
 import org.uqbar.project.wollok.game.gameboard.FullBackground
-import org.uqbar.project.wollok.game.gameboard.Window
+import org.uqbar.project.wollok.game.gameboard.Gameboard
 
-import static org.mockito.Matchers.*
-import static org.mockito.Mockito.*
+import static org.junit.Assert.*
 
 class BackgroundTest {
-	val image = "image.png"
-	val window = mock(Window)
+	val path = "image.png"
+	val gameboard = new Gameboard
 	
 	@Test
-	def cells_background_should_draw_image_in_all_positions() {
-		new CellsBackground(image, 3, 5).draw(window)
-		verify(window, times(3 * 5)).draw(any, any)
+	def void cells_background_should_create_all_board_cells() {
+		new CellsBackground(path, gameboard) => [
+			assertEquals(5 * 5, cells.size)
+		]
 	}
 	
 	@Test
-	def full_background_should_draw_full_image_at_origin() {
-		new FullBackground(image).draw(window)
-		verify(window).fullDraw(any, eq(new WGPosition(0,0)))
+	def void full_background_should_create_game_size_image() {
+		new FullBackground(path, gameboard) => [
+			assertTrue(image.size instanceof GameSize)	
+		]
 	}	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/BackgroundTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/BackgroundTest.xtend
@@ -1,0 +1,27 @@
+package org.uqbar.project.wollok.tests.game
+
+import org.junit.Test
+import org.uqbar.project.wollok.game.WGPosition
+import org.uqbar.project.wollok.game.gameboard.CellsBackground
+import org.uqbar.project.wollok.game.gameboard.FullBackground
+import org.uqbar.project.wollok.game.gameboard.Window
+
+import static org.mockito.Matchers.*
+import static org.mockito.Mockito.*
+
+class BackgroundTest {
+	val image = "image.png"
+	val window = mock(Window)
+	
+	@Test
+	def cells_background_should_draw_image_in_all_positions() {
+		new CellsBackground(image, 3, 5).draw(window)
+		verify(window, times(3 * 5)).draw(any, any)
+	}
+	
+	@Test
+	def full_background_should_draw_full_image_at_origin() {
+		new FullBackground(image).draw(window)
+		verify(window).fullDraw(any, eq(new WGPosition(0,0)))
+	}	
+}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/GameboardTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/GameboardTest.xtend
@@ -6,6 +6,8 @@ import org.uqbar.project.wollok.game.Position
 import org.uqbar.project.wollok.game.VisualComponent
 import org.uqbar.project.wollok.game.WGPosition
 import org.uqbar.project.wollok.game.gameboard.Background
+import org.uqbar.project.wollok.game.gameboard.CellsBackground
+import org.uqbar.project.wollok.game.gameboard.FullBackground
 import org.uqbar.project.wollok.game.gameboard.Gameboard
 import org.uqbar.project.wollok.game.gameboard.Window
 import org.uqbar.project.wollok.game.helpers.Application
@@ -16,8 +18,6 @@ import static org.junit.Assert.*
 import static org.mockito.Mockito.*
 import static org.uqbar.project.wollok.game.helpers.Application.*
 import static org.uqbar.project.wollok.game.helpers.Keyboard.*
-import org.uqbar.project.wollok.game.gameboard.CellsBackground
-import org.uqbar.project.wollok.game.gameboard.FullBackground
 
 class GameboardTest {
 	Gameboard gameboard

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/GameboardTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/GameboardTest.xtend
@@ -5,7 +5,7 @@ import org.junit.Test
 import org.uqbar.project.wollok.game.Position
 import org.uqbar.project.wollok.game.VisualComponent
 import org.uqbar.project.wollok.game.WGPosition
-import org.uqbar.project.wollok.game.gameboard.Cell
+import org.uqbar.project.wollok.game.gameboard.Background
 import org.uqbar.project.wollok.game.gameboard.Gameboard
 import org.uqbar.project.wollok.game.gameboard.Window
 import org.uqbar.project.wollok.game.helpers.Application
@@ -16,6 +16,7 @@ import static org.junit.Assert.*
 import static org.mockito.Mockito.*
 import static org.uqbar.project.wollok.game.helpers.Application.*
 import static org.uqbar.project.wollok.game.helpers.Keyboard.*
+import org.uqbar.project.wollok.game.gameboard.CellsBackground
 
 class GameboardTest {
 	Gameboard gameboard
@@ -35,7 +36,7 @@ class GameboardTest {
 			title = "UnTitulo"
 			width = 3
 			height = 5
-			ground = "Piso.png"
+			background = mock(Background)
 			addListener(listener)
 			addComponent(component)
 			addCharacter(character)
@@ -52,9 +53,9 @@ class GameboardTest {
 	}
 
 	@Test
-	def on_start_should_have_all_cells_created() {
+	def on_start_should_create_cells_background() {
 		gameboard.start
-		assertEquals(15, gameboard.cells.size)
+		assertEquals(CellsBackground, gameboard.background.class)
 	}
 
 	@Test
@@ -73,15 +74,15 @@ class GameboardTest {
 	}
 
 	@Test
-	def on_rendering_draw_cells_components_and_character_in_order() {
-		val cell = mock(Cell)
-		gameboard.cells.add(cell)
+	def on_rendering_draw_background_components_and_character_in_order() {
+		val background = mock(Background)
+		gameboard.background = background
 
 		var window = mock(Window)
 		gameboard.draw(window)
 
-		var inOrder = inOrder(cell, component, character)
-		inOrder.verify(cell).draw(window)
+		var inOrder = inOrder(background, component, character)
+		inOrder.verify(background).draw(window)
 		inOrder.verify(component).draw(window)
 		inOrder.verify(character).draw(window)
 	}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/GameboardTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/GameboardTest.xtend
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.*
 import static org.uqbar.project.wollok.game.helpers.Application.*
 import static org.uqbar.project.wollok.game.helpers.Keyboard.*
 import org.uqbar.project.wollok.game.gameboard.CellsBackground
+import org.uqbar.project.wollok.game.gameboard.FullBackground
 
 class GameboardTest {
 	Gameboard gameboard
@@ -56,6 +57,15 @@ class GameboardTest {
 	def on_start_should_create_cells_background() {
 		gameboard.start
 		assertEquals(CellsBackground, gameboard.background.class)
+	}
+	
+	@Test
+	def when_boardGround_is_not_null_should_create_full_background() {
+		gameboard => [
+			boardGround = "background.png"
+			start
+		]
+		assertEquals(FullBackground, gameboard.background.class)
 	}
 
 	@Test

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/ImageTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/ImageTest.xtend
@@ -1,0 +1,46 @@
+package org.uqbar.project.wollok.tests.game
+
+import org.junit.Before
+import org.junit.Test
+import org.uqbar.project.wollok.game.CellSize
+import org.uqbar.project.wollok.game.GameSize
+import org.uqbar.project.wollok.game.TextureSize
+import org.uqbar.project.wollok.game.gameboard.Gameboard
+
+import static org.junit.Assert.*
+
+class ImageTest {
+	var Gameboard gameboard 
+	
+	@Before
+	def void init() {
+		gameboard = new Gameboard => [ 
+			width = 3
+			height = 4
+		]
+	}
+	
+	@Test
+	def void texture_size_should_return_texture_dimensions() {
+		new TextureSize => [
+			assertEquals(10, width(10))
+			assertEquals(20, height(20))
+		]
+	}
+	
+	@Test
+	def void cell_size_should_return_cell_dimensions() {
+		new CellSize(50) => [
+			assertEquals(50, width(10))
+			assertEquals(50, height(20))
+		]
+	}
+	
+	@Test
+	def void game_size_should_return_game_dimensions() {
+		new GameSize(gameboard) => [
+			assertEquals(3 * 50, width(10))
+			assertEquals(4 * 50, height(20))
+		]
+	}
+}


### PR DESCRIPTION
Fixes #1192

- `game.ground("image.png")` -> sets **cells** image
- `game.boardGround("image.png")` -> sets **full game** image
- Cells and game images adapt its size respectively
- For other components, the original image size is kept