### PR TITLE
Fix #1544 - questionable error message for constructor call of unexis…

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ConstructorCalls.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ConstructorCalls.wlk.xt
@@ -178,3 +178,15 @@ class TestPersonas {
 		assert.notEquals(new Hijo(2), new Persona(2))
 	}	
 }
+
+class SomeClass {
+	method someMethod() {
+		// XPECT errors --> "Couldn't resolve reference to Class 'UnexistentException'." at "UnexistentException"
+		throw new UnexistentException("some message")
+	}
+	
+	method anotherMethod() {
+		// XPECT errors --> "Couldn't resolve reference to Class 'UnexistentException'." at "UnexistentException"
+		throw new UnexistentException(medico = "hola")
+	}
+}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -265,6 +265,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	}
 
 	def void validateNamedParameters(WClass clazz, WArgumentList parameterList) {
+		if (clazz.name === null) return  // avoid validation for non-existent classes
 		val validAttributes = clazz.allVariableNames
 		val invalidInitializers = parameterList.initializers.filter [ !validAttributes.contains(initializer.name) ]
 		invalidInitializers.forEach [ 
@@ -294,7 +295,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@Check
 	@DefaultSeverity(ERROR)
 	def invalidConstructorCall(WConstructorCall c) {
-		if (!c.hasNamedParameters && !c.isValidConstructorCall()) {
+		if (c.classRef?.name !== null && !c.hasNamedParameters && !c.isValidConstructorCall()) {
 			reportEObject(WollokDslValidator_WCONSTRUCTOR_CALL__ARGUMENTS + " " + c.prettyPrint, c, WRONG_NUMBER_ARGUMENTS_CONSTRUCTOR_CALL)
 		}
 	}


### PR DESCRIPTION
…tent class.

Added also some tests.
For future cases we might add a new method to check if a class does not exist, but I'm not sure right now to rely on name === null for all cases.