### PR TITLE
Fix 1346 constructor call constraints

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/constructors.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/constructors.wlk.xt
@@ -11,6 +11,9 @@ object constructorTests {
 
 	// XPECT methodType at m3 --> (Number, Dog) => C
 	method m3(n, dog) = new C(n, dog)
+
+	// XPECT methodType at m4 --> (Dog) => D
+	method m4(dog) = new D(2, dog)
 }
 
 class C {
@@ -20,6 +23,9 @@ class C {
 		number = n * 2
 		dog.bark()
 	}
+}
+
+class D inherits C {
 }
 
 class Dog {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/constructors.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/constructors.wlk.xt
@@ -5,4 +5,23 @@ object constructorTests {
 		// XPECT constructorType at Date --> (Number, Number, Number)
 		return new Date(1, 2, 3)	
 	}
+
+	// XPECT methodType at m2 --> (Number) => Date
+	method m2(day) = new Date(day, day, 2018)
+
+	// XPECT methodType at m3 --> (Number, Dog) => C
+	method m3(n, dog) = new C(n, dog)
+}
+
+class C {
+	var number
+
+	constructor(n, dog) {
+		number = n * 2
+		dog.bark()
+	}
+}
+
+class Dog {
+	method bark() {}
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/WollokCoreTypeDeclarations.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/WollokCoreTypeDeclarations.xtend
@@ -17,6 +17,8 @@ class WollokCoreTypeDeclarations extends TypeDeclarations {
 		Boolean >> "negate" === #[] => Boolean
 		Boolean >> "toString" === #[] => String;
 
+		// TODO Parametric types for Pairs
+		PairType.constructor(Any, Any)
 		PairType >> "getKey" === #[] => Any;
 		PairType >> "getValue" === #[] => Any;
 		

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstraintBasedTypeSystem.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstraintBasedTypeSystem.xtend
@@ -102,7 +102,7 @@ class ConstraintBasedTypeSystem implements TypeSystem, TypeProvider {
 	// ************************************************************************
 	override inferTypes() {
 		// These constraints have to be created after all files have been `analise`d
-		constraintGenerator.addInheritanceConstraints
+		constraintGenerator.addCrossReferenceConstraints
 
 		var currentStage = 0
 

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstructorConstraintsGenerator.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstructorConstraintsGenerator.xtend
@@ -1,0 +1,34 @@
+package org.uqbar.project.wollok.typesystem.constraints
+
+import java.util.List
+import org.uqbar.project.wollok.typesystem.constraints.variables.TypeVariablesRegistry
+import org.uqbar.project.wollok.wollokDsl.WConstructorCall
+
+import static extension org.uqbar.project.wollok.utils.XtendExtensions.biForEach
+import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.resolveConstructor
+
+/**
+ * @author npasserini
+ */
+class ConstructorConstraintsGenerator {
+	extension TypeVariablesRegistry registry
+	
+	List<WConstructorCall> constructorCalls = newArrayList
+	
+	new(TypeVariablesRegistry registry) {
+		this.registry = registry
+	}
+
+	def addConstructorCall(WConstructorCall call) {
+		this.constructorCalls.add(call)
+	}
+
+	def run() {
+		constructorCalls.forEach[
+			val constructor = classRef.resolveConstructor(arguments)
+			constructor.parameters.biForEach(arguments)[param, arg|
+				arg.tvar.beSubtypeOf(param.tvar)
+			]
+		]
+	}
+}

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstructorConstraintsGenerator.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstructorConstraintsGenerator.xtend
@@ -26,7 +26,11 @@ class ConstructorConstraintsGenerator {
 	def run() {
 		constructorCalls.forEach[
 			val constructor = classRef.resolveConstructor(arguments)
-			constructor.parameters.biForEach(arguments)[param, arg|
+
+			// Constructor might be null when neither the referred class nor any of it superclasses define a constructor,
+			// And wouldn't be an error if the constructor call has no parameters.
+			// TODO Handle and inform error conditions.
+			constructor?.parameters?.biForEach(arguments)[param, arg|
 				arg.tvar.beSubtypeOf(param.tvar)
 			]
 		]

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/editor/annotations/WOverrideIndicatorModelListener.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/editor/annotations/WOverrideIndicatorModelListener.xtend
@@ -14,22 +14,20 @@ import org.eclipse.jface.text.source.Annotation
 import org.eclipse.jface.text.source.IAnnotationModel
 import org.eclipse.jface.text.source.IAnnotationModelExtension
 import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.ui.editor.IXtextEditorCallback
 import org.eclipse.xtext.ui.editor.SchedulingRuleFactory
 import org.eclipse.xtext.ui.editor.XtextEditor
 import org.eclipse.xtext.ui.editor.model.IXtextModelListener
 import org.eclipse.xtext.util.concurrent.IUnitOfWork
 import org.uqbar.project.wollok.wollokDsl.WFile
 import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
-import org.eclipse.xtext.ui.editor.IXtextEditorCallback.NullImpl
-
-import static org.uqbar.project.wollok.ui.editor.annotations.WOverrideIndicatorModelListener.*
 
 import static extension org.eclipse.xtext.nodemodel.util.NodeModelUtils.*
 
 /**
  * @author jfernandes
  */
-class WOverrideIndicatorModelListener extends NullImpl implements IXtextModelListener {
+class WOverrideIndicatorModelListener extends IXtextEditorCallback.NullImpl implements IXtextModelListener {
 	public static final String JOB_NAME = "Override Indicator Updater";
 	private static ISchedulingRule SCHEDULING_RULE = SchedulingRuleFactory.INSTANCE.newSequence();
 	private Job currentJob
@@ -48,13 +46,13 @@ class WOverrideIndicatorModelListener extends NullImpl implements IXtextModelLis
 	}
 
 	override beforeDispose(XtextEditor xtextEditor) {
-		if (this.xtextEditor != null) {
+		if (this.xtextEditor !== null) {
 			this.xtextEditor = null;
 		}
 	}
 	
 	def installModelListener(XtextEditor xtextEditor) {
-		if (xtextEditor.getDocument != null) {
+		if (xtextEditor.getDocument !== null) {
 			asyncUpdateAnnotationModel
 			xtextEditor.document.addModelListener(this)
 		}
@@ -67,7 +65,7 @@ class WOverrideIndicatorModelListener extends NullImpl implements IXtextModelLis
 	}
 	
 	private def asyncUpdateAnnotationModel() {
-		if (currentJob != null) {
+		if (currentJob !== null) {
 			currentJob.cancel
 		}
 
@@ -90,7 +88,7 @@ class WOverrideIndicatorModelListener extends NullImpl implements IXtextModelLis
 		val annotationToPosition = xtextDocument
 				.readOnly(new IUnitOfWork<Map<Annotation, Position>, XtextResource>() {
 					override exec(XtextResource xtextResource) {
-						if (xtextResource == null)
+						if (xtextResource === null)
 							Collections.emptyMap
 						else
 							createOverrideIndicatorAnnotationMap(xtextResource)
@@ -110,13 +108,13 @@ class WOverrideIndicatorModelListener extends NullImpl implements IXtextModelLis
 	}
 	
 	private def anyIsNull() {
-		xtextEditor == null || xtextEditor.getDocument() == null || xtextEditor.internalSourceViewer.annotationModel == null
+		xtextEditor === null || xtextEditor.getDocument() === null || xtextEditor.internalSourceViewer.annotationModel === null
 	}
 	
 	def private getLockObject(IAnnotationModel annotationModel) {
 		if (annotationModel instanceof ISynchronizable) {
 			val lock = (annotationModel as ISynchronizable).lockObject
-			if (lock != null)
+			if (lock !== null)
 				return lock
 		}
 		return annotationModel;

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -103,7 +103,7 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 		]
 	}
 
-	protected def WollokObject[] evalEach(EList e) { e.map[eval] }
+	protected def WollokObject[] evalEach(EList<? extends EObject> objects) { objects.map[eval] }
 
 	/* BINARY */
 	override resolveBinaryOperation(String operator) { operator.asBinaryOperation }
@@ -467,5 +467,4 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 			createNamedObject(classFinder.getCachedObject(context, qualifiedName), qualifiedName)
 		}
 	}
-
 }


### PR DESCRIPTION
I understand that this covers all "traditional" constructors, both in the directly reference class and inherited. I used the look up strategy already present (`resolveConstructor`). @fdodino please verify my logic.

We should create another issue / pr for automatic (name-based) initialization which is not considered anywhere in TS.