### PR TITLE
Fix #1401 - recursive relationships lead to stack overflow in toString

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -31,7 +31,7 @@ class Exception {
 	
 	/** @private */
 	method printStackTraceWithPreffix(preffix, printer) {
-		printer.println(preffix +  self.className() + (if (message != null) (": " + message.toString()) else ""))
+		printer.println(preffix + self.className() + (if (message != null) (": " + message.toString()) else ""))
 		
 		// TODO: eventually we will need a stringbuffer or something to avoid memory consumption
 		self.getStackTrace().forEach { e =>
@@ -505,13 +505,13 @@ class Collection {
 	
 	/** @private */
 	override method internalToSmartString(alreadyShown) =
-		self.toStringPrefix() + self.map{ e => if (alreadyShown.contains(e)) e.toSmartString(alreadyShown) else e.printString() }.join(', ') + self.toStringSufix()
+		self.toStringPreffix() + self.map{ e => e.toSmartString(alreadyShown) }.join(', ') + self.toStringSuffix()
 	
 	/** @private */
-	method toStringPrefix()
+	method toStringPreffix()
 	
 	/** @private */
-	method toStringSufix()
+	method toStringSuffix()
 	
 	/** Converts a collection to a list */
 	method asList()
@@ -580,10 +580,10 @@ class Set inherits Collection {
 	override method newInstance() = #{}
 	
 	/** @private */
-	override method toStringPrefix() = "#{"
+	override method toStringPreffix() = "#{"
 	
 	/** @private */
-	override method toStringSufix() = "}"
+	override method toStringSuffix() = "}"
 	
 	/** 
 	 * Converts this set to a list
@@ -750,10 +750,10 @@ class List inherits Collection {
 	method last() = self.get(self.size() - 1)
 
 	/** @private */		 
-	override method toStringPrefix() = "["
+	override method toStringPreffix() = "["
 	
 	/** @private */
-	override method toStringSufix() = "]"
+	override method toStringSuffix() = "]"
 
 	/** 
 	 * Converts this collection to a list. No effect on Lists.

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -27,11 +27,11 @@ class Exception {
 	}
 	
 	/** Prints this exception and its backtrace to the specified printer */
-	method printStackTrace(printer) { self.printStackTraceWithPreffix("", printer) }
+	method printStackTrace(printer) { self.printStackTraceWithPrefix("", printer) }
 	
 	/** @private */
-	method printStackTraceWithPreffix(preffix, printer) {
-		printer.println(preffix + self.className() + (if (message != null) (": " + message.toString()) else ""))
+	method printStackTraceWithPrefix(prefix, printer) {
+		printer.println(prefix + self.className() + (if (message != null) (": " + message.toString()) else ""))
 		
 		// TODO: eventually we will need a stringbuffer or something to avoid memory consumption
 		self.getStackTrace().forEach { e =>
@@ -39,7 +39,7 @@ class Exception {
 		}
 		
 		if (cause != null)
-			cause.printStackTraceWithPreffix("Caused by: ", printer)
+			cause.printStackTraceWithPrefix("Caused by: ", printer)
 	}
 	
 	/** @private */
@@ -505,10 +505,10 @@ class Collection {
 	
 	/** @private */
 	override method internalToSmartString(alreadyShown) =
-		self.toStringPreffix() + self.map{ e => e.toSmartString(alreadyShown) }.join(', ') + self.toStringSuffix()
+		self.toStringPrefix() + self.map{ e => e.toSmartString(alreadyShown) }.join(', ') + self.toStringSuffix()
 	
 	/** @private */
-	method toStringPreffix()
+	method toStringPrefix()
 	
 	/** @private */
 	method toStringSuffix()
@@ -580,7 +580,7 @@ class Set inherits Collection {
 	override method newInstance() = #{}
 	
 	/** @private */
-	override method toStringPreffix() = "#{"
+	override method toStringPrefix() = "#{"
 	
 	/** @private */
 	override method toStringSuffix() = "}"
@@ -750,7 +750,7 @@ class List inherits Collection {
 	method last() = self.get(self.size() - 1)
 
 	/** @private */		 
-	override method toStringPreffix() = "["
+	override method toStringPrefix() = "["
 	
 	/** @private */
 	override method toStringSuffix() = "]"

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
@@ -172,6 +172,7 @@ class ListTestCase extends CollectionTestCase {
 		'''.test
 	}		
 
+	// #1305 vs. #1401 - Infinite loop forces this test to change
 	@Test
 	def void elementsToString() {
 		'''
@@ -184,12 +185,18 @@ class ListTestCase extends CollectionTestCase {
 		}
 		
 		program c {
+			/*
 			assert.throwsExceptionWithMessage(
 				"Expected [[es un a]] but found [[cierto que era un b!]]", 
+				{ assert.equals([ a ], [ new B() ]) }
+			)
+			*/
+			assert.throwsExceptionWithMessage(
+				"Expected [[a[]]] but found [[a B[]]]", 
 				{ assert.equals([ a ], [ new B() ]) }
 			)
 		}
 		'''.interpretPropagatingErrors
 	}	
-		
+	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RecursiveToStringTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/RecursiveToStringTestCase.xtend
@@ -52,4 +52,27 @@ class RecursiveToStringTestCase extends AbstractWollokInterpreterTestCase {
 		'''.interpretPropagatingErrors
 	}
 
+	@Test
+	def void testMessageErrorInBidirectionalRelationship() {
+		'''
+		class Cuenta {
+			const property duenios = []
+		}
+		
+		class Duenio {
+			const property cuentas = []
+		}
+		
+		program prueba {
+			try {
+				const cuenta = new Cuenta()
+				const duenio = new Duenio(cuentas = [ cuenta ])
+				cuenta.duenios().add(duenio)
+				cuenta.metodoInexistente()
+			} catch e {
+				assert.equals("a Cuenta[duenios=[a Duenio[cuentas=[a Cuenta]]]] does not understand metodoInexistente()", e.getMessage())
+			}
+		}
+		'''.interpretPropagatingErrors
+	}
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/SetTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/SetTestCase.xtend
@@ -167,6 +167,7 @@ class SetTestCase extends CollectionTestCase {
 		'''.test
 	} 	
 	
+	// #1305 vs. #1401 - Infinite loop forces this test to change
 	@Test
 	def void elementsToString() {
 		'''
@@ -179,8 +180,14 @@ class SetTestCase extends CollectionTestCase {
 		}
 		
 		program c {
+			/*
 			assert.throwsExceptionWithMessage(
 				"Expected [#{es un a}] but found [#{cierto que era un b!}]", 
+				{ assert.equals(#{a}, #{new B()}) }
+			)
+			*/
+			assert.throwsExceptionWithMessage(
+				"Expected [#{a[]}] but found [#{a B[]}]", 
 				{ assert.equals(#{a}, #{new B()}) }
 			)
 		}


### PR DESCRIPTION
Estamos resolviendo los issues #1401 y #1414 , poniendo en la balanza que es preferible evitar un stack overflow en lugar de mostrar en forma elegante los elementos de una colección (por eso #1305 quedará en wontfix).
