### PR TITLE
Fix #1324 repl console mac

### DIFF
--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
@@ -58,7 +58,11 @@ class WollokLauncher extends WollokChecker {
 			interpreter.interpret(parsed)
 	
 			if (parameters.hasRepl) {
-				val formatter = if (parameters.noAnsiFormat) new RegularReplOutputFormatter else new AnsiColoredReplOutputFormatter 
+				val formatter = if (parameters.noAnsiFormat) new RegularReplOutputFormatter else new AnsiColoredReplOutputFormatter
+				// FIXME: Issue #
+				// TODO 1: Preguntar si es MAC
+				// TODO 2: Pasarlo a una configuración de Wollok
+				// val formatter = new RegularReplOutputFormatter
 				new WollokRepl(this, injector, interpreter, mainFile, parsed, formatter).startRepl
 			}
 			System.exit(0)

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncher.xtend
@@ -19,6 +19,8 @@ import org.uqbar.project.wollok.launch.repl.RegularReplOutputFormatter
 import org.uqbar.project.wollok.launch.repl.WollokRepl
 import org.uqbar.project.wollok.wollokDsl.WFile
 
+import static extension org.uqbar.project.wollok.utils.OperatingSystemUtils.*
+
 /**
  * Main program launcher for the interpreter.
  * Able to run in debug mode in which case it will open ports and publish
@@ -58,11 +60,7 @@ class WollokLauncher extends WollokChecker {
 			interpreter.interpret(parsed)
 	
 			if (parameters.hasRepl) {
-				val formatter = if (parameters.noAnsiFormat) new RegularReplOutputFormatter else new AnsiColoredReplOutputFormatter
-				// FIXME: Issue #
-				// TODO 1: Preguntar si es MAC
-				// TODO 2: Pasarlo a una configuración de Wollok
-				// val formatter = new RegularReplOutputFormatter
+				val formatter = if (parameters.noAnsiFormat || isOsMac) new RegularReplOutputFormatter else new AnsiColoredReplOutputFormatter
 				new WollokRepl(this, injector, interpreter, mainFile, parsed, formatter).startRepl
 			}
 			System.exit(0)

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
@@ -28,7 +28,6 @@ import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
  * @author tesonep
  * @author jfernandes
  */
-// I18N
 class WollokRepl {
 	val Injector injector
 	val WollokLauncher launcher

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokAnsiColorLineStyleListener.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokAnsiColorLineStyleListener.xtend
@@ -11,6 +11,7 @@ import org.eclipse.swt.graphics.Font
 import org.eclipse.swt.graphics.GlyphMetrics
 
 import static org.uqbar.project.wollok.ui.console.highlight.AnsiCommands.*
+import static org.uqbar.project.wollok.utils.OperatingSystemUtils.*
 
 /**
  * A LineStyleListener that interprets ansi codes
@@ -87,10 +88,12 @@ class WollokAnsiColorLineStyleListener implements LineStyleListener {
         WollokConsoleAttributes.updateRangeStyle(range, lastAttributes)
         if (isCode) {
             val showEscapeCodes = WollokConsolePreferenceUtils.getBoolean(WollokConsolePreferenceConstants.PREF_SHOW_ESCAPES)
-            if (showEscapeCodes)
+            // FIXME: MAC // puede ser esto lo que reviente
+            if (showEscapeCodes || isOsMac)
                 range.font = new Font(null, "Monospaced", 6, SWT.NORMAL)
             else
                 range.metrics = new GlyphMetrics(0, 0, 0)
+            // fin FIXME
         }
         ranges.add(range)
         lastRangeEnd += range.length

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokAnsiColorLineStyleListener.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokAnsiColorLineStyleListener.xtend
@@ -88,12 +88,10 @@ class WollokAnsiColorLineStyleListener implements LineStyleListener {
         WollokConsoleAttributes.updateRangeStyle(range, lastAttributes)
         if (isCode) {
             val showEscapeCodes = WollokConsolePreferenceUtils.getBoolean(WollokConsolePreferenceConstants.PREF_SHOW_ESCAPES)
-            // FIXME: MAC // puede ser esto lo que reviente
             if (showEscapeCodes || isOsMac)
                 range.font = new Font(null, "Monospaced", 6, SWT.NORMAL)
             else
                 range.metrics = new GlyphMetrics(0, 0, 0)
-            // fin FIXME
         }
         ranges.add(range)
         lastRangeEnd += range.length

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokConsoleColorPalette.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokConsoleColorPalette.xtend
@@ -1,6 +1,7 @@
 package org.uqbar.project.wollok.ui.console.highlight
 
 import org.eclipse.swt.graphics.RGB
+import static extension org.uqbar.project.wollok.utils.OperatingSystemUtils.*
 
 /**
  * 
@@ -144,7 +145,7 @@ class WollokConsoleColorPalette {
     }
 
     def static void setPalette(String paletteName) {
-        currentPaletteName = paletteName;
+        currentPaletteName = paletteName
         if (PALETTE_VGA.equalsIgnoreCase(paletteName))
             palette = paletteVGA
         else if (PALETTE_WINXP.equalsIgnoreCase(paletteName))
@@ -156,10 +157,9 @@ class WollokConsoleColorPalette {
         else if (PALETTE_XTERM.equalsIgnoreCase(paletteName))
             palette = paletteXTerm
         else {
-            val os = System.getProperty("os.name");
-            if (os === null || os.startsWith("Windows"))
+            if (isOsWindows)
                 setPalette(PALETTE_WINXP)
-            else if (os.startsWith("Mac"))
+            else if (isOsMac)
                 setPalette(PALETTE_MAC)
             else
                 setPalette(PALETTE_XTERM)

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokReplConsolePageParticipant.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokReplConsolePageParticipant.xtend
@@ -23,8 +23,9 @@ class WollokReplConsolePageParticipant implements IConsolePageParticipant {
 		if (page.control instanceof StyledText) {
             viewer = page.control as StyledText
             
-            //TODO: eventually this will be configurable (to enable / disable)
-            #[new WollokAnsiColorLineStyleListener, new WollokCodeHighLightLineStyleListener, new WollokStyleRangeListener(viewer)].forEach[
+            #[new WollokAnsiColorLineStyleListener, // si es mac lo más violento es volarlo, o probarlo 
+            	new WollokCodeHighLightLineStyleListener, new WollokStyleRangeListener(viewer)
+            ].forEach[
             	viewer.addLineStyleListener(it)
             	listeners += it	
             ]


### PR DESCRIPTION
Fixes #1324 . Now , console in Mac shows responses only in Black (no link underlined, no error in red, no values in blue). Normal behavior tested in Linux.

In a (near) future, we should upgrade Eclipse to Oxygen, and use SWT's latest solved version...