### PR TITLE
Fixing assert.equals() when used with one parameter

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lib.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib.wlk
@@ -1,5 +1,3 @@
-import wollok.vm.*
-
 /** 
  * Console is a global wollok object that implements a character-based console device
  * called "standard input/output" stream 
@@ -72,6 +70,13 @@ object assert {
 	 */
 	method notThat(value) {
 		if (value) throw new AssertionException("Value was not false")
+	}
+	
+	/*
+	 * This method avoids confusion with equals definition in Object
+	 */
+	override method equals(value) {
+		throw new AssertionException("assert.equals(expected, actual): missing second parameter")
 	}
 	
 	/** 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/asserts/AssertTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/asserts/AssertTestCase.xtend
@@ -28,6 +28,16 @@ class AssertTestCase extends AbstractWollokInterpreterTestCase {
 	}
 
 	@Test
+	def void assertWithOneParameterShouldFail() {
+		'''
+		assert.throwsExceptionLike(
+			new AssertionException("assert.equals(expected, actual): missing second parameter"),
+			{ => assert.equals(4) }
+		)
+		'''.test
+	}
+	
+	@Test
 	def void assertEqualsWhenEqualsWorks() {
 		'''
 		assert.equals(4, 4)

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/natives/ExceptionPropagationInNativeTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/natives/ExceptionPropagationInNativeTestCase.xtend
@@ -46,7 +46,7 @@ program natives {
 			} catch e {
 				assert.equals(e.getStackTraceAsString(), 
 		"wollok.lib.AssertionException: Expected [1] but found [true]
-			at  [/lib.wlk:86]
+			at  [/lib.wlk:91]
 			at  [/assertTest.wpgm:3]
 		"
 				)

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -79,7 +79,7 @@ class SetTest extends CollectionTestCase {
 		assert.equals(#{1,2,3}, set.asSet())		
 		const list = set.asList()
 		assert.equals(3, list.size())
-		[1,2,3].forEach{i=>assert.equals(list.contains(i))}
+		[1,2,3].forEach{i=>assert.that(list.contains(i))}
 		'''.test
 	}
 	


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4549002/58392112-cb498000-800e-11e9-9d61-77a718cdfe93.png)

Funny thing is that we had an error in our sanity tests (using `assert.equals` instead of `assert.that`).