### PR TITLE
Fix some ts errors

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/failureMessages.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/failureMessages.wlk.xt
@@ -2,6 +2,11 @@
 
 
 object pepita {
+	var energia = 0
+
+	// XPECT methodType at vola --> (Number) => Void
+	method vola(kms) { energia -= kms + 10 }
+	
 	method energia() = 100
 }
 
@@ -18,5 +23,10 @@ object wollok {
 	
 	// XPECT warnings --> "Type system: expected <<pepita>> but found <<arbol>>" at "arbol"
 	method prueba2() = self.tomarEnergia(arbol)
+	
+	method prueba3() {
+		// XPECT warnings --> "Type system: expected <<Number>> but found <<arbol>>" at "arbol"
+		pepita.vola(arbol)	
+	}
 }
 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/inheritParameters.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/inheritParameters.wlk.xt
@@ -1,0 +1,36 @@
+/* XPECT_SETUP org.uqbar.project.wollok.tests.typesystem.xpect.TypeSystemXpectTestCase END_SETUP */
+
+class Ave {
+	var property energia
+		
+	method come() {
+		energia += 3
+	}
+}
+
+class Golondrina inherits Ave {
+	
+	method vola() {
+		energia -= 10 
+	}
+	
+}
+
+object entrenador {
+	// XPECT methodType at alimentar --> (Ave) => Void
+	method alimentar(ave) {
+		ave.come()
+	}
+	
+	// XPECT methodType at queVuele --> (Golondrina) => Void
+	method queVuele(golondrina) {
+		golondrina.vola()
+		self.alimentar(golondrina)
+	}
+}
+
+object wollok {
+	method testEntrenador() {
+		entrenador.alimentar(new Ave())
+	}
+}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/super.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/typesystem/xpect/super.wlk.xt
@@ -104,7 +104,7 @@ class EntrenadorDeGolondrinas inherits EntrenadorDeAves {
 class EntrenadorDeAves {
 	const ave
 	
-	// XPECT! type at a --> Ave
+	// XPECT type at a --> Ave
 	constructor(a) {
 		ave = a	
 	}
@@ -121,7 +121,7 @@ class EntrenadorDeAves {
 }
 
 object wollok {
-	// method entrenadorDeAves() = new EntrenadorDeAves(new Ave())
+	method entrenadorDeAves() = new EntrenadorDeAves(new Ave())
 	method entrenadorDeGolondrinas() = new EntrenadorDeGolondrinas(new Golondrina())
 }
 

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/UnifyVariables.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/UnifyVariables.xtend
@@ -57,9 +57,14 @@ class UnifyVariables extends AbstractInferenceStrategy {
 			return Cancel
 		}
 
+		// Do not unify args with params
+		if(subtype.typeInfo !== null && subtype.typeInfo.hasPostponedMinType && supertype.owner.isParameter) {
+			return Cancel
+		}
+		
 		// We can only unify in absence of errors, this aims for avoiding error propagation 
 		// and further analysis of the (maybe) correct parts of the program.
-		if(supertype.hasErrors) {
+		if(subtype.hasErrors || supertype.hasErrors) {
 			log.debug('''Unifying «subtype» with «supertype»: errors found, aborting unification''')
 			return Error
 		}
@@ -93,6 +98,10 @@ class UnifyVariables extends AbstractInferenceStrategy {
 	def dispatch isEmpty(VoidTypeInfo it) { true }
 	def dispatch isEmpty(GenericTypeInfo it) { minTypes.isEmpty && maximalConcreteTypes === null }
 
+
+	def dispatch hasPostponedMinType(VoidTypeInfo it) { false }
+	def dispatch hasPostponedMinType(GenericTypeInfo it) { minTypes.values.contains(Postponed)}
+
 	// ************************************************************************
 	// ** Unification conditions
 	// ************************************************************************
@@ -118,10 +127,11 @@ class UnifyVariables extends AbstractInferenceStrategy {
 		}
 	}
 	
-	def dispatch doUnifyWith(GenericTypeInfo t1, GenericTypeInfo t2) {
+	def dispatch doUnifyWith(GenericTypeInfo t1, GenericTypeInfo t2) {		
 		t1.minTypes = minTypesUnion(t1, t2)
 		t1.joinMaxTypes(t2.maximalConcreteTypes)
 		t1.messages.addAll(t2.messages)
+
 
 		t2.users.forEach[typeInfo = t1]
 
@@ -147,6 +157,8 @@ class UnifyVariables extends AbstractInferenceStrategy {
 			if(isReadyIn(t1) && isReadyIn(t2))
 				// It was already present and ready in both originating typeInfo's
 				Ready
+			else if (isPostponedIn(t1) || isPostponedIn(t2))
+				Postponed
 			else
 				// Mark this concrete type to be further propagated.
 				Pending
@@ -158,9 +170,17 @@ class UnifyVariables extends AbstractInferenceStrategy {
 	 * and if its Ready (i.e. type information has already been propagated.
 	 */
 	def boolean isReadyIn(WollokType wollokType, GenericTypeInfo type) {
-		type.minTypes.get(wollokType) == Ready
+		wollokType.isStateIn(type, Ready)
+	}
+	
+	def boolean isPostponedIn(WollokType wollokType, GenericTypeInfo type) {
+		wollokType.isStateIn(type, Postponed)
 	}
 
+	def boolean isStateIn(WollokType wollokType, GenericTypeInfo type, ConcreteTypeState state) {
+		type.minTypes.get(wollokType) == state
+	}
+	
 	def <T> T uniqueElement(Set<T> it) { iterator.next }
 
 }

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/UnifyVariables.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/UnifyVariables.xtend
@@ -58,7 +58,7 @@ class UnifyVariables extends AbstractInferenceStrategy {
 		}
 
 		// Do not unify args with params
-		if(subtype.typeInfo !== null && subtype.typeInfo.hasPostponedMinType && supertype.owner.isParameter) {
+		if(subtype.typeInfo !== null && (subtype.typeInfo.isEmpty || subtype.typeInfo.hasPostponedMinType) && supertype.owner.isParameter) {
 			return Cancel
 		}
 		

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/UnifyVariables.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/constraints/strategies/UnifyVariables.xtend
@@ -58,7 +58,7 @@ class UnifyVariables extends AbstractInferenceStrategy {
 		}
 
 		// Do not unify args with params
-		if(subtype.typeInfo !== null && (subtype.typeInfo.isEmpty || subtype.typeInfo.hasPostponedMinType) && supertype.owner.isParameter) {
+		if(subtype.isArgOf(supertype)) {
 			return Cancel
 		}
 		
@@ -95,9 +95,14 @@ class UnifyVariables extends AbstractInferenceStrategy {
 		}
 	}
 
+	def isArgOf(TypeVariable subtype, TypeVariable supertype) { 
+		subtype.typeInfo !== null && 
+		(subtype.typeInfo.isEmpty || subtype.typeInfo.hasPostponedMinType) && 
+		supertype.owner.isParameter
+	}
+
 	def dispatch isEmpty(VoidTypeInfo it) { true }
 	def dispatch isEmpty(GenericTypeInfo it) { minTypes.isEmpty && maximalConcreteTypes === null }
-
 
 	def dispatch hasPostponedMinType(VoidTypeInfo it) { false }
 	def dispatch hasPostponedMinType(GenericTypeInfo it) { minTypes.values.contains(Postponed)}


### PR DESCRIPTION
Fix #1600
Fix #1569
Fix #1615

Estos problemas era causados por la unificación entre argumentos y parámetros. Creo que esas relaciones deberían estar aparte de las generales de sub/super tipo, ya que debe postergarse hacia el final del proceso de inferencia, por si se detectan errores.