### PR TITLE
Fixing #1477

### DIFF
--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/WollokActivator.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/WollokActivator.xtend
@@ -99,14 +99,14 @@ class WollokActivator extends org.uqbar.project.wollok.ui.internal.WollokActivat
 	}
 
 	def void generateIssues(Resource resource) {
+		if (!resource.exists) return;
 		val issues = validator.validate(resource, CheckMode.ALL, null)
-		mapIssues.put(resource.platformURI, issues)
+		mapIssues.put(resource.platformFullPath, issues)
 	}
 	
 	def void refreshTypeErrors(IProject project, Resource resource, IProgressMonitor monitor) {
 		Display.^default.syncExec [
-			val locationURI = resource.platformURI
-			val issues = mapIssues.get(locationURI)
+			val issues = mapIssues.get(resource.platformFullPath)
 			new MarkerIssueProcessor(resource.IFile, markerCreator, markerTypeProvider).processIssues(issues, monitor)
 		]
 	}
@@ -135,9 +135,8 @@ class WollokActivator extends org.uqbar.project.wollok.ui.internal.WollokActivat
 			Thread.sleep(300) // fixes synchronization problem
 			val wollokTextEditor = editor as WollokTextEditor
 			if (wollokTextEditor.resource === null) return;
-			val activeURI = wollokTextEditor.resource.locationURI
-			val activeEditorURI = activeURI.toString.replaceAll(workspaceURI, " ").trim
-			val issues = mapIssues.get(activeEditorURI) ?: #[]
+			val resource = wollokTextEditor.resource.platformFullPath
+			val issues = mapIssues.get(resource) ?: #[]
 			Display.getDefault.syncExec [|
 				new AnnotationIssueProcessor(editor.document, editor.internalSourceViewer.getAnnotationModel(),
 					issueResolutionProvider).processIssues(issues, new NullProgressMonitor)

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
@@ -78,6 +78,7 @@ import static org.uqbar.project.wollok.WollokConstants.*
 import static org.uqbar.project.wollok.scoping.root.WollokRootLocator.*
 
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
+import org.eclipse.core.resources.IResource
 
 /**
  * Extension methods to Wollok semantic model.
@@ -884,4 +885,12 @@ class WollokModelExtensions {
 	def static dispatch boolean isAssertWKO(EObject e) { false }
 	def static dispatch boolean isAssertWKO(WNamedObject wko) { wko.fqn.equals(WollokDSK.ASSERT) }
 	def static dispatch boolean isAssertWKO(WVariableReference ref) { ref.ref.isAssertWKO }
+	
+	def static dispatch String getPlatformFullPath(Resource resource) {
+		resource.IFile.platformFullPath
+	}
+	
+	def static dispatch String getPlatformFullPath(IResource resource) {
+		resource.fullPath.toString
+	}
 }


### PR DESCRIPTION
El editor trabaja con un mapa de issues cacheados que se refresca cada vez que se corre el builder con o sin el Type System. El problema que ocurría era que el mapa utiliza como clave el resource, que funcionaba ok si trabajabas dentro del workspace pero no si lo importabas desde otro directorio (workspaceURI no te servía, y cuando quería parsear el archivo quedaba un path inconsistente, grababa platform y chequeaba contra un file con path absoluto, nunca matcheaba y quedaba la marca gris porque no lo reconocía).

De paso eliminamos del chequeo de issues aquellos resources que generan del import, y que dan error.