### PR TITLE
Feature : copy and copywithout

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -769,7 +769,7 @@ class Collection {
 	}
 	
 	method without(elementToRemove) {
-		return [1,2,4,5]
+		return self.filter{ element => element != elementToRemove }
 	}
 	/**
 	 * Answers a new List that contains the elements of self collection 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -768,9 +768,14 @@ class Collection {
 		return copy
 	}
 	
-	method without(elementToRemove) {
+	method copyWithout(elementToRemove) {
 		return self.filter{ element => element != elementToRemove }
 	}
+	
+	method copyWith(elementToAdd) {
+		return [1,2,3,4,5,6]
+	}
+	
 	/**
 	 * Answers a new List that contains the elements of self collection 
 	 * sorted by a criteria given by a closure. The closure receives two objects

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -768,12 +768,32 @@ class Collection {
 		return copy
 	}
 	
+	/**
+	 * Answers a new collection without element that is passed by parameter
+	 *
+	 * @returns a new Collection
+	 *
+	 * Example:
+	 *      [1, 5, 9, 2, 4].copyWithout(9) => Answers [1, 5, 2, 4]
+	 *
+	 */
 	method copyWithout(elementToRemove) {
 		return self.filter{ element => element != elementToRemove }
 	}
 	
+	/**
+	 * Answers a new collection with the added element which is received by parameter
+	 *
+	 * @returns a new Collection
+	 *
+	 * Example:
+	 *      [1, 5, 9, 2, 4].copyWith(9) => Answers [1, 5, 2, 4, 9]
+	 *
+	 */
 	method copyWith(elementToAdd) {
-		return [1,2,3,4,5,6]
+		const copy = self.copy()
+		copy.add(elementToAdd)
+		return copy
 	}
 	
 	/**

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -769,12 +769,15 @@ class Collection {
 	}
 	
 	/**
-	 * Answers a new collection without element that is passed by parameter
+	 * Answers a new collection without element that is passed by parameter.
+	 * If the element occurs more than once in the collection, all occurrences
+	 * will be removed.
 	 *
 	 * @returns a new Collection
 	 *
 	 * Example:
 	 *      [1, 5, 9, 2, 4].copyWithout(9) => Answers [1, 5, 2, 4]
+	 *      [1, 5, 9, 2, 9].copyWithout(9) => Answers [1, 5, 2]
 	 *
 	 */
 	method copyWithout(elementToRemove) {
@@ -782,7 +785,7 @@ class Collection {
 	}
 	
 	/**
-	 * Answers a new collection with the added element which is received by parameter
+	 * Answers a new collection with the added element which is received by parameter.
 	 *
 	 * @returns a new Collection
 	 *

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -768,6 +768,9 @@ class Collection {
 		return copy
 	}
 	
+	method without(elementToRemove) {
+		return [1,2,4,5]
+	}
 	/**
 	 * Answers a new List that contains the elements of self collection 
 	 * sorted by a criteria given by a closure. The closure receives two objects

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
@@ -235,6 +235,5 @@ class ListTestCase extends CollectionTestCase {
 		'''
 		assert.throwsExceptionWithMessage("Message max sent to an empty collection. It must have at least one element.", { [].max() })
 		'''.test
-	}
-	 	
+	}	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
@@ -235,5 +235,6 @@ class ListTestCase extends CollectionTestCase {
 		'''
 		assert.throwsExceptionWithMessage("Message max sent to an empty collection. It must have at least one element.", { [].max() })
 		'''.test
-	}	
+	}
+	 	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
@@ -123,6 +123,15 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 	}
 	
 	@Test
+	def void copyWithDontMutateTheCollection(){
+		'''
+		const unList = [1,2,3,4,5]
+		const newList = unList.copyWith(3)
+		assert.equals(unList, [1,2,3,4,5])
+		'''.test
+	}
+	
+	@Test
 	def void whenPassANumberAtCopyWithMethodReturnANewCollectionWithThisNumber() {
 		'''
 		const unList = [1,2,3,4,5]

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
@@ -96,20 +96,29 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 	}
 	
 	@Test
-	def void whenPassANumberAtWithoutMethodReturnANewListWithoutThisNumber() {
+	def void whenPassANumberAtCopyWithoutMethodReturnANewCollectionWithoutThisNumber() {
 		'''
 		const unList = [1,2,3,4,5]
-		const newList = unList.without(3)
+		const newList = unList.copyWithout(3)
 		assert.equals(newList, [1,2,4,5])
 		'''.test
 	}
 	
 	@Test
-	def void whenPassAStringAtWithoutMethodReturnANewListWithoutThisString() {
+	def void whenPassAStringAtCopyWithoutMethodReturnANewCollectionWithoutThisString() {
 		'''
 		const unList = ["hola","como","estas"]
-		const newList = unList.without("como")
+		const newList = unList.copyWithout("como")
 		assert.equals(newList, ["hola","estas"])
+		'''.test
+	}
+	
+	@Test
+	def void whenPassANumberAtCopyWithMethodReturnANewCollectionWithThisNumber() {
+		'''
+		const unList = [1,2,3,4,5]
+		const newList = unList.copyWith(6)
+		assert.equals(newList, [1,2,3,4,5,6])
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
@@ -104,4 +104,13 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 		'''.test
 	}
 	
+	@Test
+	def void whenPassAStringAtWithoutMethodReturnANewListWithoutThisString() {
+		'''
+		const unList = ["hola","como","estas"]
+		const newList = unList.without("como")
+		assert.equals(newList, ["hola","estas"])
+		'''.test
+	}
+	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
@@ -96,6 +96,15 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 	}
 	
 	@Test
+	def void copyWithoutDontMutateTheCollection(){
+		'''
+		const unList = [1,2,3,4,5]
+		const newList = unList.copyWithout(3)
+		assert.equals(unList, [1,2,3,4,5])
+		'''.test
+	}
+	
+	@Test
 	def void whenPassANumberAtCopyWithoutMethodReturnANewCollectionWithoutThisNumber() {
 		'''
 		const unList = [1,2,3,4,5]

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
@@ -122,4 +122,13 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 		'''.test
 	}
 	
+	@Test
+	def void whenPassAStringAtCopyWithMethodReturnANewCollectionWithThisString() {
+		'''
+		const unList = ["hola","como"]
+		const newList = unList.copyWith("estas")
+		assert.equals(newList, ["hola","como","estas"])
+		'''.test
+	}
+	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/CollectionTest.xtend
@@ -95,4 +95,13 @@ class CollectionTest extends AbstractWollokInterpreterTestCase {
 		}'''.interpretPropagatingErrors
 	}
 	
+	@Test
+	def void whenPassANumberAtWithoutMethodReturnANewListWithoutThisNumber() {
+		'''
+		const unList = [1,2,3,4,5]
+		const newList = unList.without(3)
+		assert.equals(newList, [1,2,4,5])
+		'''.test
+	}
+	
 }


### PR DESCRIPTION
# Cambios

- Se agregan las funcionalidades `copyWith` y `copyWithout` en las que se habla en [#1518](https://github.com/uqbar-project/wollok/issues/1518)

`copyWith` retorna una nueva lista con el elemento que le pases por parametro al final

`copyWithout` retorna una nueva lista sin el elemento especificado por parametro
