### PR TITLE
Autocomplete with typesystem

### DIFF
--- a/org.uqbar.project.wollok.typeSystem.ui/src/org/uqbar/project/wollok/typeSystem/ui/labeling/WollokTypeSystemLabelExtensionImpl.xtend
+++ b/org.uqbar.project.wollok.typeSystem.ui/src/org/uqbar/project/wollok/typeSystem/ui/labeling/WollokTypeSystemLabelExtensionImpl.xtend
@@ -1,9 +1,9 @@
 package org.uqbar.project.wollok.typeSystem.ui.labeling
 
+import org.apache.log4j.Logger
 import org.eclipse.emf.ecore.EObject
 import org.uqbar.project.wollok.typesystem.WollokTypeSystemActivator
 import org.uqbar.project.wollok.ui.labeling.WollokTypeSystemLabelExtension
-import org.apache.log4j.Logger
 
 class WollokTypeSystemLabelExtensionImpl implements WollokTypeSystemLabelExtension {
 
@@ -11,17 +11,27 @@ class WollokTypeSystemLabelExtensionImpl implements WollokTypeSystemLabelExtensi
 
 	override resolvedType(EObject o) {
 		// if disabled
-		if (!WollokTypeSystemActivator.^default.isTypeSystemEnabled(o))
+		if (!o.isTypeSystemEnabled)
 			return null
 
-		this.doResolvedType(o) ?: 
-		"Any"
+		o.doResolvedType?.toString ?: "Any"
+	}
+	
+	override allMessages(EObject o) {
+		if (!o.isTypeSystemEnabled)
+			return newArrayList
+			
+		o.doResolvedType.allMessages.map [ messageType | messageType.method ].toList
 	}
 
+	override isTypeSystemEnabled(EObject o) {
+		WollokTypeSystemActivator.^default.isTypeSystemEnabled(o)
+	}
+	
 	def doResolvedType(EObject o) {
 		try {
 			val typeSystem = WollokTypeSystemActivator.^default.getTypeSystem(o)
-			return typeSystem.type(o)?.toString
+			return typeSystem.type(o)
 		} catch (Exception e) {
 			log.error("Error in type system !! " + e.message, e)
 			return null

--- a/org.uqbar.project.wollok.typeSystem.ui/src/org/uqbar/project/wollok/typeSystem/ui/labeling/WollokTypeSystemLabelExtensionImpl.xtend
+++ b/org.uqbar.project.wollok.typeSystem.ui/src/org/uqbar/project/wollok/typeSystem/ui/labeling/WollokTypeSystemLabelExtensionImpl.xtend
@@ -20,8 +20,9 @@ class WollokTypeSystemLabelExtensionImpl implements WollokTypeSystemLabelExtensi
 	override allMessages(EObject o) {
 		if (!o.isTypeSystemEnabled)
 			return newArrayList
-			
-		o.doResolvedType.allMessages.map [ messageType | messageType.method ].toList
+		val resolvedType = o.doResolvedType
+		if (resolvedType === null) return newArrayList
+		resolvedType.allMessages.map [ messageType | messageType.method ].toList
 	}
 
 	override isTypeSystemEnabled(EObject o) {

--- a/org.uqbar.project.wollok.typeSystem.ui/src/org/uqbar/project/wollok/typeSystem/ui/labeling/WollokTypeSystemLabelExtensionImpl.xtend
+++ b/org.uqbar.project.wollok.typeSystem.ui/src/org/uqbar/project/wollok/typeSystem/ui/labeling/WollokTypeSystemLabelExtensionImpl.xtend
@@ -1,7 +1,10 @@
 package org.uqbar.project.wollok.typeSystem.ui.labeling
 
+import java.util.List
 import org.apache.log4j.Logger
 import org.eclipse.emf.ecore.EObject
+import org.uqbar.project.wollok.typesystem.MessageType
+import org.uqbar.project.wollok.typesystem.WollokType
 import org.uqbar.project.wollok.typesystem.WollokTypeSystemActivator
 import org.uqbar.project.wollok.ui.labeling.WollokTypeSystemLabelExtension
 
@@ -17,14 +20,17 @@ class WollokTypeSystemLabelExtensionImpl implements WollokTypeSystemLabelExtensi
 		o.doResolvedType?.toString ?: "Any"
 	}
 	
-	override allMessages(EObject o) {
-		if (!o.isTypeSystemEnabled)
-			return newArrayList
-		val resolvedType = o.doResolvedType
-		if (resolvedType === null) return newArrayList
-		resolvedType.allMessages.map [ messageType | messageType.method ].toList
+	// TODO: We should define this service public in the interface
+	// MessageType should be exported in TypeSystem bundle in order to be visible
+	// for external ones, like wollok.ui
+	def allMessages(EObject o) {
+		o.ifHasType [ resolvedType | resolvedType.allMessages.toList ]
 	}
-
+	
+	override allMethods(EObject o) {
+		o.allMessages.map [ method ].toList
+	}
+	
 	override isTypeSystemEnabled(EObject o) {
 		WollokTypeSystemActivator.^default.isTypeSystemEnabled(o)
 	}
@@ -39,4 +45,11 @@ class WollokTypeSystemLabelExtensionImpl implements WollokTypeSystemLabelExtensi
 		}
 	}
 
+	def List<MessageType> ifHasType(EObject o, (WollokType)=>List<MessageType> declarations) {
+		if (!o.isTypeSystemEnabled) return newArrayList
+		val resolvedType = o.doResolvedType
+		if (resolvedType === null) return newArrayList
+		declarations.apply(resolvedType)
+	}
+	
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/MessageType.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/MessageType.xtend
@@ -2,6 +2,7 @@ package org.uqbar.project.wollok.typesystem
 
 import java.util.List
 import org.eclipse.xtend.lib.annotations.Accessors
+import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
 
 import static extension org.uqbar.project.wollok.ui.utils.XTendUtilExtensions.*
 
@@ -14,9 +15,11 @@ class MessageType {
 	String name
 	List<WollokType> parameterTypes
 	WollokType returnType
+	@Accessors(PUBLIC_GETTER) WMethodDeclaration method
 	
-	new(String name, List<WollokType> parameterTypes, WollokType returnType) {
-		this.name = name
+	new(WMethodDeclaration method, List<WollokType> parameterTypes, WollokType returnType) {
+		this.method = method
+		this.name = method.name
 		this.parameterTypes = parameterTypes
 		this.returnType = returnType
 	}

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/UnionType.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/UnionType.xtend
@@ -2,6 +2,7 @@ package org.uqbar.project.wollok.typesystem
 
 import java.util.List
 import org.eclipse.xtend.lib.annotations.Accessors
+import static extension org.uqbar.project.wollok.utils.XtendExtensions.*
 
 class UnionType extends BasicType {
 	@Accessors(PUBLIC_GETTER)
@@ -15,10 +16,7 @@ class UnionType extends BasicType {
 	}
 	
 	override getAllMessages() {
-		this.types.fold(newArrayList, [ acum, type | 
-				acum.addAll(type.allMessages)
-				acum
-		])
+		this.types.flatMap [ type | type.allMessages ]
 	}
 	
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/UnionType.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/UnionType.xtend
@@ -13,4 +13,12 @@ class UnionType extends BasicType {
 		super(types.sortBy[name].join('(', '|', ')', [toString]))
 		this.types = types.toList
 	}
+	
+	override getAllMessages() {
+		this.types.fold(newArrayList, [ acum, type | 
+				acum.addAll(type.allMessages)
+				acum
+		])
+	}
+	
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/WollokType.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/WollokType.xtend
@@ -52,4 +52,5 @@ interface WollokType {
 	 * Restrict this type to match type parameters of supertype in order to be a valid subtype.
 	 */
 	def void beSubtypeOf(WollokType supertype)
+	
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstraintBasedTypeSystem.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/ConstraintBasedTypeSystem.xtend
@@ -204,7 +204,7 @@ class ConstraintBasedTypeSystem implements TypeSystem, TypeProvider {
 	}
 
 	override queryMessageTypeForMethod(WMethodDeclaration it) {
-		new MessageType(it.name, parameters.map[type], type)
+		new MessageType(it, parameters.map[type], type)
 	}
 
 	def objectType(WNamedObject model) {

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/WollokDslProposalProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/WollokDslProposalProvider.xtend
@@ -102,6 +102,14 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 
 	// default
 	def dispatch void memberProposalsForTarget(WExpression expression, Assignment assignment, ICompletionProposalAcceptor acceptor) {
+		if (expression instanceof WConstructorCall) {
+			val constructorCall = expression as WConstructorCall
+			constructorCall.classRef?.methodsAsProposals(acceptor)
+			return
+		}
+		if (expression.isTypeSystemEnabled) {
+			completeProposalsFor(expression, acceptor)
+		}
 	}
 
 	// literals

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/WollokDslProposalProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/WollokDslProposalProvider.xtend
@@ -1,5 +1,6 @@
 package org.uqbar.project.wollok.ui.contentassist
 
+import org.eclipse.core.runtime.Platform
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.Assignment
 import org.eclipse.xtext.CrossReference
@@ -11,6 +12,7 @@ import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor
 import org.uqbar.project.wollok.interpreter.WollokClassFinder
 import org.uqbar.project.wollok.ui.Messages
 import org.uqbar.project.wollok.ui.WollokActivator
+import org.uqbar.project.wollok.ui.labeling.WollokTypeSystemLabelExtension
 import org.uqbar.project.wollok.wollokDsl.WBooleanLiteral
 import org.uqbar.project.wollok.wollokDsl.WClosure
 import org.uqbar.project.wollok.wollokDsl.WConstructorCall
@@ -34,6 +36,8 @@ import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
 /**
  *
  * @author jfernandes
+ * @author dodain
+ * 
  * @see    https://www.eclipse.org/Xtext/documentation/310_eclipse_support.html#content-assist
  * 
  */
@@ -43,6 +47,41 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 	
 	WollokProposalBuilder builder
 	
+	// Type System
+	WollokTypeSystemLabelExtension labelExtension = null
+	boolean labelExtensionResolved = false
+
+	def obtainLabelExtension() {
+		if (!labelExtensionResolved) {
+			labelExtension = resolveLabelExtension
+			labelExtensionResolved = true
+		}
+		labelExtension
+	}
+	
+	def synchronized getAllMessages(EObject obj) {
+		val tsLabelExtension = obtainLabelExtension
+		if (tsLabelExtension !== null)
+			tsLabelExtension.allMessages(obj)
+		else
+			newArrayList
+	}
+
+	def boolean isTypeSystemEnabled(EObject obj) {
+		obtainLabelExtension.isTypeSystemEnabled(obj)
+	}
+
+	def resolveLabelExtension() {
+		val configPoints = Platform.getExtensionRegistry.getConfigurationElementsFor(
+			"org.uqbar.project.wollok.ui.wollokTypeSystemLabelExtension")
+
+		if (configPoints.empty)
+			null
+		else
+			configPoints.get(0).createExecutableExtension("class") as WollokTypeSystemLabelExtension
+	}
+	
+	
 	override complete_WConstructorCall(EObject model, RuleCall ruleCall, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
 		if (model instanceof WConstructorCall) {
 			val initializations = (model as WConstructorCall).createInitializersForNamedParametersInConstructor
@@ -51,7 +90,6 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 		super.complete_WConstructorCall(model, ruleCall, context, acceptor)
 	}
 	
-	// This whole implementation is just an heuristic until we have a type system
 	override completeWMemberFeatureCall_Feature(EObject model, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
 		val call = model as WMemberFeatureCall
 		builder = new WollokProposalBuilder
@@ -93,16 +131,27 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 	
 	// to a variable
 	def dispatch void memberProposalsForTarget(WVariableReference ref, Assignment assignment, ICompletionProposalAcceptor acceptor) {
-		memberProposalsForTarget(ref.ref, assignment, acceptor)
+		val referencedElement = ref.ref
+		if (referencedElement.isTypeSystemEnabled)
+			completeProposalsFor(referencedElement, acceptor)
+		else
+			memberProposalsForTarget(referencedElement, assignment, acceptor)
 	}
 
 	// any referenciable shows all messages that you already sent to it
 	def dispatch void memberProposalsForTarget(WReferenciable ref, Assignment assignment, ICompletionProposalAcceptor acceptor) {
-		ref.messageSentAsProposals(acceptor)
+		if (ref.isTypeSystemEnabled)
+			completeProposalsFor(ref, acceptor)
+		else 
+			ref.messageSentAsProposals(acceptor)
 	}
 
 	// for variables tries to resolve the type based on the initial value (for literal objects like strings, lists, etc)
 	def dispatch void memberProposalsForTarget(WVariable ref, Assignment assignment, ICompletionProposalAcceptor acceptor) {
+		if (ref.isTypeSystemEnabled) {
+			completeProposalsFor(ref, acceptor)
+			return
+		}
 		val WMethodContainer type = ref.resolveType
 		if (type !== null) {
 			type.methodsAsProposals(acceptor)
@@ -110,6 +159,15 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 		else {
 			ref.messageSentAsProposals(acceptor)
 		}
+	}
+	
+	protected def void completeProposalsFor(EObject o, ICompletionProposalAcceptor acceptor) {
+		val allMessages = o.allMessages
+		allMessages.forEach [ method | 
+			builder.model = method
+			builder.reference = method.methodContainer.nameWithPackage
+			addProposal(method, acceptor)
+		]
 	}
 
 	// message to WKO's (shows the object's methods)
@@ -180,33 +238,6 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 			acceptor.accept(createCompletionProposal(fqn, fqn, image, context))
 		]
 	}
-
-	//@Inject
-  	//protected WollokDslTypeSystem system
-//
-//	def dispatch void memberProposalsForTarget(WVariableReference reference, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
-//		super.completeWMemberFeatureCall_Feature(reference, assignment, context, acceptor)
-////		 TYPE SYSTEM
-////		 TODO: Hacer un extension point
-//				reference.ref.type.allMessages.forEach[m| if (m != null) acceptor.addProposal(context, m.asProposal, WollokActivator.getInstance.getImageDescriptor('icons/wollok-icon-method_16.png').createImage)]
-//					reference.ref.messagesSentTo.forEach[m| acceptor.addProposal(context, m.asProposalText, m.image)]
-//	}
-/*
-	def asProposal(MessageType message) {
-		message.name + "(" + message?.parameterTypes.map[p| p.asParamName ].join(", ") + ")"
-	}
-
-	def dispatch String asParamName(WollokType type) { type.name }
-	def dispatch String asParamName(StructuralType type) { "anObj" }
-	def dispatch String asParamName(ObjectLiteralWollokType type) { "anObj" }
-
-	def type(WReferenciable r) {
-		val env = system.emptyEnvironment()
-		val e = r.eResource.contents.filter(WFile).head.body
-		system.inferTypes(env, e)
-		system.queryTypeFor(env, r).first
-	}
-*/
 
 	override completeWConstructorCall_ClassRef(EObject model, Assignment assignment, ContentAssistContext context, ICompletionProposalAcceptor acceptor) {
 		lookupCrossReference((assignment.terminal as CrossReference), context, new ConstructorCallAcceptorDelegate(acceptor))

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/WollokDslProposalProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/WollokDslProposalProvider.xtend
@@ -59,10 +59,10 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 		labelExtension
 	}
 	
-	def synchronized getAllMessages(EObject obj) {
+	def synchronized getAllMethods(EObject obj) {
 		val tsLabelExtension = obtainLabelExtension
 		if (tsLabelExtension !== null)
-			tsLabelExtension.allMessages(obj)
+			tsLabelExtension.allMethods(obj)
 		else
 			newArrayList
 	}
@@ -170,7 +170,7 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 	}
 	
 	protected def void completeProposalsFor(EObject o, ICompletionProposalAcceptor acceptor) {
-		val allMessages = o.allMessages
+		val allMessages = o.allMethods
 		allMessages.forEach [ method | 
 			builder.model = method
 			builder.reference = method.methodContainer.nameWithPackage

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/labeling/WollokTypeSystemLabelExtension.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/labeling/WollokTypeSystemLabelExtension.xtend
@@ -6,6 +6,6 @@ import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
 
 interface WollokTypeSystemLabelExtension {
 	def String resolvedType(EObject obj)
-	def List<WMethodDeclaration> allMessages(EObject obj)
+	def List<WMethodDeclaration> allMethods(EObject obj)
 	def boolean isTypeSystemEnabled(EObject obj)
 }

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/labeling/WollokTypeSystemLabelExtension.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/labeling/WollokTypeSystemLabelExtension.xtend
@@ -1,7 +1,11 @@
 package org.uqbar.project.wollok.ui.labeling
 
+import java.util.List
 import org.eclipse.emf.ecore.EObject
+import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
 
 interface WollokTypeSystemLabelExtension {
 	def String resolvedType(EObject obj)
+	def List<WMethodDeclaration> allMessages(EObject obj)
+	def boolean isTypeSystemEnabled(EObject obj)
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/ResourceUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/ResourceUtils.xtend
@@ -21,10 +21,11 @@ class ResourceUtils {
 	def static IFile getIFile(EObject obj) { obj.eResource.IFile }
 
 	def static IFile getIFile(Resource resource) {
-		val platformString = resource.URI.toPlatformString(true)
+		val resourceURI = resource.URI.toString
+		val platformString = if (resourceURI.startsWith(CLASSPATH)) resourceURI else resource.URI.toPlatformString(true) 
 		if(platformString === null) {
 			// could be a synthetic file
-			return null;
+			return null
 		}
 		workspace.root.getFile(new Path(platformString))
 	}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/ResourceUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/ResourceUtils.xtend
@@ -22,7 +22,7 @@ class ResourceUtils {
 
 	def static IFile getIFile(Resource resource) {
 		val resourceURI = resource.URI.toString
-		val platformString = if (resourceURI.startsWith(CLASSPATH)) resourceURI else resource.URI.toPlatformString(true) 
+		val platformString = if (resourceURI.startsWith(CLASSPATH)) resourceURI else resource.URI.toPlatformString(true)
 		if(platformString === null) {
 			// could be a synthetic file
 			return null

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/ResourceUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/ResourceUtils.xtend
@@ -21,8 +21,12 @@ class ResourceUtils {
 	def static IFile getIFile(EObject obj) { obj.eResource.IFile }
 
 	def static IFile getIFile(Resource resource) {
-		val resourceURI = resource.URI.toString
-		val platformString = if (resourceURI.startsWith(CLASSPATH)) resourceURI else resource.URI.toPlatformString(true)
+		// *******************************************************
+		// val resourceURI = resource.URI.toString
+		// val platformString = if (resourceURI.startsWith(CLASSPATH)) resourceURI else resource.URI.toPlatformString(true)
+		// prueba travis
+		val platformString = resource.URI.toPlatformString(true)
+		// *******************************************************
 		if(platformString === null) {
 			// could be a synthetic file
 			return null

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/ResourceUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/ResourceUtils.xtend
@@ -21,12 +21,8 @@ class ResourceUtils {
 	def static IFile getIFile(EObject obj) { obj.eResource.IFile }
 
 	def static IFile getIFile(Resource resource) {
-		// *******************************************************
-		// val resourceURI = resource.URI.toString
-		// val platformString = if (resourceURI.startsWith(CLASSPATH)) resourceURI else resource.URI.toPlatformString(true)
-		// prueba travis
-		val platformString = resource.URI.toPlatformString(true)
-		// *******************************************************
+		val resourceURI = resource.URI.toString
+		val platformString = if (resourceURI.startsWith(CLASSPATH)) resourceURI else resource.URI.toPlatformString(true) 
 		if(platformString === null) {
 			// could be a synthetic file
 			return null
@@ -34,6 +30,15 @@ class ResourceUtils {
 		workspace.root.getFile(new Path(platformString))
 	}
 
+	def static IFile getPlatformFile(EObject o) {
+		val platformString = o.eResource.URI.toPlatformString(true)
+		if(platformString === null) {
+			// could be a synthetic file
+			return null
+		}
+		workspace.root.getFile(new Path(platformString))
+	}
+	
 	def static IWorkspace workspace() {
 		ResourcesPlugin.workspace
 	}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/AbstractConfigurableDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/AbstractConfigurableDslValidator.xtend
@@ -54,7 +54,7 @@ class AbstractConfigurableDslValidator extends AbstractWollokDslValidator implem
 
 	def preferences(EObject obj) {
 		if(WEclipseUtils.isWorkspaceOpen) {
-			val ifile = obj.IFile
+			val ifile = obj.platformFile
 			if(ifile !== null) {
 				return preferenceStoreAccess.getContextPreferenceStore(ifile.project)
 			}


### PR DESCRIPTION
![anim](https://user-images.githubusercontent.com/4549002/46288848-8c395c80-c55d-11e8-8f6a-bf8345dc0f99.gif)

Today, you must save the file in order to get all updated autocomplete options.

It also supports union types:
![uniontypesautocomplete](https://user-images.githubusercontent.com/4549002/46288991-05d14a80-c55e-11e8-8985-32ee4e730bef.png)
(it repeats methods from each polymorphic definition, because they may have different wollok docs)

Implementation of StringType and IntType (both from Type System) lacks a proper allMessages() methods, returning an empty arraylist. This causes no effect on autocomplete, because String and NumberLiteral use a different algorithm. But I think we could enhance them for future uses.