### PR TITLE
fix: remove unused messages

### DIFF
--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
@@ -106,7 +106,6 @@ WollokDslValidator_VARIABLE_NEVER_USED = Esta variable nunca se utiliza
 WollokDslValidator_PARAMETER_NEVER_USED = Este par\u00E1metro nunca se utiliza
 WollokDslValidator_WARN_VARIABLE_NEVER_ASSIGNED = Esta variable nunca se asigna
 
-WollokDslValidator_PROPERTY_ONLY_ALLOWED_IN_METHOD_CONTAINER = S\u00F3lo se puede definir una propiedad en un objeto, clase o mixin
 WollokDslValidator_PROPERTY_NOT_WRITABLE = No se puede modificar la propiedad constante {0}
 
 WollokDslValidator_DUPLICATED_CONSTRUCTOR = Ya hay otro constructor con la misma cantidad de par\u00E1metros
@@ -198,7 +197,6 @@ SYNTAX_DIAGNOSIS_BAD_MESSAGE = Mensaje incorrecto: {0}
 # ** Conversions
 # ****************************
 WollokConversion_INVALID_CONVERSION = El valor {0} no puede convertirse al tipo {1}
-WollokConversion_UNSUPPORTED_CONVERSION_WOLLOK_JAVA = Conversi\u00F3n no v\u00E1lida de {0} ({1}) hacia Wollok
 WollokConversion_INTEGER_VALUE_REQUIRED = {0} debe ser un n\u00FAmero entero
 WollokConversion_POSITIVE_INTEGER_VALUE_REQUIRED = {0} debe ser un n\u00FAmero positivo y entero
 WollokConversion_DECIMAL_SCALE_REQUIRED = El valor {0} debe tener menos de {1} posiciones decimales

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
@@ -106,6 +106,7 @@ WollokDslValidator_VARIABLE_NEVER_USED = Esta variable nunca se utiliza
 WollokDslValidator_PARAMETER_NEVER_USED = Este par\u00E1metro nunca se utiliza
 WollokDslValidator_WARN_VARIABLE_NEVER_ASSIGNED = Esta variable nunca se asigna
 
+WollokDslValidator_PROPERTY_ONLY_ALLOWED_IN_CERTAIN_METHOD_CONTAINERS = S\u00F3lo se puede definir una propiedad en un objeto, clase o mixin
 WollokDslValidator_PROPERTY_NOT_WRITABLE = No se puede modificar la propiedad constante {0}
 
 WollokDslValidator_DUPLICATED_CONSTRUCTOR = Ya hay otro constructor con la misma cantidad de par\u00E1metros


### PR DESCRIPTION
Actually, if you run tests in the dev env, it produces no warnings, but the prod env does. If searched for the two reported message strings and they do not seem to be used, so I propose to remove them.