### PR TITLE
Fix #1504 assertion exception for expected exception

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lib.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib.wlk
@@ -226,7 +226,7 @@ object assert {
 				else
 					throw new OtherValueExpectedException("Expected other value", ex)
 			}
-		if (continue) throw new Exception("Should have thrown an exception")	
+		if (continue) throw new AssertionException("Should have thrown an exception")	
 	}
 	
 	/**

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ExceptionTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ExceptionTestCase.xtend
@@ -598,8 +598,8 @@ class ExceptionTestCase extends AbstractWollokInterpreterTestCase {
 	def void assertThrowsExceptionFailing() {
 		'''
 		var a = 0
-		assert.throwsExceptionWithMessage(
-			"Block { a + 1 } should have failed",
+		assert.throwsExceptionLike(
+			new AssertionException("Block { a + 1 } should have failed"),
 			{ assert.throwsException({ a + 1 }) }
 		)
 		'''.test


### PR DESCRIPTION
Instead of a red bar, now there is an orange one for expected exceptions not thrown.

![image](https://user-images.githubusercontent.com/4549002/46049260-ce990e80-c103-11e8-93f4-70889725a2bb.png)
