### PR TITLE
Fix #1404 - fake native class throws an ugly exception

### DIFF
--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/Messages.java
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/Messages.java
@@ -15,7 +15,6 @@ public class Messages extends NLS {
 	public static String LINE;
 	public static String REPL_WELCOME;
 	public static String REPL_END;
-	public static String WVM_ERROR;
 
 	// ****************************
 	// ** Launcher messages

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherInterpreterEvaluator.xtend
@@ -12,10 +12,10 @@ import org.uqbar.project.wollok.wollokDsl.WFile
 import org.uqbar.project.wollok.wollokDsl.WSuite
 import org.uqbar.project.wollok.wollokDsl.WTest
 
+import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
 import static extension org.uqbar.project.wollok.launch.tests.WollokExceptionUtils.*
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
-import org.uqbar.project.wollok.interpreter.core.WollokProgramExceptionWrapper
 
 /**
  * 

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages.properties
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages.properties
@@ -8,7 +8,6 @@ ALL_TEST_IN_FOLDER=All tests in folder {0}
 REPL_WELCOME=Wollok interactive console (type \"quit\" to quit):
 REPL_END=Quitting console. Bye!
 LINE=line
-WVM_ERROR=Wollok VM Error in line 
 
 # Launcher
 WollokLauncher_REQUEST_PORT_EVENTS_PORT_ARE_BOTH_REQUIRED = Both RequestsPort and EventsPort should be informed

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages_es.properties
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages_es.properties
@@ -9,7 +9,6 @@ ALL_TEST_IN_FOLDER=Todos los tests de la carpeta {0}
 REPL_WELCOME=Consola Interactiva de Wollok (escriba \"quit\" para salir):
 REPL_END=Consola terminada. Hasta luego!
 LINE=l\u00EDnea
-WVM_ERROR=Error de la VM de Wollok en la l\u00EDnea
 
 # Launcher
 WollokLauncher_REQUEST_PORT_EVENTS_PORT_ARE_BOTH_REQUIRED = Las opciones RequestsPort y EventsPort son obligatorias

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
@@ -169,9 +169,10 @@ class WollokRepl {
 	}
 
 	def stackTraceAsString(Throwable e) {
-		val s = new ByteArrayOutputStream
-		e.printStackTrace(new PrintStream(s))
-		new String(s.toByteArray)
+		//val s = new ByteArrayOutputStream
+		//e.printStackTrace(new PrintStream(s))
+		//new String(s.toByteArray)
+		e.message
 	}
 
 	def getNumberOfLinesBefore() {

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
@@ -2,10 +2,8 @@ package org.uqbar.project.wollok.launch.repl
 
 import com.google.inject.Injector
 import java.io.BufferedReader
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStreamReader
-import java.io.PrintStream
 import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.util.LazyStringInputStream
@@ -27,6 +25,7 @@ import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
  * 
  * @author tesonep
  * @author jfernandes
+
  */
 class WollokRepl {
 	val Injector injector
@@ -169,9 +168,6 @@ class WollokRepl {
 	}
 
 	def stackTraceAsString(Throwable e) {
-		//val s = new ByteArrayOutputStream
-		//e.printStackTrace(new PrintStream(s))
-		//new String(s.toByteArray)
 		e.message
 	}
 
@@ -208,14 +204,7 @@ class WollokRepl {
 	}
 
 	def dispatch void handleException(WollokInterpreterException e) {
-		if (e.lineNumber > numberOfLinesBefore) {
-			printlnIdent('''«WVM_ERROR» («e.lineNumber - numberOfLinesBefore»): «e.nodeText»:'''.errorStyle)
-		}
-
-		if (e.cause !== null) {
-			indent
-			handleException(e.cause)
-		}
+		printlnIdent(e.convertToString.errorStyle)
 	}
 
 	def getPrompt() {

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokExceptionUtils.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokExceptionUtils.xtend
@@ -1,89 +1,14 @@
 package org.uqbar.project.wollok.launch.tests
 
-import java.io.PrintWriter
-import java.io.StringWriter
-import java.util.List
 import org.eclipse.osgi.util.NLS
 import org.uqbar.project.wollok.Messages
-import org.uqbar.project.wollok.errorHandling.StackTraceElementDTO
 import org.uqbar.project.wollok.interpreter.WollokInterpreterException
-import org.uqbar.project.wollok.interpreter.core.WollokObject
 import org.uqbar.project.wollok.interpreter.core.WollokProgramExceptionWrapper
 import wollok.lib.AssertionException
 
 import static org.uqbar.project.wollok.sdk.WollokDSK.*
 
-import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
-import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions.*
-
 class WollokExceptionUtils {
-
-
-	/**
-	 * Converts a StackTraceElementDTO to a List of parseable Strings for a RMI call
-	 */
-	def static dispatch List<StackTraceElementDTO> convertStackTrace(Exception exception) {
-		newArrayList
-	}
-
-	def static dispatch List<StackTraceElementDTO> convertStackTrace(WollokProgramExceptionWrapper exception) {
-		exception.wollokException.internalStackTraceToDTO
-	}
-
-	def static dispatch List<StackTraceElementDTO> convertStackTrace(WollokObject wollokException) {
-		wollokException.internalStackTraceToDTO
-	}
-
-	/**
-	 * Converts an exception to a String
-	 */
-	def static dispatch String convertToString(WollokProgramExceptionWrapper exception) {
-		val wollokException = exception.wollokException
-		val className = wollokException.call("className").wollokToJava(String) as String
-		val message = exception.wollokMessage
-		val concatMessage = if (message !== null) ": " + message else "" 
-		return className + concatMessage
-	}
-
-	def static dispatch String convertToString(WollokInterpreterException exception) {
-		return "ERROR: " + exception.originalCause.message
-	}
-
-	def static Throwable originalCause(Throwable e) {
-		if (e.cause === null) return e
-		e.cause.originalCause
-	}
-	
-	def static dispatch String convertToString(Exception exception) {
-		val sw = new StringWriter
-		exception.printStackTrace(new PrintWriter(sw))
-		sw.toString
-	}
-
-	def static dispatch String convertToString(WollokObject exception) {
-		exception.call("getStackTrace").wollokToJava(String) as String
-	}
-	
-	/**
-	 * Prepares an exception for a RMI call
-	 */
-	def static dispatch void prepareExceptionForTrip(Throwable e) {
-		if (e.cause !== null)
-			e.cause.prepareExceptionForTrip
-	}
-
-	def static dispatch void prepareExceptionForTrip(WollokInterpreterException e) {
-		e.sourceElement = null
-
-		if (e.cause !== null)
-			e.cause.prepareExceptionForTrip
-	}
-
-	def static dispatch void prepareExceptionForTrip(WollokProgramExceptionWrapper e) {
-		e.URI = null
-		if (e.cause !== null)
-			e.cause.prepareExceptionForTrip
-	}
 
 	/**
 	 * Determines whether an exception is an AssertionException 
@@ -120,33 +45,4 @@ class WollokExceptionUtils {
 		throw new IllegalArgumentException(NLS.bind(Messages.WollokInterpreter_assertionExceptionNotValid, e.class.name))
 	}
 
-	/**
-	 * Gets current URI
-	 */
-	def static dispatch getURI(WollokInterpreterException e) {
-		e.objectURI
-	}
-	
-	def static dispatch getURI(WollokProgramExceptionWrapper e) {
-		e.URI
-	}
-	
-	def static dispatch getURI(Exception e) {
-		throw new IllegalArgumentException(NLS.bind(Messages.WollokInterpreter_assertionExceptionNotValid, e.class.name))
-	}
-	
-	/**
-	 * Get current line number
-	 */
-	def static dispatch getLineNumber(WollokInterpreterException e) {
-		e.lineNumber
-	}
-	
-	def static dispatch getLineNumber(WollokProgramExceptionWrapper e) {
-		e.lineNumber
-	}
-	
-	def static dispatch getLineNumber(Exception e) {
-		throw new IllegalArgumentException(NLS.bind(Messages.WollokInterpreter_assertionExceptionNotValid, e.class.name))
-	}
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteTestReporter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/WollokRemoteTestReporter.xtend
@@ -14,7 +14,7 @@ import org.uqbar.project.wollok.wollokDsl.WFile
 import org.uqbar.project.wollok.wollokDsl.WTest
 import wollok.lib.AssertionException
 
-import static extension org.uqbar.project.wollok.launch.tests.WollokExceptionUtils.*
+import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 
 /**

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/json/WollokJSONTestsReporter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/json/WollokJSONTestsReporter.xtend
@@ -13,7 +13,7 @@ import org.uqbar.project.wollok.wollokDsl.WTest
 import wollok.lib.AssertionException
 
 import static extension org.uqbar.project.wollok.ui.utils.XTendUtilExtensions.*
-import static extension org.uqbar.project.wollok.launch.tests.WollokExceptionUtils.*
+import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
 
 /**
  * A test reporter that prints to console in JSON format.

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/TestTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/TestTestCase.xtend
@@ -3,7 +3,7 @@ package org.uqbar.project.wollok.tests.interpreter
 import org.junit.Assert
 import org.junit.Test
 import org.uqbar.project.wollok.interpreter.WollokInterpreterException
-import static extension org.uqbar.project.wollok.launch.tests.WollokExceptionUtils.*
+import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
 
 /**
  * @author tesonep

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/WollokComparisonFailure.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/WollokComparisonFailure.xtend
@@ -3,8 +3,7 @@ package org.uqbar.project.wollok.tests.interpreter
 import org.junit.ComparisonFailure
 import org.uqbar.project.wollok.interpreter.core.WollokObject
 import org.uqbar.project.wollok.interpreter.core.WollokProgramExceptionWrapper
-import org.uqbar.project.wollok.launch.tests.WollokExceptionUtils
-
+import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
 import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions.wollokToJava
 
 class WollokComparisonFailure extends ComparisonFailure {
@@ -27,7 +26,7 @@ class WollokComparisonFailure extends ComparisonFailure {
 		if(wollokException === null)
 			return this
 		
-		val elements = WollokExceptionUtils.convertStackTrace(wollokException).map[asStackTraceElement]
+		val elements = wollokException.convertStackTrace.map[asStackTraceElement]
 		stackTrace = elements.toArray(<StackTraceElement>newArrayOfSize(0))
 		this
 	}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/natives/NativeTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/natives/NativeTestCase.xtend
@@ -121,4 +121,20 @@ class NativeTestCase extends AbstractWollokInterpreterTestCase {
 		''']
 		.interpretPropagatingErrors
 	}
+	
+	@Test
+	def void nativeMethodInAFakeNativeClass() {
+		#["natives"->'''
+			class FakeNativeClass {
+				method aNativeMethod() native
+			}
+			
+			test "native method in a fake native class" {
+				assert.throwsExceptionWithMessage("You declared a native method but there is no native definition for natives.FakeNativeClass (maybe it is a pure Wollok definition)", 
+				{ new FakeNativeClass() })
+			}
+		''']
+		.interpretPropagatingErrors
+	}
+	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
@@ -30,7 +30,8 @@ public class Messages extends NLS {
 	public static String WollokInterpreter_binaryOperationNotCompoundAssignment;
 	public static String WollokInterpreter_visualObjectWithoutPosition;
 	public static String WollokInterpreter_illegalOperationEmptyCollection;
-	
+	public static String WollokDslInterpreter_native_class_not_found;
+
 	public static String WollokScopeProvider_unresolvedImport;
 	
 	public static String WollokDslValidator_CLASS_NAME_MUST_START_UPPERCASE;

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/WollokExceptionExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/WollokExceptionExtensions.xtend
@@ -69,7 +69,7 @@ class WollokExceptionExtensions {
 	}
 
 	def static dispatch String convertToString(WollokInterpreterException exception) {
-		return "ERROR: " + exception.originalCause.message
+		exception.originalCause.convertToString
 	}
 	
 	def static dispatch String convertToString(Exception exception) {
@@ -164,6 +164,18 @@ class WollokExceptionExtensions {
 	def static Throwable originalCause(Throwable e) {
 		if (e.cause === null) return e
 		e.cause.originalCause
+	}
+	
+	def static String originalMessage(Throwable e) {
+		e.originalCause.doOriginalMessage 
+	}
+	
+	def static dispatch doOriginalMessage(WollokProgramExceptionWrapper e) {
+		e.wollokMessage
+	}
+	
+	def static dispatch doOriginalMessage(Throwable e) {
+		e.message		
 	}
 	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/WollokExceptionExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/WollokExceptionExtensions.xtend
@@ -1,7 +1,5 @@
 package org.uqbar.project.wollok.errorHandling
 
-import java.io.PrintWriter
-import java.io.StringWriter
 import java.util.List
 import org.eclipse.osgi.util.NLS
 import org.uqbar.project.wollok.Messages
@@ -23,12 +21,16 @@ class WollokExceptionExtensions {
 	/**
 	 * Converts a StackTraceElementDTO to a List of parseable Strings for a RMI call
 	 */
-	def static dispatch List<StackTraceElementDTO> convertStackTrace(Exception exception) {
+	def static dispatch List<StackTraceElementDTO> convertStackTrace(Throwable e) {
 		newArrayList
 	}
 
 	def static dispatch List<StackTraceElementDTO> convertStackTrace(WollokProgramExceptionWrapper exception) {
 		exception.wollokException.internalStackTraceToDTO
+	}
+
+	def static dispatch List<StackTraceElementDTO> convertStackTrace(WollokInterpreterException exception) {
+		exception.originalCause.convertStackTrace
 	}
 
 	def static dispatch List<StackTraceElementDTO> convertStackTrace(WollokObject wollokException) {
@@ -73,9 +75,7 @@ class WollokExceptionExtensions {
 	}
 	
 	def static dispatch String convertToString(Exception exception) {
-		val sw = new StringWriter
-		exception.printStackTrace(new PrintWriter(sw))
-		sw.toString
+		"ERROR: " + exception.message
 	}
 
 	def static dispatch String convertToString(WollokObject exception) {

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/WollokExceptionExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/WollokExceptionExtensions.xtend
@@ -68,6 +68,10 @@ class WollokExceptionExtensions {
 		return className + concatMessage
 	}
 
+	def static dispatch String convertToString(WollokInterpreterException exception) {
+		return "ERROR: " + exception.originalCause.message
+	}
+	
 	def static dispatch String convertToString(Exception exception) {
 		val sw = new StringWriter
 		exception.printStackTrace(new PrintWriter(sw))
@@ -155,6 +159,11 @@ class WollokExceptionExtensions {
 	
 	def static String printStackTrace(StackTraceElementDTO[] stackTrace) {
 		stackTrace.fold("", [ acum, ste | acum + ste.toLink ])
+	}
+
+	def static Throwable originalCause(Throwable e) {
+		if (e.cause === null) return e
+		e.cause.originalCause
 	}
 	
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterConsole.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterConsole.xtend
@@ -2,6 +2,7 @@ package org.uqbar.project.wollok.interpreter
 
 import java.io.Serializable
 import com.google.inject.Singleton
+import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
 
 /**
  * A console where the interpreter will write stuff into.
@@ -21,6 +22,6 @@ interface WollokInterpreterConsole extends Serializable {
 @Singleton
 class SysoutWollokInterpreterConsole implements WollokInterpreterConsole {
 	override logMessage(String message) { println(message)	}
-	override logError(Throwable exception) { exception.printStackTrace }
+	override logError(Throwable exception) { println("ERROR: " + exception.originalCause.message) }
 	override logError(String message) { System.err.println(message) }
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterConsole.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterConsole.xtend
@@ -3,6 +3,7 @@ package org.uqbar.project.wollok.interpreter
 import java.io.Serializable
 import com.google.inject.Singleton
 import static extension org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions.*
+import org.uqbar.project.wollok.errorHandling.WollokExceptionExtensions
 
 /**
  * A console where the interpreter will write stuff into.
@@ -22,6 +23,6 @@ interface WollokInterpreterConsole extends Serializable {
 @Singleton
 class SysoutWollokInterpreterConsole implements WollokInterpreterConsole {
 	override logMessage(String message) { println(message)	}
-	override logError(Throwable exception) { println("ERROR: " + exception.originalCause.message) }
+	override logError(Throwable exception) { println(exception.convertToString) }
 	override logError(String message) { System.err.println(message) }
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/WollokInterpreterEvaluator.xtend
@@ -248,7 +248,7 @@ class WollokInterpreterEvaluator implements XInterpreterEvaluator<WollokObject> 
 
 	def <T> newInstanceWithWrapped(String className, T wrapped) {
 		newInstance(className) => [
-			val JavaWrapper<T> native = getNativeObject(className)
+			val native = getNativeObject(className) as JavaWrapper<T>
 			native.wrapped = wrapped
 		]
 	}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
@@ -27,6 +27,7 @@ WollokInterpreter_constructorCallNotAllowed = Impossible to call a constructor o
 WollokInterpreter_binaryOperationNotCompoundAssignment = Binary operation is not a compound assignment
 WollokInterpreter_visualObjectWithoutPosition = Visual object doesn't have any position: {0}
 WollokInterpreter_illegalOperationEmptyCollection = Illegal operation ''{0}'' on empty collection
+WollokDslInterpreter_native_class_not_found = You declared a native method but there is no native definition for {0} (maybe it is a pure Wollok definition)
 
 # Scope provider
 WollokScopeProvider_unresolvedImport = Error while resolving import {0}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
@@ -26,6 +26,7 @@ WollokInterpreter_constructorCallNotAllowed = No puede llamar a un constructor d
 WollokInterpreter_binaryOperationNotCompoundAssignment = La operaci\u00F3n binaria no es una asignaci\u00F3n compuesta
 WollokInterpreter_visualObjectWithoutPosition = El objeto visual no tiene posici\u00F3n: {0}
 WollokInterpreter_illegalOperationEmptyCollection = Operaci\u00F3n '{0}' no permitida en colecciones vac\u00EDas
+WollokDslInterpreter_native_class_not_found = Declar\u00F3 un \u00E9todo nativo pero no se encontr\u00F3 la definici\u00F3n nativa de {0} (posiblemente se trate de un elemento definido s\u00F3lo en Wollok)
 
 # Scope provider
 WollokScopeProvider_unresolvedImport = Error al resolver el import {0}
@@ -101,7 +102,7 @@ WollokDslValidator_NATIVE_METHOD_ONLY_IN_CLASSES = M\u00E9todos nativos s\u00F3l
 
 WollokDslValidator_NO_EXPRESSION_AFTER_RETURN = Expresi\u00F3n inv\u00E1lida luego de un return
 WollokDslValidator_NO_EXPRESSION_AFTER_THROW = Expresi\u00F3n inv\u00E1lida luego de un throw
-WollokDslValidator_UNREACHABLE_CODE = C\u00F3digo que nunca se va a ejecutar
+WollokDslValidator_UNREACHABLE_CODE = Este c\u00F3digo nunca se va a ejecutar
 
 WollokDslValidator_NO_RETURN_EXPRESSION_IN_CONSTRUCTOR = No se puede devolver un valor en un constructor. 
 WollokDslValidator_SUPER_EXPRESSION_IN_CONSTRUCTOR = No se puede usar invocar con super en el cuerpo del constructor. Hay que usar la sintaxis de delegaci\u00F3n.


### PR DESCRIPTION
Acá hice dos cosas, por un lado mejoré el mensaje de error cuando el class loader quiere cargar una clase y no existe (también agregué un test), y por otra parte el stack trace de Java en la consola es algo que causa muy mala impresión, la anulé por el momento. La mayoría de las veces resolvemos esas cuestiones replicando el incidente por lo que el stack trace de java con código xtend es poco útil.

![image](https://user-images.githubusercontent.com/4549002/45123054-0b449c00-b13c-11e8-968e-020dcd5426d0.png)
