### PR TITLE
Fix #1519 non initialized variables and const in method containers

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/ConstructorsQuickFixTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/ConstructorsQuickFixTest.xtend
@@ -1000,7 +1000,7 @@ class ConstructorsQuickFixTest extends AbstractWollokQuickFixTestCase {
 			}
 		}
 		''']
-		assertQuickfix(initial, result, Messages.WollokDslQuickFixProvider_add_missing_initializations_name, 7, "You must provide initial value to the following references: saludo, color")
+		assertQuickfix(initial, result, Messages.WollokDslQuickFixProvider_add_missing_initializations_name, 4, "You must provide initial value to the following references: saludo, color")
 	}	
 
 	@Test
@@ -1032,7 +1032,7 @@ class ConstructorsQuickFixTest extends AbstractWollokQuickFixTestCase {
 			}
 		}
 		''']
-		assertQuickfix(initial, result, Messages.WollokDslQuickFixProvider_add_missing_initializations_name, 6, "You must provide initial value to the following references: color")
+		assertQuickfix(initial, result, Messages.WollokDslQuickFixProvider_add_missing_initializations_name, 4, "You must provide initial value to the following references: color")
 	}
 	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NamedObjectVariableInitialization.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NamedObjectVariableInitialization.wlk.xt
@@ -1,0 +1,12 @@
+/* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
+
+object withUninitializedVariables {
+	// XPECT warnings --> "Variable is never assigned" at "x"
+	var x
+	// XPECT errors --> "Variable is never assigned" at "y"
+	const y
+	
+	method x() = x
+	
+	method sumXY() = x + y
+}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NamedParameters.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NamedParameters.wlk.xt
@@ -9,7 +9,6 @@ class Ave {
 	method volar() { energia -= 10 }
 }
 class Golondrina inherits Ave {
-	// XPECT warnings --> "Variable is never assigned" at "peso"
 	var peso
 	method estaGorda() = peso > 100
 }
@@ -120,4 +119,22 @@ class A {
 	constructor(x, y, z) = self(x = y, inexistente = 3) {
 		b = y
 	}
+}
+
+class Something {
+    const property aValue
+    var property anotherValue
+}
+
+object somethingBuilder {
+	method buildEmptySomething() {
+		return new Something()
+	}
+	// XPECT errors --> "You must provide initial value to the following references: aValue" at "new Something(anotherValue = 2)"
+	method buildPartialSomething1() = new Something(anotherValue = 2)
+
+	// XPECT errors --> "You must provide initial value to the following references: anotherValue" at "new Something(aValue = 3)"
+	method buildPartialSomething2() = new Something(aValue = 3)
+	
+	method buildCompleteSomething() = new Something(anotherValue = 2, aValue = 3)
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/UnusedVariable.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/UnusedVariable.wlk.xt
@@ -4,10 +4,8 @@ class WithUnusedVariables {
 	var a = 123
 	// XPECT warnings --> "Unused variable" at "b"
 	var b = 123
-	// XPECT warnings --> "Variable is never assigned" at "c"
 	var c 
 	var d
-	// XPECT errors --> "Variable is never assigned" at "x" 
 	const x 
 	const z = 1
 	

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
@@ -410,8 +410,13 @@ class WollokModelExtensions {
 		clazz.constructors.findFirst[matches(nrOfParams)]
 	}
 
-	def static dispatch getConstructors(EObject o) { newArrayList }
-	def static dispatch getConstructors(WClass c) { c.allConstructors }
+	def static dispatch boolean shouldCheckInitialization(WMethodContainer mc) { true }
+	def static dispatch boolean shouldCheckInitialization(WClass c) { c.hasConstructors } 
+	
+	def static boolean hasConstructors(WMethodContainer c) { !c.getConstructors.isEmpty }
+
+	def static dispatch List<WConstructor> getConstructors(EObject o) { newArrayList }
+	def static dispatch List<WConstructor> getConstructors(WClass c) { c.allConstructors }
 
 	def static matches(WConstructor it, int nrOfArgs) {
 		if(hasVarArgs)

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -764,8 +764,10 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@CheckGroup(WollokCheckGroup.POTENTIAL_PROGRAMMING_PROBLEM)
 	def unusedVariablesAndInitializedConstants(WVariableDeclaration it) {
 		val assignments = variable.assignments
+		val declaringContext = it.declaringContext
+		val shouldCheckInitialization = declaringContext === null || declaringContext.shouldCheckInitialization
 		// Variable has no assignments
-		if (assignments.empty) {
+		if (assignments.empty && shouldCheckInitialization) {
 			if (writeable)
 				warning(WollokDslValidator_WARN_VARIABLE_NEVER_ASSIGNED, it, WVARIABLE_DECLARATION__VARIABLE,
 					VARIABLE_NEVER_ASSIGNED)


### PR DESCRIPTION
Bueno, en el issue #1519 está la definición de lo que hice, básicamente evitar la validación de variables y constantes sin inicializar si la clase no tiene constructores (en los wko quedó igual, agregué tests). Si tenemos constructores, se validan en cada uno que el objeto quede bien construido (que no haya variables o constantes sin inicializar).