### PR TITLE
Fix #1443 - Outline page refresh without ClassCast

### DIFF
--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/WollokActivator.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/WollokActivator.xtend
@@ -111,7 +111,11 @@ class WollokActivator extends org.uqbar.project.wollok.ui.internal.WollokActivat
 		Display.^default.syncExec [
 			val outlineView = activePage.findView("org.eclipse.ui.views.ContentOutline") as ContentOutline
 			if (outlineView !== null) {
-				(outlineView.currentPage as OutlinePage).scheduleRefresh
+				val outlinePage = outlineView.currentPage
+				try {
+					(outlinePage as OutlinePage).scheduleRefresh
+				} catch (ClassCastException e) {
+				}
 			}
 		]
 	}


### PR DESCRIPTION
Just a simple empty catch to avoid an error log