### PR TITLE
fix: #1241 - dayOfWeek() returns object

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -2370,7 +2370,12 @@ class Date {
 	  */
 	method day() native
 	
-	/** Answers the day of the week of the Date with an object representation */
+	/** Answers the day of the week of the Date with an object representation.
+	 * There is a wko (well known object) for every day of the week.
+	 *
+	 * Example:
+	 *     new Date(24, 2, 2018).dayOfWeek() ==> Answers saturday object
+	 */
 	method dayOfWeek() = daysOfWeek.get(self.internalDayOfWeek() - 1)
 	
 	/** Answers the day of week of the Date, where

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -2274,6 +2274,17 @@ class Closure {
 	
 }
 
+/** Represents days of week. */	
+
+object monday { }
+object tuesday { }
+object wednesday { }
+object thursday { }
+object friday { }
+object saturday { }
+object sunday { }
+const daysOfWeek = [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
+
 /**
  *
  * Represents a Date (without time). A Date is immutable, once created you can not change it.
@@ -2359,6 +2370,9 @@ class Date {
 	  */
 	method day() native
 	
+	/** Answers the day of the week of the Date with an object representation */
+	method dayOfWeek() = daysOfWeek.get(self.internalDayOfWeek() - 1)
+	
 	/** Answers the day of week of the Date, where
 	 * 1 = MONDAY
 	 * 2 = TUESDAY
@@ -2367,9 +2381,9 @@ class Date {
 	 * 7 = SUNDAY
 	 *
 	 * Example:
-	 *     new Date(24, 2, 2018).dayOfWeek() ==> Answers 6 (SATURDAY) 
+	 *     new Date(24, 2, 2018).internalDayOfWeek() ==> Answers 6 (SATURDAY) 
 	 */
-	method dayOfWeek() native
+	method internalDayOfWeek() native
 	
 	/** 
 	  * Answers the month number of the Date

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WDate.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WDate.xtend
@@ -79,7 +79,7 @@ class WDate extends AbstractJavaWrapper<LocalDate> {
 		wrapped.minusYears(years.coerceToInteger)
 	}
 	
-	def dayOfWeek() { wrapped.dayOfWeek.value }
+	def internalDayOfWeek() { wrapped.dayOfWeek.value }
 	
 	@NativeMessage("<")
 	def lessThan(LocalDate aDate) {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/DateTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/DateTestCase.xtend
@@ -109,7 +109,15 @@ class DateTestCase extends AbstractWollokInterpreterTestCase {
 	def void tuesdayIsSecondDayOfWeek() {
 		'''
 		const aDay = new Date(7, 6, 2016)
-		assert.equals(aDay.dayOfWeek(), 2) 
+		assert.equals(aDay.internalDayOfWeek(), 2) 
+		'''.test
+	}
+	
+	@Test
+	def void tuesdayDayOfWeekIsTuesdayObject() {
+		'''
+		const aDay = new Date(7, 6, 2016)
+		assert.equals(aDay.dayOfWeek(), tuesday) 
 		'''.test
 	}
 


### PR DESCRIPTION
It looks like I forgot to create this PR during last hackaton.

now `someDateObject.dayOfWeek()` returns an object representation for days of the week instead of an integer. Note that now exists `internalDayOfWeek()` which returns an integer.