### PR TITLE
Fix #1491 - validation and quick fix for return expression in parameter

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/ReturnInParameterQuickFixTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/ReturnInParameterQuickFixTest.xtend
@@ -1,0 +1,28 @@
+package org.uqbar.project.wollok.tests.quickfix
+
+import org.junit.Test
+import org.uqbar.project.wollok.ui.Messages
+
+class ReturnInParameterQuickFixTest extends AbstractWollokQuickFixTestCase {
+
+	@Test
+	def removeReturnInParameter(){
+		val initial = #['''
+		object foo {
+			 method bar(){
+			 	return 3.min(return 4)
+			 }
+		}
+		''']
+
+		val result = #['''
+		object foo {
+			 method bar(){
+			 	return 3.min(4)
+			 }
+		}
+		''']
+		assertQuickfix(initial, result, Messages.WollokDslQuickFixProvider_remove_return_keyword_name)
+	}
+
+}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/cannotReturnAssignment.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/cannotReturnAssignment.wlk.xt
@@ -1,11 +1,28 @@
 /* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
 
 object a {
-   var ahorro = 100
+	var ahorro = 100
    
-   method m() {
-   	   // XPECT errors --> "Cannot return an assignment" at "ahorro = ahorro * 0.20"
-   	   return ahorro = ahorro * 0.20
-   }
+	method m() {
+		// XPECT errors --> "Cannot return an assignment" at "ahorro = ahorro * 0.20"
+		return ahorro = ahorro * 0.20
+	}
 
+	method m2(param) {
+		ahorro += param
+	}
+}
+
+object foo {
+	 method bar(){
+	 	if (2 == 2) {
+	 		return 3
+	 	}
+	 	// XPECT errors --> "Can't use 'return' expression as argument. Tip: remove 'return' keyword." at "4"
+	 	return 3.min(return 4)
+	 }
+	 method bar2() {
+	 	// XPECT errors --> "Can't use 'return' expression as argument. Tip: remove 'return' keyword." at "9"
+	 	a.m2(return 9)
+	 }
 }

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/Messages.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/Messages.java
@@ -117,6 +117,8 @@ public class Messages extends NLS {
 	public static String WollokDslQuickfixProvider_create_method_superclass_description;
 	public static String WollokDslQuickFixProvider_remove_override_keyword_name;
 	public static String WollokDslQuickFixProvider_remove_override_keyword_description;
+	public static String WollokDslQuickFixProvider_remove_return_keyword_name;
+	public static String WollokDslQuickFixProvider_remove_return_keyword_description;
 	public static String WollokDslQuickFixProvider_create_constructor_class_name; 
 	public static String WollokDslQuickFixProvider_create_constructor_class_description; 
 	public static String WollokDslQuickFixProvider_adjust_constructor_call_name; 

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages.properties
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages.properties
@@ -183,6 +183,9 @@ WollokDslQuickfixProvider_create_method_superclass_description = Add new method 
 WollokDslQuickFixProvider_remove_override_keyword_name = Remove override keyword
 WollokDslQuickFixProvider_remove_override_keyword_description = Remove override keyword.
 
+WollokDslQuickFixProvider_remove_return_keyword_name = Remove return keyword
+WollokDslQuickFixProvider_remove_return_keyword_description = Remove return keyword.
+
 WollokDslQuickFixProvider_create_constructor_superclass_name = Create constructor in superclass
 WollokDslQuickFixProvider_create_constructor_superclass_description = Add new constructor in superclass. 
 

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages_es.properties
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages_es.properties
@@ -111,6 +111,9 @@ WollokDslQuickfixProvider_create_method_superclass_description = Crear el m\u00E
 WollokDslQuickFixProvider_remove_override_keyword_name = Eliminar "override" al m\u00E9todo
 WollokDslQuickFixProvider_remove_override_keyword_description = Indicar que el m\u00E9todo es una definici\u00F3n propia de la clase, no tiene que ver con la superclase
 
+WollokDslQuickFixProvider_remove_return_keyword_name = Eliminar "return" de la expresi\u00F3n
+WollokDslQuickFixProvider_remove_return_keyword_description = Eliminar "return" de la expresi\u00F3n.
+
 WollokDslQuickFixProvider_create_constructor_superclass_name = Crear constructor en la superclase 
 WollokDslQuickFixProvider_create_constructor_superclass_description = Agregar un nuevo constructor en la superclase 
 

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
@@ -260,6 +260,13 @@ class WollokDslQuickfixProvider extends DefaultQuickfixProvider {
 		]
 	}
 
+	@Fix(CANT_USE_RETURN_EXPRESSION_IN_ARGUMENT)
+	def removeReturnKeyword(Issue issue, IssueResolutionAcceptor acceptor) {
+		acceptor.accept(issue, Messages.WollokDslQuickFixProvider_remove_return_keyword_name,
+			Messages.WollokDslQuickFixProvider_remove_return_keyword_description, null) [ e, it |
+			xtextDocument.deleteToken(e, RETURN + blankSpace)
+		]
+	}
 	/** 
 	 * ***********************************************************************
 	 * 							Unexistent methods

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
@@ -118,6 +118,7 @@ public class Messages extends NLS {
 	public static String WollokDslValidator_CANNOT_RETURN_ASSIGNMENT;
 	public static String WollokDslValidator_SUPER_EXPRESSION_IN_CONSTRUCTOR;
 	public static String WollokDslValidator_RETURN_FORGOTTEN;
+	public static String WollokDslValidator_CANT_USE_RETURN_EXPRESSION_IN_ARGUMENT;
 	public static String WollokDslValidator_METHOD_DOES_NOT_RETURN_A_VALUE_ON_EVERY_POSSIBLE_FLOW;
 	public static String WollokDslValidator_INVALID_EFFECTLESS_EXPRESSION_IN_SEQUENCE;
 	public static String WollokDslValidator_VAR_ARG_PARAM_MUST_BE_THE_LAST_ONE;

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
@@ -144,6 +144,7 @@ WollokDslValidator_OBJECT_MUST_CALL_SUPERCLASS_CONSTRUCTOR = Object must explici
 WollokDslValidator_NO_SUPERCLASS_CONSTRUCTOR = No superclass constructor or wrong number of arguments. You must explicitly call a constructor: {0}
 WollokDslValidator_DUPLICATED_VARIABLE_IN_HIERARCHY = There is already an instance variable with this name in the hierarchy
 WollokDslValidator_RETURN_FORGOTTEN = Method produces a value but you are not returning it. Did you forget the return ?
+WollokDslValidator_CANT_USE_RETURN_EXPRESSION_IN_ARGUMENT = Can't use 'return' expression as argument. Tip: remove 'return' keyword.
 
 WollokDslValidator_CLASS_MUST_IMPLEMENT_ABSTRACT_METHODS = Class {0} cannot be instantiated because it has abstract methods
 WollokDslValidator_CLASS_WITHOUT_INHERITANCE_MUST_IMPLEMENT_ALL_METHODS = Class {0} cannot be instantiated. You must implement all methods

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
@@ -142,7 +142,8 @@ WollokDslValidator_NO_SUPERCLASS_CONSTRUCTOR = No existe el constructor de la su
 
 WollokDslValidator_DUPLICATED_VARIABLE_IN_HIERARCHY = Ya existe una variable de instancia con este nombre en la jerarqu\u00EDa
 
-WollokDslValidator_RETURN_FORGOTTEN = El cuerpo del M\u00E9todo genera un valor que no se estar retornando. Olvidaste el 'return' ?
+WollokDslValidator_RETURN_FORGOTTEN = El cuerpo del m\u00E9todo genera un valor que no se est\u00E1 retornando. Olvidaste el 'return' ?
+WollokDslValidator_CANT_USE_RETURN_EXPRESSION_IN_ARGUMENT = No se puede usar una expresi\u00F3n con 'return' como par\u00E1metro. Elimine la palabra 'return'.
 
 WollokDslValidator_CLASS_MUST_IMPLEMENT_ABSTRACT_METHODS = No se puede instanciar la clase {0} porque tiene m\u00E9todos abstractos
 WollokDslValidator_CLASS_WITHOUT_INHERITANCE_MUST_IMPLEMENT_ALL_METHODS = No se puede instanciar la clase {0}. Debe implementar todos los m\u00E9todos 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -208,10 +208,17 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 	def dispatch static isReturnWithValue(EObject it) { false }
 	// REVIEW: this is a hack solution. We don't want to compute "return" statements that are
 	//  within a closure as a return on the containing method.
-	def dispatch static isReturnWithValue(WReturnExpression it) { expression !== null && allContainers.forall[!(it instanceof WClosure)] }
-
-	def dispatch static hasReturnWithValue(WReturnExpression e) { e.isReturnWithValue }
+	def dispatch static isReturnWithValue(WReturnExpression it) { validReturnExpression && expression !== null && allContainers.forall[!(it instanceof WClosure)] }
+	def dispatch static hasReturnWithValue(WReturnExpression r) { r.returnWithValue }
 	def dispatch static hasReturnWithValue(EObject e) { e.eAllContents.exists[isReturnWithValue] }
+
+	def static dispatch boolean isValidReturnExpression(EObject o) { 
+		val container = o.eContainer
+		container !== null && container.isValidReturnExpression
+	}
+	def static dispatch boolean isValidReturnExpression(WMemberFeatureCall call) { false }
+	def static dispatch boolean isValidReturnExpression(WBlockExpression expr) { true }
+	def static dispatch boolean isValidReturnExpression(WMethodDeclaration method) { true }
 
 	def static allVariableDeclarations(WMethodContainer it) { 
 		linearizeHierarchy.fold(newArrayList) [variableDeclarations, type |

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
@@ -536,7 +536,7 @@ class WollokModelExtensions {
 	}
 
 	def static dispatch boolean returnsOnAllPossibleFlows(WReturnExpression it, boolean returnsOnSuperExpression) {
-		true
+		validReturnExpression
 	}
 
 	def static dispatch boolean returnsOnAllPossibleFlows(WThrow it, boolean returnsOnSuperExpression) {

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -137,6 +137,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	public static val INITIALIZATION_VALUE_NEVER_USED = "INITIALIZATION_VALUE_NEVER_USED"
 	public static val VARIABLE_NEVER_ASSIGNED = "VARIABLE_NEVER_ASSIGNED"
 	public static val RETURN_FORGOTTEN = "RETURN_FORGOTTEN"
+	public static val CANT_USE_RETURN_EXPRESSION_IN_ARGUMENT = "CANT_USE_RETURN_EXPRESSION_IN_ARGUMENT"
 	public static val VAR_ARG_PARAM_MUST_BE_THE_LAST_ONE = "VAR_ARG_PARAM_MUST_BE_THE_LAST_ONE"
 	public static val PROPERTY_ONLY_ALLOWED_IN_CERTAIN_METHOD_CONTAINERS = "PROPERTY_ONLY_ALLOWED_IN_CERTAIN_METHOD_CONTAINERS"
 	public static val WRONG_NUMBER_ARGUMENTS_CONSTRUCTOR_CALL = "WRONG_NUMBER_ARGUMENTS_CONSTRUCTOR_CALL" 
@@ -1088,6 +1089,13 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 			report(WollokDslValidator_CANNOT_RETURN_ASSIGNMENT, it, WRETURN_EXPRESSION__EXPRESSION)
 	}
 
+	@Check
+	@DefaultSeverity(ERROR)
+	def returnUsedInAnExpression(WReturnExpression it) {
+		if (expression !== null && !isValidReturnExpression)
+			report(WollokDslValidator_CANT_USE_RETURN_EXPRESSION_IN_ARGUMENT, it, WRETURN_EXPRESSION__EXPRESSION, CANT_USE_RETURN_EXPRESSION_IN_ARGUMENT)
+	}
+	
 	@Check
 	@DefaultSeverity(ERROR)
 	def noSuperInConstructorBody(WSuperInvocation it) {


### PR DESCRIPTION
![anim](https://user-images.githubusercontent.com/4549002/46985662-e2f87780-d0c1-11e8-84f0-f702ce9980e9.gif)

Added new validation and changed validator for "return" in method to avoid a misleading "Must return on every possible flow" message.

Added also a quick fix in order to remove "return" keyword.

I'd like to review the error reported and quick fix messages too.