### PR TITLE
Formatter cli #1666

### DIFF
--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/Messages.java
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/Messages.java
@@ -44,6 +44,7 @@ public class Messages extends NLS {
 	public static String WollokLauncherOptions_JAR_LIBRARIES;
 	public static String WollokLauncherOptions_WOLLOK_FILES;
 	public static String WollokLauncherOptions_DONT_VALIDATE;
+	public static String WollokLauncherOptions_SAVE_FILE;
 	
 	static {
 		// initialize resource bundle

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokFormatter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokFormatter.xtend
@@ -1,7 +1,9 @@
 package org.uqbar.project.wollok.launch
 
 import com.google.inject.Injector
+import java.io.BufferedWriter
 import java.io.File
+import java.io.FileWriter
 import org.eclipse.xtext.resource.SaveOptions
 import org.eclipse.xtext.serializer.ISerializer
 import org.uqbar.project.wollok.wollokDsl.WFile
@@ -14,8 +16,15 @@ class WollokFormatter extends WollokChecker {
 	
 	override doSomething(WFile parsed, Injector injector, File mainFile, WollokLauncherParameters parameters) {
 		val serializer = injector.getInstance(ISerializer)
-		val options = SaveOptions.newBuilder.format().getOptions()
-		println(serializer.serialize(parsed, options))
+		val formattedFile = serializer.serialize(parsed, SaveOptions.newBuilder.format.options)
+		if (parameters.saveFile) {
+			new BufferedWriter(new FileWriter(mainFile)) => [
+				write(formattedFile)
+				close
+			]
+		} else {
+			println(formattedFile)
+		}
 	}
 	
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokFormatter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokFormatter.xtend
@@ -1,0 +1,21 @@
+package org.uqbar.project.wollok.launch
+
+import com.google.inject.Injector
+import java.io.File
+import org.eclipse.xtext.resource.SaveOptions
+import org.eclipse.xtext.serializer.ISerializer
+import org.uqbar.project.wollok.wollokDsl.WFile
+
+class WollokFormatter extends WollokChecker {
+	
+	def static void main(String[] args) {
+		new WollokFormatter().doMain(args)
+	}
+	
+	override doSomething(WFile parsed, Injector injector, File mainFile, WollokLauncherParameters parameters) {
+		val serializer = injector.getInstance(ISerializer)
+		val options = SaveOptions.newBuilder.format().getOptions()
+		println(serializer.serialize(parsed, options))
+	}
+	
+}

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherParameters.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherParameters.xtend
@@ -33,6 +33,7 @@ class WollokLauncherParameters {
 	boolean noAnsiFormat = false
 	boolean severalFiles = false
 	boolean validate = true
+	boolean saveFile = false
 
 	Integer numberOfDecimals = null
 	String printingStrategy = null
@@ -60,6 +61,9 @@ class WollokLauncherParameters {
 		buildNumberPreferences(sb)
 		buildListOption(sb, libraries, "lib", ',')
 		buildListOption(sb, wollokFiles, "wf", ' ')
+		// only for formatter
+		if (saveFile) sb.append("-save ")
+		//
 		sb.toString
 	}
 
@@ -107,6 +111,8 @@ class WollokLauncherParameters {
 		printingStrategy = parseParameterString(cmdLine, "printingStrategy")
 		coercingStrategy = parseParameterString(cmdLine, "coercingStrategy")
 
+		saveFile = cmdLine.hasOption("save")
+		
 		if ((requestsPort == 0 && eventsPort != 0) || (requestsPort != 0 && eventsPort == 0)) {
 			throw new RuntimeException(Messages.WollokLauncher_REQUEST_PORT_EVENTS_PORT_ARE_BOTH_REQUIRED)
 		}
@@ -204,6 +210,8 @@ class WollokLauncherParameters {
 			add("numberOfDecimals", Messages.WollokLauncherOptions_NUMBER_DECIMALS, "decimals", 1)
 			add("printingStrategy", Messages.WollokLauncherOptions_DECIMAL_PRINTING_STRATEGY, "name", 1)
 			add("coercingStrategy", Messages.WollokLauncherOptions_DECIMAL_CONVERSION_STRATEGY, "name", 1)
+
+			add("save", Messages.WollokLauncherOptions_SAVE_FILE, "save", 0)
 
 			addList("lib", Messages.WollokLauncherOptions_JAR_LIBRARIES, "libs", ',')
 			addList("wf", Messages.WollokLauncherOptions_WOLLOK_FILES, "files", ' ')

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherParameters.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/WollokLauncherParameters.xtend
@@ -83,7 +83,6 @@ class WollokLauncherParameters {
 	}
 
 	def parse(String[] args) {
-		args.forEach[println(it)]
 		val parser = new OptionalGnuParser
 		val cmdLine = parser.parse(options, args, false)
 

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages.properties
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages.properties
@@ -33,3 +33,4 @@ WollokLauncherOptions_DECIMAL_CONVERSION_STRATEGY = Strategy to use when convert
 WollokLauncherOptions_JAR_LIBRARIES = Extra JAR libraries
 WollokLauncherOptions_WOLLOK_FILES = Wollok files
 WollokLauncherOptions_DONT_VALIDATE = Avoid running Wollok validator, just execute program.
+WollokLauncherOptions_SAVE_FILE=Save formatter result in the same file

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages_es.properties
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/messages_es.properties
@@ -34,3 +34,4 @@ WollokLauncherOptions_DECIMAL_CONVERSION_STRATEGY = Criterio a usar para convert
 WollokLauncherOptions_JAR_LIBRARIES = Librer\u00EDas JAR extras
 WollokLauncherOptions_WOLLOK_FILES = Archivos Wollok a ejecutar
 WollokLauncherOptions_DONT_VALIDATE = Ejecutar el programa sin utilizar el validador de Wollok
+WollokLauncherOptions_SAVE_FILE=Grabar el resultado del formateo en el mismo archivo

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting2/WollokDslFormatter.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/formatting2/WollokDslFormatter.xtend
@@ -28,10 +28,12 @@ import org.uqbar.project.wollok.wollokDsl.WListLiteral
 import org.uqbar.project.wollok.wollokDsl.WMemberFeatureCall
 import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
 import org.uqbar.project.wollok.wollokDsl.WMixin
+import org.uqbar.project.wollok.wollokDsl.WNamedArgumentsList
 import org.uqbar.project.wollok.wollokDsl.WNamedObject
 import org.uqbar.project.wollok.wollokDsl.WObjectLiteral
 import org.uqbar.project.wollok.wollokDsl.WPackage
 import org.uqbar.project.wollok.wollokDsl.WParameter
+import org.uqbar.project.wollok.wollokDsl.WPositionalArgumentsList
 import org.uqbar.project.wollok.wollokDsl.WPostfixOperation
 import org.uqbar.project.wollok.wollokDsl.WProgram
 import org.uqbar.project.wollok.wollokDsl.WReturnExpression
@@ -50,12 +52,8 @@ import static org.uqbar.project.wollok.wollokDsl.WollokDslPackage.Literals.*
 
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
-import org.uqbar.project.wollok.wollokDsl.WNamedArgumentsList
-import org.uqbar.project.wollok.wollokDsl.WPositionalArgumentsList
 
 class WollokDslFormatter extends AbstractFormatter2 {
-	
-	@Inject extension WollokDslGrammarAccess
 	
 	def dispatch void format(WFile file, extension IFormattableDocument document) {
 		file => [


### PR DESCRIPTION
This will allow `wollok-cli` to run formatter externally:

![wollokFormat](https://user-images.githubusercontent.com/4549002/59976714-c12f8880-959e-11e9-919f-becc89e1b0da.gif)

You can do

```bash
wollok format pepita.wlk // prints formatted file directly to the console
wollok format pepita.wlk -save // saves formatted file directly into pepita.wlk
```