### PR TITLE
Fix #1611.

### DIFF
--- a/org.uqbar.project.wollok.typeSystem.ui/src/org/uqbar/project/wollok/typeSystem/ui/builder/WollokTypeSystemBuilderParticipant.xtend
+++ b/org.uqbar.project.wollok.typeSystem.ui/src/org/uqbar/project/wollok/typeSystem/ui/builder/WollokTypeSystemBuilderParticipant.xtend
@@ -2,7 +2,6 @@ package org.uqbar.project.wollok.typeSystem.ui.builder
 
 import com.google.inject.Inject
 import com.google.inject.Singleton
-import org.apache.log4j.Level
 import org.apache.log4j.Logger
 import org.eclipse.core.runtime.CoreException
 import org.eclipse.core.runtime.IProgressMonitor
@@ -76,10 +75,11 @@ class WollokTypeSystemBuilderParticipant implements IXtextBuilderParticipant {
 				wollokActivator.generateIssues(it)
 				wollokActivator.refreshTypeErrors(project, it, monitor)
 			]
+
+			wollokActivator.refreshOutline
+			wollokActivator.refreshErrorsInEditor
 		]
 
-		wollokActivator.refreshOutline
-		wollokActivator.refreshErrorsInEditor
 	}
 
 	def isWollokUserFile(Resource it) { IFile !== null && IFile.isWollokExtension && !isCoreLib }


### PR DESCRIPTION
El error sólo se produce si el type system está desactivado, está refrescando el outline y los errores siempre, esté activado o no. Muevo los refrescos dentro del if.

Como consecuencia, si deshabilitamos el type system y no le damos rebuild, los errores de tipos preexistentes quedan para siempre. Se podría mejorar pero creo que es aceptable; un clean limpiaría los errores.