### PR TITLE
Wollok game issues

### DIFF
--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/Messages.java
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/Messages.java
@@ -11,6 +11,8 @@ public class Messages extends NLS {
 	public static String WollokGame_NoMessage;
 	public static String WollokGame_CharacterKeyNotFound;
 	public static String WollokGame_ListenerNotFound;
+	public static String WollokGame_SoundGameNotStarted;
+	public static String WollokGame_AudioNotFound;
 	
 	static {
 		// initialize resource bundle

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/VisualComponent.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/VisualComponent.xtend
@@ -66,7 +66,6 @@ abstract class VisualComponent {
 			this.addMessage(end, color)
 			return 
 		}
-		
 		balloonMessages.add(new BalloonMessage(message, color))
 	}
 

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Gameboard.xtend
@@ -1,9 +1,12 @@
 package org.uqbar.project.wollok.game.gameboard;
 
+import com.badlogic.gdx.Gdx
+import com.badlogic.gdx.audio.Sound
 import java.util.Collection
-
 import java.util.List
+import java.util.Map
 import org.apache.log4j.Logger
+import org.eclipse.osgi.util.NLS
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.uqbar.project.wollok.game.Messages
 import org.uqbar.project.wollok.game.Position
@@ -16,10 +19,6 @@ import org.uqbar.project.wollok.interpreter.core.WollokProgramExceptionWrapper
 import static org.uqbar.project.wollok.sdk.WollokDSK.*
 
 import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions.*
-import org.eclipse.osgi.util.NLS
-import com.badlogic.gdx.Gdx
-import com.badlogic.gdx.audio.Sound
-import java.util.Map
 
 @Accessors
 class Gameboard {
@@ -165,14 +164,25 @@ class Gameboard {
 	}
 
 	def sound(String audioFile) {
-		audioFile.fetchSound.play(1.0f)
+		val sound = audioFile.fetchSound
+		if (sound !== null) {
+			sound.play(1.0f)
+		}
 	}
 	
 	def fetchSound(String audioFile) {
+		if (Gdx.app === null)
+			throw new RuntimeException(Messages.WollokGame_SoundGameNotStarted)
+			
 		var sound = audioFiles.get(audioFile)
 		if (sound === null) {
-			sound = Gdx.audio.newSound(Gdx.files.internal(audioFile))
-			audioFiles.put(audioFile, sound)
+			try {
+				val soundFile = Gdx.files.internal(audioFile)
+				sound = Gdx.audio.newSound(soundFile)
+				audioFiles.put(audioFile, sound)
+			} catch (Exception e) {
+				println(NLS.bind(Messages.WollokGame_AudioNotFound, audioFile))
+			}
 		}
 		sound
 	}

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/gameboard/Window.xtend
@@ -81,8 +81,10 @@ class Window {
 		var plusWidth = 0	
 		glyphLayout.reset
 		this.setText(newText, baseWidth, color)
-		
-		while (glyphLayout.height > 29) {
+
+		var previousHeight = 0f
+		while (glyphLayout.height > 29 && previousHeight !== glyphLayout.height) {
+			previousHeight = glyphLayout.height
 			glyphLayout.reset
 			plusWidth += 10
 			this.setText(newText, baseWidth + plusWidth, color)
@@ -103,6 +105,7 @@ class Window {
 			patchIndex++
 			textX = 5
 		}
+		
 		val x = xInPixels + (DELTA_TO_VISUAL_COMPONENT * adjustmentX)
 		var adjustmentY = 1
 		var textY = 0

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/TimeListener.xtend
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/listeners/TimeListener.xtend
@@ -35,6 +35,5 @@ class TimeListener extends GameboardListener {
 	def boolean shouldRun() {
 		System.currentTimeMillis - timeSinceLastRun > millisecondsEvery
 	}
-	
-	
+
 }

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/messages.properties
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/messages.properties
@@ -4,3 +4,5 @@
 WollokGame_NoMessage = NO MESSAGE
 WollokGame_CharacterKeyNotFound = Character key [{0}] not found.
 WollokGame_ListenerNotFound = There is no tick event called {0}.
+WollokGame_SoundGameNotStarted = You cannot play sounds until the game has started. Try using it inside an onTick / onPressDo block.
+WollokGame_AudioNotFound = File "{0}" not found in project. Have you defined an "assets" source folder?

--- a/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/messages_es.properties
+++ b/org.uqbar.project.wollok.game/src/org/uqbar/project/wollok/game/messages_es.properties
@@ -4,3 +4,5 @@
 WollokGame_NoMessage = FALTA MENSAJE
 WollokGame_CharacterKeyNotFound = No se encuentra el caracter {0} .
 WollokGame_ListenerNotFound = No existe el evento de nombre {0}.
+WollokGame_SoundGameNotStarted = No se puede pedir un sonido hasta que el juego comience. Pruebe definirlo dentro de un bloque onTick / onPressDo.
+WollokGame_AudioNotFound = El archivo "{0}" no se encontr\u00F3 en el proyecto. Revise si existe una carpeta fuente donde se encuentra el archivo.


### PR DESCRIPTION
Dos arreglos:

- #1663 Game se cuelga al lanzar error con más de un salto de línea
- #1669 game.sound() tira un error cuando el juego no arrancó (no es la solución, evitamos un error feo y lo reemplazamos por una sugerencia ya que el diseño del juego requiere pensar bien una alternativa)

A futuro quedan otros issues que necesitan más definición