### PR TITLE
Fix #1479 self type return

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/list.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/list.wlk.xt
@@ -24,6 +24,21 @@ class TestCollection {
 	
 		// XPECT type at occurrencesOf --> {(Number) => Number}
 		const occurrencesOf = { e => sample.occurrencesOf(e) }
+
+		// XPECT type at size --> {() => Number}
+		const size = { sample.size()) }
+
+		// XPECT type at add --> {(Number) => Void}
+		const add = { e => sample.add(e) }
+
+		// XPECT type at remove --> {(Number) => Void}
+		const remove = { e => sample.remove(e) }
+
+		// XPECT type at addAll --> {(Collection<Number>) => Void}
+		const addAll = { l => sample.addAll(l) }
+
+		// XPECT type at removeAll --> {(Collection<Number>) => Void}
+		const removeAll = { l => sample.removeAll(l) }
 	}
 
 	method basicClosures() {
@@ -33,6 +48,15 @@ class TestCollection {
 		// XPECT type at find --> Number
 		const find = sample.find { x => x.even }
 
+
+	//	 method forEach(closure) {
+	//	 method removeAllSuchThat(closure) {
+		// method all()
+		// method any()
+		// method findOrDefault()
+		// method findOrElse()
+		// method count()
+		// method anyOne()
 	}
 	
 	// Requieren comparable	
@@ -40,15 +64,16 @@ class TestCollection {
 	//	method max()		
 	//	method min(closure)
 	//	method min() = self.min({it => it})
-//		method sortedBy(closure)
+	// method sortedBy(closure)
 
 	//	Requieren sumables
 	//	method sum(closure) = self.fold(0, { acc, e => acc + closure.apply(e) })
 	//	method sum() = self.sum( {it => it} )
 
 	// Requiere method-scoped type parameters	
-	//	method map(closure) = self.fold([], { acc, e =>
-	//	method flatMap(closure) = self.fold(self.newInstance(), { acc, e =>
+	//	method map(closure)
+	//	method flatMap(closure)
+	//	method fold(closure) 
 }
 
 /**
@@ -67,9 +92,6 @@ class TestList {
 	// Métodos generales de collection pero que Requieren self type
 	//	 method filter(closure) = self.fold(self.newInstance(), { acc, e =>
 	//	method +(elements) {
-	//	method addAll(elements) { elements.forEach { e => self.add(e) } }
-	//	method removeAll(elements) { 
-	//	 method removeAllSuchThat(closure) {
 	//	method flatten() = self.flatMap { e => e }
 	//	method copy() {
 	//	method newInstance()	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/list.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/list.wlk.xt
@@ -12,53 +12,67 @@ class TestCollection {
 	const sample = [1, 2, 3]
 
 	method generalCollection() {
-		//  XPECT type  at asList --> List<Number>
+		// XPECT type  at asList --> List<Number>
 		const asList = sample.asList()
 		
-		//  XPECT type  at asSet --> Set<Number>
+		// XPECT type  at asSet --> Set<Number>
 		const asSet = sample.asSet()
 		
-		//  XPECT type  at isEmpty --> Boolean
+		// XPECT type  at isEmpty --> Boolean
 		const isEmpty = sample.isEmpty()
 		
-		//  XPECT type  at contains --> {(Number) => Boolean}
+		// XPECT type  at contains --> {(Number) => Boolean}
 		const contains = { e => sample.contains(e) }
 	
-		//  XPECT type  at occurrencesOf --> {(Number) => Number}
+		// XPECT type  at occurrencesOf --> {(Number) => Number}
 		const occurrencesOf = { e => sample.occurrencesOf(e) }
 
-		//  XPECT type  at size --> {() => Number}
+		// XPECT type  at size --> {() => Number}
 		const size = { sample.size()) }
 
-		//  XPECT type  at add --> {(Number) => Void}
+		// XPECT type  at anyOne --> {() => Number}
+		const anyOne = { sample.anyOne() }
+
+		// XPECT type  at add --> {(Number) => Void}
 		const add = { e => sample.add(e) }
 
-		//  XPECT type  at remove --> {(Number) => Void}
+		// XPECT type  at remove --> {(Number) => Void}
 		const remove = { e => sample.remove(e) }
 
-		//  XPECT type  at addAll --> {(Collection<Number>) => Void}
+		// XPECT type  at addAll --> {(Collection<Number>) => Void}
 		const addAll = { l => sample.addAll(l) }
 
-		//  XPECT type  at removeAll --> {(Collection<Number>) => Void}
+		// XPECT type  at removeAll --> {(Collection<Number>) => Void}
 		const removeAll = { l => sample.removeAll(l) }
 	}
 
 	method basicClosures() {
-		//  XPECT type  at filterSome --> Number
-		const filterSome = sample.filter { x => x.even }.first() 		
+		// XPECT type at forEach --> {({(Number) => Void}) => Void}
+		const forEach = { action => sample.forEach(action) } 
 
-		//  XPECT type  at find --> Number
-		const find = sample.find { x => x.even }
+		// XPECT type at filter --> {({(Number) => Boolean}) => List<Number>}
+		const filter = { cond => sample.filter(cond) } 
 
+		// XPECT type at find --> {({(Number) => Boolean}) => Number}
+		const find = { predicate => sample.find(predicate) }
 
-	//	 method forEach(closure) {
-	//	 method removeAllSuchThat(closure) {
-		// method all()
-		// method any()
-		// method findOrDefault()
-		// method findOrElse()
-		// method count()
-		// method anyOne()
+		// XPECT type at findOrDefault --> {({(Number) => Boolean}, Number) => Number}
+		const findOrDefault = { predicate, defaultValue => sample.findOrDefault(predicate, defaultValue) }
+
+		// XPECT type at findOrElse --> {({(Number) => Boolean}, {() => Number}) => Number}
+		const findOrElse = { predicate, actionIfAbsent => sample.findOrElse(predicate, actionIfAbsent) }
+
+		// XPECT type at removeAllSuchThat --> {({(Number) => Boolean}) => Void}
+		const removeAllSuchThat = { closure => sample.removeAllSuchThat(closure) }
+
+		// XPECT type at all --> {({(Number) => Boolean}) => Boolean}
+		const all = { predicate => sample.all(predicate) }
+
+		// XPECT type at any --> {({(Number) => Boolean}) => Boolean}
+		const any = { predicate => sample.any(predicate) }
+
+		// XPECT type at count --> {({(Number) => Boolean}) => Number}
+		const count = { predicate => sample.count(predicate)}
 	}
 	
 	// Requieren comparable	
@@ -86,12 +100,12 @@ class TestList {
 	const sample = [1, 2, 3]
 
 	method listSpecific() {
-		//  XPECT type  at first --> Number
+		// XPECT type  at first --> Number
 		const first = sample.first() 	
 	}
 
 	method selfTyped() {
-		//  XPECT type  at filter --> {({(Number) => Boolean}) => List<Number>}
+		// XPECT type  at filter --> {({(Number) => Boolean}) => List<Number>}
 		const filter = { cond => sample.filter(cond) } 
 
 	//	method +(elements) {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/list.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/list.wlk.xt
@@ -1,4 +1,6 @@
-/* XPECT_SETUP org.uqbar.project.wollok.tests.typesystem.xpect.TypeSystemXpectTestCase END_SETUP */
+/*  XPECT_SETUP
+org.uqbar.project.wollok.tests.typesystem.xpect.TypeSystemXpectTestCase
+END_SETUP  */
 
 /** 
  * Tests generales a todas las collecciones
@@ -10,42 +12,42 @@ class TestCollection {
 	const sample = [1, 2, 3]
 
 	method generalCollection() {
-		// XPECT type at asList --> List<Number>
+		//  XPECT type  at asList --> List<Number>
 		const asList = sample.asList()
 		
-		// XPECT type at asSet --> Set<Number>
+		//  XPECT type  at asSet --> Set<Number>
 		const asSet = sample.asSet()
 		
-		// XPECT type at isEmpty --> Boolean
+		//  XPECT type  at isEmpty --> Boolean
 		const isEmpty = sample.isEmpty()
 		
-		// XPECT type at contains --> {(Number) => Boolean}
+		//  XPECT type  at contains --> {(Number) => Boolean}
 		const contains = { e => sample.contains(e) }
 	
-		// XPECT type at occurrencesOf --> {(Number) => Number}
+		//  XPECT type  at occurrencesOf --> {(Number) => Number}
 		const occurrencesOf = { e => sample.occurrencesOf(e) }
 
-		// XPECT type at size --> {() => Number}
+		//  XPECT type  at size --> {() => Number}
 		const size = { sample.size()) }
 
-		// XPECT type at add --> {(Number) => Void}
+		//  XPECT type  at add --> {(Number) => Void}
 		const add = { e => sample.add(e) }
 
-		// XPECT type at remove --> {(Number) => Void}
+		//  XPECT type  at remove --> {(Number) => Void}
 		const remove = { e => sample.remove(e) }
 
-		// XPECT type at addAll --> {(Collection<Number>) => Void}
+		//  XPECT type  at addAll --> {(Collection<Number>) => Void}
 		const addAll = { l => sample.addAll(l) }
 
-		// XPECT type at removeAll --> {(Collection<Number>) => Void}
+		//  XPECT type  at removeAll --> {(Collection<Number>) => Void}
 		const removeAll = { l => sample.removeAll(l) }
 	}
 
 	method basicClosures() {
-		// XPECT type at filterSome --> Number
+		//  XPECT type  at filterSome --> Number
 		const filterSome = sample.filter { x => x.even }.first() 		
 
-		// XPECT type at find --> Number
+		//  XPECT type  at find --> Number
 		const find = sample.find { x => x.even }
 
 
@@ -84,15 +86,17 @@ class TestList {
 	const sample = [1, 2, 3]
 
 	method listSpecific() {
-		// XPECT type at first --> Number
+		//  XPECT type  at first --> Number
 		const first = sample.first() 	
 	}
 
+	method selfTyped() {
+		//  XPECT type  at filter --> {({(Number) => Boolean}) => List<Number>}
+		const filter = { cond => sample.filter(cond) } 
 
-	// Métodos generales de collection pero que Requieren self type
-	//	 method filter(closure) = self.fold(self.newInstance(), { acc, e =>
 	//	method +(elements) {
 	//	method flatten() = self.flatMap { e => e }
 	//	method copy() {
-	//	method newInstance()	
+	//	method newInstance()			
+	}
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/GenericType.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/GenericType.xtend
@@ -91,4 +91,10 @@ class GenericTypeSchema {
 	def GenericTypeInstance instanceFor(ConcreteType concreteType) {
 		new GenericTypeInstance(rawType, typeParameters.doMapValues[instanceFor(concreteType)])
 	}
+
+	// ************************************************************************
+	// ** Misc
+	// ************************************************************************
+	
+	override toString() '''«rawType.baseType»<«typeParameters»>'''
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/CollectionTypeDeclarations.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/CollectionTypeDeclarations.xtend
@@ -44,6 +44,7 @@ class CollectionTypeDeclarations extends TypeDeclarations {
 		C >> "isEmpty" === #[] => Boolean
 		C >> "contains" === #[E] => Boolean
 		C >> "asList" === #[] => List.of(E)
+		C >> "anyOne" === #[] => E
 
 		C >> "forEach" === #[closure(#[E], Void)] => Void
 		C >> "find" === #[predicate(E)] => E;
@@ -62,5 +63,6 @@ class CollectionTypeDeclarations extends TypeDeclarations {
 		C >> "remove" === #[E] => Void
 		C >> "addAll" === #[Collection.of(E)] => Void
 		C >> "removeAll" === #[Collection.of(E)] => Void
+		C >> "removeAllSuchThat" === #[predicate(E)] => Void
 	}
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/CollectionTypeDeclarations.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/CollectionTypeDeclarations.xtend
@@ -12,8 +12,8 @@ class CollectionTypeDeclarations extends TypeDeclarations {
 			it >> "occurrencesOf" === #[ELEMENT] => Number
 		]
 
-		// TODO This should use SELF type.
-		Collection >> "filter" === #[predicate(ELEMENT)] => List.of(ELEMENT);
+		Collection >> "filter" === #[predicate(ELEMENT)] => SelfType.of(ELEMENT);
+		Range >> "filter" === #[predicate(Number)] => List.of(Number);
 
 		(List == Any) => Boolean;
 		List + List.of(ELEMENT) => List.of(ELEMENT);
@@ -34,7 +34,6 @@ class CollectionTypeDeclarations extends TypeDeclarations {
 		Dictionary >> "forEach" === #[closure(#[DKEY, DVALUE], Void)] => Void;
 
 		Range >> "internalToSmartString" === #[Boolean] => String;
-		Range >> "filter" === #[closure(#[Number], Boolean)] => List.of(Number);
 
 		(Set == Any) => Boolean
 		Set >> "equals" === #[Any] => Boolean;

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/CollectionTypeDeclarations.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/CollectionTypeDeclarations.xtend
@@ -2,7 +2,6 @@ package org.uqbar.project.wollok.typesystem.annotations
 
 class CollectionTypeDeclarations extends TypeDeclarations {
 	override declarations() {
-		Collection >> "add" === #[ELEMENT] => Void
 		Collection + Collection.of(ELEMENT) => Collection.of(ELEMENT);
 		Collection >> "min" === #[closure(#[ELEMENT], Number)] => ELEMENT;
 		Collection >> "max" === #[closure(#[ELEMENT], Number)] => ELEMENT;
@@ -19,46 +18,50 @@ class CollectionTypeDeclarations extends TypeDeclarations {
 		(List == Any) => Boolean;
 		List + List.of(ELEMENT) => List.of(ELEMENT);
 		List >> "equals" === #[Any] => Boolean;
-		List >> "add" === #[ELEMENT] => Void
 		List >> "first" === #[] => ELEMENT
 		List >> "drop" === #[Number] => List.of(ELEMENT)
 		List >> "take" === #[Number] => List.of(ELEMENT)
-		List >> "sum" === #[closure(#[ELEMENT], Number)] => Number
 
-		val (AnnotationContext, TypeAnnotation)=>void basicCollection = [ collectionType, elementType |
-			collectionType >> "isEmpty" === #[] => Boolean
-			collectionType >> "contains" === #[elementType] => Boolean
-			collectionType >> "asList" === #[] => List.of(elementType)
-
-			collectionType >> "forEach" === #[closure(#[elementType], Void)] => Void
-			collectionType >> "find" === #[predicate(elementType)] => elementType;
-			collectionType >> "all" === #[predicate(elementType)] => Boolean
-			collectionType >> "any" === #[predicate(elementType)] => Boolean
-			collectionType >> "find" === #[predicate(elementType)] => elementType
-			collectionType >> "findOrDefault" === #[predicate(elementType), elementType] => elementType
-			collectionType >> "findOrElse" === #[predicate(elementType), closure(#[], elementType)] => elementType
-			collectionType >> "count" === #[predicate(elementType)] => Number
-		]
-
-		basicCollection.apply(Collection, ELEMENT)
-		basicCollection.apply(List, ELEMENT)
-		basicCollection.apply(Set, ELEMENT)
-		basicCollection.apply(Range, Number)
+		Collection.mutableCollection(ELEMENT)
+		List.mutableCollection(ELEMENT)
+		Set.mutableCollection(ELEMENT)
+		Range.basicCollection(Number)
 
 		#[Collection, List, Set, Range, Dictionary].forEach [
-		        it >> "size" === #[] => Number
+			it >> "size" === #[] => Number
 		]
 
 		Dictionary >> "forEach" === #[closure(#[DKEY, DVALUE], Void)] => Void;
 
-		Range >> "sum" === #[closure(#[Number], Number)] => Number;
 		Range >> "internalToSmartString" === #[Boolean] => String;
 		Range >> "filter" === #[closure(#[Number], Boolean)] => List.of(Number);
 
 		(Set == Any) => Boolean
 		Set >> "equals" === #[Any] => Boolean;
 		Set + Set.of(ELEMENT) => Set.of(ELEMENT);
-		Set >> "add" === #[ELEMENT] => Void
-		Set >> "sum" === #[closure(#[ELEMENT], Number)] => Number;
+	}
+
+	def basicCollection(AnnotationContext C, TypeAnnotation E) {
+		C >> "isEmpty" === #[] => Boolean
+		C >> "contains" === #[E] => Boolean
+		C >> "asList" === #[] => List.of(E)
+
+		C >> "forEach" === #[closure(#[E], Void)] => Void
+		C >> "find" === #[predicate(E)] => E;
+		C >> "all" === #[predicate(E)] => Boolean
+		C >> "any" === #[predicate(E)] => Boolean
+		C >> "find" === #[predicate(E)] => E
+		C >> "findOrDefault" === #[predicate(E), E] => E
+		C >> "findOrElse" === #[predicate(E), closure(#[], E)] => E
+		C >> "count" === #[predicate(E)] => Number
+		C >> "sum" === #[closure(#[E], Number)] => Number;
+	}
+
+	def mutableCollection(AnnotationContext C, TypeAnnotation E) {
+		C.basicCollection(E)
+		C >> "add" === #[E] => Void
+		C >> "remove" === #[E] => Void
+		C >> "addAll" === #[Collection.of(E)] => Void
+		C >> "removeAll" === #[Collection.of(E)] => Void
 	}
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/TypeAnnotation.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/TypeAnnotation.xtend
@@ -12,7 +12,7 @@ import org.uqbar.project.wollok.typesystem.WollokType
  * A concrete class or WKO which's methods we want to annotate.
  */
 interface AnnotationContext {
-	def ConcreteType getType()	
+	def ConcreteType getType()
 }
 
 /**
@@ -89,8 +89,9 @@ class ClassParameterTypeAnnotation implements TypeAnnotation {
 	String paramName
 
 	new(GenericType type, String paramName) {
-		if (!type.typeParameterNames.contains(paramName)) {
-			throw new IllegalArgumentException(NLS.bind(Messages.RuntimeTypeSystemException_BAD_TYPE_ANNOTATION, type, paramName))
+		if(!type.typeParameterNames.contains(paramName)) {
+			throw new IllegalArgumentException(
+				NLS.bind(Messages.RuntimeTypeSystemException_BAD_TYPE_ANNOTATION, type, paramName))
 		}
 
 		this.type = type
@@ -107,9 +108,32 @@ class GenericTypeInstanceAnnotation implements TypeAnnotation {
 
 	@Accessors
 	val Map<String, TypeAnnotation> typeParameters
-	
+
 	new(GenericType type, Map<String, TypeAnnotation> typeParameters) {
 		this.type = type
 		this.typeParameters = typeParameters
 	}
 }
+
+/**
+ * This allows to annotate something to be of the same type as the receiver. E.g. several collection 
+ * methods return objects of the same type of the receiver: Set.filter returns a Set and List.filter returns a List.
+ * 
+ * Right now this is only implemented self types for generic types with a single type parameter (such as collections)
+ */
+class GenericSelfTypeInstanceAnnotation implements TypeAnnotation {
+	@Accessors
+	TypeAnnotation uniqueTypeParameter
+
+	new(TypeAnnotation uniqueTypeParameter) {
+		this.uniqueTypeParameter = uniqueTypeParameter
+	}
+}
+
+/** Helper for the type declaration DSL to create SelfType annotations */
+class SelfType {
+	static def of(TypeAnnotation uniqueTypeParameter) {
+		new GenericSelfTypeInstanceAnnotation(uniqueTypeParameter)
+	}
+}
+

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/TypeDeclarations.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/TypeDeclarations.xtend
@@ -121,6 +121,7 @@ abstract class TypeDeclarations {
 	// ****************************************************************************
 	// ** Core class and object types
 	// ****************************************************************************
+
 	def Void() { new VoidTypeAnnotation() }
 
 	def Any() { new SimpleTypeAnnotation(WollokType.WAny) }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/typeRegistry/AnnotatedTypeRegistry.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/typeRegistry/AnnotatedTypeRegistry.xtend
@@ -4,20 +4,24 @@ import java.util.Map
 import org.eclipse.emf.ecore.EObject
 import org.uqbar.project.wollok.typesystem.ClassInstanceType
 import org.uqbar.project.wollok.typesystem.ConcreteType
+import org.uqbar.project.wollok.typesystem.GenericType
 import org.uqbar.project.wollok.typesystem.GenericTypeSchema
 import org.uqbar.project.wollok.typesystem.annotations.ClassParameterTypeAnnotation
+import org.uqbar.project.wollok.typesystem.annotations.GenericSelfTypeInstanceAnnotation
 import org.uqbar.project.wollok.typesystem.annotations.GenericTypeInstanceAnnotation
 import org.uqbar.project.wollok.typesystem.annotations.SimpleTypeAnnotation
 import org.uqbar.project.wollok.typesystem.annotations.TypeAnnotation
 import org.uqbar.project.wollok.typesystem.annotations.TypeDeclarationTarget
 import org.uqbar.project.wollok.typesystem.annotations.VoidTypeAnnotation
-import org.uqbar.project.wollok.typesystem.constraints.variables.GeneralTypeVariableSchema
+import org.uqbar.project.wollok.typesystem.constraints.variables.CompoundSelfTypeVariableSchema
+import org.uqbar.project.wollok.typesystem.constraints.variables.CompoundTypeVariableSchema
 import org.uqbar.project.wollok.typesystem.constraints.variables.GenericTypeInstance
 import org.uqbar.project.wollok.typesystem.constraints.variables.ITypeVariable
 import org.uqbar.project.wollok.typesystem.constraints.variables.ParameterTypeVariableOwner
 import org.uqbar.project.wollok.typesystem.constraints.variables.ProgramElementTypeVariableOwner
 import org.uqbar.project.wollok.typesystem.constraints.variables.TypeVariableOwner
 import org.uqbar.project.wollok.typesystem.constraints.variables.TypeVariablesRegistry
+import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
 
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 import static extension org.uqbar.project.wollok.utils.XtendExtensions.*
@@ -62,16 +66,22 @@ class AnnotatedTypeRegistry implements TypeDeclarationTarget {
 		newTypeVariable(owner) => [beSealed(annotation.type)]
 	}
 
-	def dispatch ITypeVariable beSealed(TypeVariableOwner owner, ClassParameterTypeAnnotation annotation) {
-		newClassParameterVar(owner, annotation.type, annotation.paramName)
-	}
-
 	def dispatch ITypeVariable beSealed(TypeVariableOwner owner, VoidTypeAnnotation annotation) {
 		newTypeVariable(owner) => [beVoid]
 	}
 
+	def dispatch ITypeVariable beSealed(TypeVariableOwner owner, ClassParameterTypeAnnotation annotation) {
+		newClassParameterVar(owner, annotation.type, annotation.paramName)
+	}
+
 	def dispatch ITypeVariable beSealed(TypeVariableOwner owner, GenericTypeInstanceAnnotation it) {
 		type.schemaOrInstance(typeParameters.beAllSealedFor(owner)).asTypeVariableFor(owner).register
+	}
+
+	def dispatch ITypeVariable beSealed(TypeVariableOwner owner, GenericSelfTypeInstanceAnnotation it) {
+		val baseType = owner.baseSelfType
+		val typeParameters = #{baseType.typeParameterNames.head -> uniqueTypeParameter}
+		baseType.schema(typeParameters.beAllSealedFor(owner)).asSelfTypeVariableFor(owner).register
 	}
 	
 	// ************************************************************************
@@ -89,10 +99,22 @@ class AnnotatedTypeRegistry implements TypeDeclarationTarget {
 	}
 
 	def dispatch asTypeVariableFor(GenericTypeSchema schema, TypeVariableOwner owner) {
-		new GeneralTypeVariableSchema(owner, schema)
+		new CompoundTypeVariableSchema(owner, schema)
+	}
+
+	def asSelfTypeVariableFor(GenericTypeSchema schema, TypeVariableOwner owner) {
+		new CompoundSelfTypeVariableSchema(owner, schema)
 	}
 
 	def asOwner(EObject programElement) {
 		new ProgramElementTypeVariableOwner(programElement)
+	}
+	
+	def dispatch GenericType baseSelfType(ProgramElementTypeVariableOwner it) {
+		programElement.baseSelfType
+	}
+
+	def dispatch GenericType baseSelfType(WMethodDeclaration it) {
+		registry.typeSystem.genericType(wollokClass)
 	}
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/typeRegistry/MethodTypeSchema.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/typeRegistry/MethodTypeSchema.xtend
@@ -9,7 +9,7 @@ import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
 
 /**
  * Type schemas are different from types in that they can have type variables inside.
- * E.g. method filter in type List<E> has type ()=>E
+ * E.g. method first in type List<E> has type ()=>E
  */
 abstract class MethodTypeSchema {
 	TypeVariablesRegistry registry

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/ClassParameterTypeVariable.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/ClassParameterTypeVariable.xtend
@@ -62,6 +62,10 @@ class ClassParameterTypeVariable extends TypeVariableSchema {
 		instanceFor(variable).beSupertypeOf(variable)
 	}
 
+	// ************************************************************************
+	// ** Instantiation (i.e. look for a related tvar, the actual tvar)
+	// ************************************************************************
+
 	override instanceFor(TypeVariable variable) {
 		variable.owner.classTypeParameter as TypeVariable
 	}
@@ -69,7 +73,11 @@ class ClassParameterTypeVariable extends TypeVariableSchema {
 	override instanceFor(ConcreteType concreteReceiver) {
 		(concreteReceiver as GenericTypeInstance).param(paramName)
 	}
-	
+
+	/**
+	 * Once this class type parameter is associated to a program element, we can get related to an actual 
+	 * type variable. This method and the following contain the algorithm for looking for that TVar.
+	 */
 	def dispatch ITypeVariable classTypeParameter(ProgramElementTypeVariableOwner owner) {
 		// TODO We are ignoring here other possible type variable owners, so this will be a problem soon.
 		owner.programElement.classTypeParameter
@@ -101,4 +109,4 @@ class ClassParameterTypeVariable extends TypeVariableSchema {
 	}
 		
 	override toString() '''t(«owner.debugInfo»: «genericType».«paramName»)'''
-	}
+}

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/CompoundSelfTypeVariableSchema.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/CompoundSelfTypeVariableSchema.xtend
@@ -1,0 +1,34 @@
+package org.uqbar.project.wollok.typesystem.constraints.variables
+
+import org.uqbar.project.wollok.typesystem.ConcreteType
+import org.uqbar.project.wollok.typesystem.GenericTypeSchema
+
+class CompoundSelfTypeVariableSchema extends TypeVariableSchema {
+	GenericTypeSchema schema
+
+	new(TypeVariableOwner owner, GenericTypeSchema schema) {
+		super(owner)
+		this.schema = schema
+	}
+
+	override getType() {
+		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	}
+
+	// ************************************************************************
+	// ** Instantiation
+	// ************************************************************************
+	override instanceFor(TypeVariable variable) {
+		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	}
+
+	override instanceFor(ConcreteType concreteReceiver) {
+		val typeSchema = new GenericTypeSchema((concreteReceiver as GenericTypeInstance).rawType, schema.typeParameters)
+		registry.newSealed(owner, typeSchema.instanceFor(concreteReceiver))
+	}
+
+	// ************************************************************************
+	// ** Misc
+	// ************************************************************************
+	override toString() '''Self<«schema.typeParameters»>'''
+}

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/CompoundTypeVariableSchema.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/CompoundTypeVariableSchema.xtend
@@ -1,0 +1,60 @@
+package org.uqbar.project.wollok.typesystem.constraints.variables
+
+import org.uqbar.project.wollok.typesystem.ConcreteType
+import org.uqbar.project.wollok.typesystem.GenericTypeSchema
+import org.uqbar.project.wollok.typesystem.WollokType
+import org.uqbar.project.wollok.wollokDsl.WBinaryOperation
+import org.uqbar.project.wollok.wollokDsl.WMemberFeatureCall
+import org.uqbar.project.wollok.wollokDsl.WSuperInvocation
+
+class CompoundTypeVariableSchema extends TypeVariableSchema {
+	GenericTypeSchema typeSchema
+	var instanceCount = 0
+		
+	new(TypeVariableOwner owner, GenericTypeSchema typeSchema) {
+		super(owner)
+		this.typeSchema = typeSchema
+	}
+	
+ 	override getType() {
+		WollokType.WAny // TODO
+	}
+	
+	/**
+	 * I can have supertypes when I am used as return type for a method. 
+	 * The received type variable should be a a message send 
+	 * (i.e. {@link WMemberFeatureCall}, {@link WBinaryOperation} or {@link WSuperInvocation}
+	 */
+	def dispatch beSubtypeOf(TypeVariable variable) {
+		instanceFor(variable).beSubtypeOf(variable)
+	}
+	
+	/**
+	 * I can have subtypes when I am used as parameter type for a method. 
+	 * The received type variable should be being used as a parametr to a message send, i.e.
+	 * its container should be a message send, 
+	 * such as {@link WMemberFeatureCall}, {@link WBinaryOperation} or {@link WSuperInvocation}.
+	 */
+	def dispatch beSupertypeOf(TypeVariable variable) {
+		instanceFor(variable).beSupertypeOf(variable)
+	}
+
+	// ************************************************************************
+	// ** Schema instantiation
+	// ************************************************************************
+	
+	override instanceFor(TypeVariable variable) {
+		registry.newSealed(createOwner, typeSchema.instanceFor(variable))
+	}
+	
+	override instanceFor(ConcreteType concreteReceiver) {
+		registry.newSealed(createOwner, typeSchema.instanceFor(concreteReceiver))
+	}
+	
+	def createOwner() {
+		new ParameterTypeVariableOwner(owner, '''$« instanceCount += 1 »''')
+	}
+	
+	override toString() '''t(«owner.debugInfoInContext»: «typeSchema»)'''
+	
+}

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/ITypeVariable.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/ITypeVariable.xtend
@@ -5,6 +5,9 @@ import org.uqbar.project.wollok.typesystem.ConcreteType
 import org.uqbar.project.wollok.typesystem.Messages
 import org.uqbar.project.wollok.typesystem.WollokType
 
+/**
+ * Superclass of actual type variables and type variable schemas.
+ */
 abstract class ITypeVariable {
 	@Accessors
 	val TypeVariableOwner owner

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariableOwner.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariableOwner.xtend
@@ -175,7 +175,9 @@ class ParameterTypeVariableOwner extends TypeVariableOwner {
 		parent.errorReportTarget
 	}
 	
-	override debugInfo() '''tparam «paramName» of «parent.debugInfo»'''
+	def ownDebugInfo() '''if (paramName.startsWith("$")) "instance" else "param"» «paramName»'''
 	
-	override debugInfoInContext() '''tparam «paramName» of «parent.debugInfoInContext»'''
+	override debugInfo() '''«ownDebugInfo» of «parent.debugInfo»'''
+	
+	override debugInfoInContext() '''«ownDebugInfo» «paramName» of «parent.debugInfoInContext»'''
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariableSchema.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/variables/TypeVariableSchema.xtend
@@ -2,25 +2,18 @@ package org.uqbar.project.wollok.typesystem.constraints.variables
 
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtend.lib.annotations.Accessors
-import org.uqbar.project.wollok.typesystem.ConcreteType
-import org.uqbar.project.wollok.typesystem.GenericTypeSchema
-import org.uqbar.project.wollok.typesystem.WollokType
-import org.uqbar.project.wollok.wollokDsl.WBinaryOperation
-import org.uqbar.project.wollok.wollokDsl.WMemberFeatureCall
-import org.uqbar.project.wollok.wollokDsl.WSuperInvocation
 
 /**
- * I represent a type parameter that is bound to a class, for example I am the {@code E} in {@code List<E>}.
- * I am a class type parameter, please note that there is currently no support for method type parameters in Wollok type system.
+ * I represent a variable associated to some type of schema containing type parameters. 
+ * I can be simple, as {@code E} in {@code List<E>} (single class type parameter),
+ * compound, as `(E) => Boolean` as the paramter of List.find,
+ * or a self type, as the return type of List.filter (which is also compound).
  * 
  * In the current state of the art, parametric types (and hence, type parameters) are only introduced by type annotations,
- * But they can be progagated to other parts of the code that use objects with parametric types.
+ * but they can be progagated to other parts of the code that use objects with parametric types.
  * Blocks have also parametric types, but they are handled by normal type variables and a special type info ({@link ClosureTypeInfo}).
  * 
  * I am a proxy for a real type variable, which will be computed on each use. 
- * 
- * Since I am related to a class, current usage expects to be related to a message send, and the real type variable will be obtained
- * from the receiver of the message.
  */
 abstract class TypeVariableSchema extends ITypeVariable {
 	@Accessors
@@ -42,56 +35,4 @@ abstract class TypeVariableSchema extends ITypeVariable {
 		throw new UnsupportedOperationException("Yet not implemented")		
 	}
 
-}
-
-class GeneralTypeVariableSchema extends TypeVariableSchema {
-	GenericTypeSchema typeSchema
-	var instanceCount = 0
-		
-	new(TypeVariableOwner owner, GenericTypeSchema typeSchema) {
-		super(owner)
-		this.typeSchema = typeSchema
-	}
-	
- 	override getType() {
-		WollokType.WAny // TODO
-	}
-	
-	/**
-	 * I can have supertypes when I am used as return type for a method. 
-	 * The received type variable should be a a message send 
-	 * (i.e. {@link WMemberFeatureCall}, {@link WBinaryOperation} or {@link WSuperInvocation}
-	 */
-	def dispatch beSubtypeOf(TypeVariable variable) {
-		instanceFor(variable).beSubtypeOf(variable)
-	}
-	
-	/**
-	 * I can have subtypes when I am used as parameter type for a method. 
-	 * The received type variable should be being used as a parametr to a message send, i.e.
-	 * its container should be a message send, 
-	 * such as {@link WMemberFeatureCall}, {@link WBinaryOperation} or {@link WSuperInvocation}.
-	 */
-	def dispatch beSupertypeOf(TypeVariable variable) {
-		instanceFor(variable).beSupertypeOf(variable)
-	}
-
-	// ************************************************************************
-	// ** Schema instantiation
-	// ************************************************************************
-	
-	override instanceFor(TypeVariable variable) {
-		registry.newSealed(createOwner, typeSchema.instanceFor(variable))
-	}
-	
-	override instanceFor(ConcreteType concreteReceiver) {
-		registry.newSealed(createOwner, typeSchema.instanceFor(concreteReceiver))
-	}
-	
-	def createOwner() {
-		new ParameterTypeVariableOwner(owner, '''$« instanceCount += 1 »''')
-	}
-	
-	override toString() '''t(«owner.debugInfoInContext»: «typeSchema»)'''
-	
 }


### PR DESCRIPTION
Now #[].filter(...) returns a list and #{}.filter(...) returns a set.
Even if both are the same method filter from collection.

Also, several list methods have been typed, see list.wlk.xt for details.