### PR TITLE
Fix #1559 autocomplete roto con typesystem disabled

### DIFF
--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/AbstractContainerWollokType.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/AbstractContainerWollokType.xtend
@@ -48,7 +48,7 @@ abstract class AbstractContainerWollokType extends BasicType implements Concrete
   	}
   	
   	override getAllMessages() {		
- 		container.allMethods.map[m| typeSystem.queryMessageTypeForMethod(m)]		
+ 		container.allUntypedMethods.map[m| typeSystem.queryMessageTypeForMethod(m)]		
  	}
  
  	override ConcreteType instanceFor(TypeVariable parent) { this }

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/WollokDslProposalProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/contentassist/WollokDslProposalProvider.xtend
@@ -60,11 +60,15 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 	}
 	
 	def synchronized getAllMethods(EObject obj) {
+		if (!obj.isTypeSystemEnabled)
+			return (obj as WMethodContainer).allUntypedMethods
+		else {
 		val tsLabelExtension = obtainLabelExtension
-		if (tsLabelExtension !== null)
-			tsLabelExtension.allMethods(obj)
-		else
-			newArrayList
+			if (tsLabelExtension !== null)
+				tsLabelExtension.allMethods(obj)
+			else
+				newArrayList
+		}
 	}
 
 	def boolean isTypeSystemEnabled(EObject obj) {
@@ -207,6 +211,7 @@ class WollokDslProposalProvider extends AbstractWollokDslProposalProvider {
 		builder.accessorKind = Accessor.SETTER
 		ref.allPropertiesSetters.forEach [ addProposal(it, acceptor) ]
 		builder.accessorKind = Accessor.NONE
+		println(ref.allMethods)
 		ref.allMethods.forEach[ addProposal(it, acceptor) ]
 	}
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/HumanReadableUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/HumanReadableUtils.xtend
@@ -91,7 +91,7 @@ class HumanReadableUtils {
 		val fullMessage = methodName + "(" + parameters.join(",") + ")"
 		val similarMethods = container.findMethodsByName(methodName)
 		if (similarMethods.empty) {
-			val caseSensitiveMethod = container.allMethods.findMethodIgnoreCase(methodName, parameters.size)
+			val caseSensitiveMethod = container.allUntypedMethods.findMethodIgnoreCase(methodName, parameters.size)
 			if (caseSensitiveMethod !== null) {
 				(NLS.bind(Messages.WollokDslValidator_METHOD_DOESNT_EXIST_CASE_SENSITIVE,
 					#[container.name, fullMessage, #[caseSensitiveMethod].convertToString]))

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -255,11 +255,11 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 	}
 	
 	def static findMethod(WMethodContainer c, WMemberFeatureCall it) {
-		c.allMethods.findFirst [ m | m.matches(feature, memberCallArguments) ]	
+		c.allUntypedMethods.findFirst [ m | m.matches(feature, memberCallArguments) ]	
 	}
 	
 	def static findMethodIgnoreCase(WMethodContainer c, String methodName, int argumentsSize) {
-		c.allMethods.findMethodIgnoreCase(methodName, argumentsSize) 
+		c.allUntypedMethods.findMethodIgnoreCase(methodName, argumentsSize) 
 	}
 
 	def static findMethodIgnoreCase(Iterable<WMethodDeclaration> methods, String methodName, int argumentsSize) {
@@ -267,7 +267,7 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 	}
 
 	def static dispatch List<WMethodDeclaration> findMethodsByName(WMethodContainer c, String methodName) {
-		c.allMethods.findMethodsByName(methodName)
+		c.allUntypedMethods.findMethodsByName(methodName)
 	}
 	
 	def static dispatch List<WMethodDeclaration> findMethodsByName(WollokObject o, String methodName) {
@@ -278,12 +278,12 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 		methods.filter [ m | m.name.equals(methodName) && !m.overrides ].toList
 	}
 	
-	def static dispatch Iterable<WMethodDeclaration> allMethods(WMixin it) { methods }
-	def static dispatch Iterable<WMethodDeclaration> allMethods(WNamedObject it) { inheritedMethods }
-	def static dispatch Iterable<WMethodDeclaration> allMethods(WObjectLiteral it) { inheritedMethods }
-	def static dispatch Iterable<WMethodDeclaration> allMethods(MixedMethodContainer it) { inheritedMethods }
-	def static dispatch Iterable<WMethodDeclaration> allMethods(WClass it) { inheritedMethods }
-	def static dispatch Iterable<WMethodDeclaration> allMethods(WSuite it) { methods }
+	def static dispatch Iterable<WMethodDeclaration> allUntypedMethods(WMixin it) { methods }
+	def static dispatch Iterable<WMethodDeclaration> allUntypedMethods(WNamedObject it) { inheritedMethods }
+	def static dispatch Iterable<WMethodDeclaration> allUntypedMethods(WObjectLiteral it) { inheritedMethods }
+	def static dispatch Iterable<WMethodDeclaration> allUntypedMethods(MixedMethodContainer it) { inheritedMethods }
+	def static dispatch Iterable<WMethodDeclaration> allUntypedMethods(WClass it) { inheritedMethods }
+	def static dispatch Iterable<WMethodDeclaration> allUntypedMethods(WSuite it) { methods }
 
 	def static allVariables(WMethodContainer it) {
 		allVariableDeclarations.map [ variable ]
@@ -450,7 +450,7 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 
 	def static boolean isValidCall(WMethodContainer c, WMemberFeatureCall call) {
 		c.matchesPropertiesInHierarchy(call.feature, call.memberCallArguments.size) 
-			|| c.allMethods.exists[isValidMessage(call)] 
+			|| c.allUntypedMethods.exists[isValidMessage(call)] 
 	}
 
 	def static boolean matchesPropertiesInHierarchy(WMethodContainer it, String propertyName, int parametersSize) {


### PR DESCRIPTION
El problema es que para un WMethodContainer está devolviendo una lista vacía el método allMethods (duplica! :P) porque no invoca el comportamiento modelado en WMethodContainerException. Ahora chequea que el typesystem se encuentre desactivado y vuelve a ser le mismo comportamiento de antes. Caso contrario delega en la implementación del typesystem. 

Tiene sentido lanzar una 1.7.3? Al menos en UTN aún no se tomó parcial y al menos para mi es una herramienta bastante útil a la hora de codear. 

