### PR TITLE
Feature #1692 change to string of date

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -2478,10 +2478,10 @@ class Date {
 	  *
 	  * Example:
 	  *     new Date(day = 12, month = 5, year = 2018).plusDays(1) 
-	  *        ==> Answers 13/5/18, a day forward
+	  *        ==> Answers 13/5/2018, a day forward
 	  *     
 	  *     new Date(day = 12, month = 5, year = 2018).plusDays(-1)
-	  *        ==> Answers 11/5/18, a day back
+	  *        ==> Answers 11/5/2018, a day back
 	  */
 	method plusDays(_days) native
 	
@@ -2492,10 +2492,10 @@ class Date {
 	  *
 	  * Example:
 	  *     new Date(day = 31, month = 1, year = 2018).plusMonths(1)
-      *        ==> Answers 28/2/18, a month forward 
+      *        ==> Answers 28/2/2018, a month forward
 	  *     
 	  *     new Date(day = 12, month = 5, year = 2018).plusMonths(-1)
-	  *        ==> Answers 12/4/18, a month back
+	  *        ==> Answers 12/4/2018, a month back
 	  */
 	method plusMonths(_months) native
 	
@@ -2506,10 +2506,10 @@ class Date {
 	  *
 	  * Example:
 	  *     new Date(day = 31, month = 1, year = 2018).plusYears(1)
-      *        ==> Answers 31/1/19, a year forward 
+      *        ==> Answers 31/1/2019, a year forward
 	  *     
 	  *     new Date(day = 12, month = 5, year = 2018).plusYears(-1)
-	  *        ==> Answers 12/5/17, a year back
+	  *        ==> Answers 12/5/2017, a year back
 	  */
 	method plusYears(_years) native
 	
@@ -2558,10 +2558,10 @@ class Date {
      *
 	 * Examples:
 	 * 		new Date(day = 1, month = 1, year = 2009).minusDays(1) 
-	 *          ==> Answers 31/12/08, a day back 
+	 *          ==> Answers 31/12/2008, a day back
 	 *
 	 * 		new Date(day = 1, month = 1, year = 2009).minusDays(-1) 
-	 *          ==> Answers 2/1/09, a day forward 
+	 *          ==> Answers 2/1/2009, a day forward
 	 */
 	method minusDays(_days) native
 	
@@ -2572,10 +2572,10 @@ class Date {
 	  *
 	  * Examples:
 	  * 		new Date(day = 1, month = 1, year = 2009).minusMonths(1) 
-	  *             ==> Answers 1/12/08, a month back
+	  *             ==> Answers 1/12/2008, a month back
 	  *
 	  * 		new Date(day = 1, month = 1, year = 2009).minusMonths(-1) 
-	  *             ==> Answers 1/2/09, a month forward
+	  *             ==> Answers 1/2/2009, a month forward
 	  */
 	method minusMonths(_months) native
 	
@@ -2586,10 +2586,10 @@ class Date {
 	  *
 	  * Examples:
 	  * 		new Date(day = 1, month = 1, year = 2009).minusYears(1) 
-	  *             ==> Answers 1/1/08, a year back
+	  *             ==> Answers 1/1/2008, a year back
 	  *
 	  * 		new Date(day = 1, month = 1, year = 2009).minusYears(-1) 
-	  *             ==> Answers 1/1/10, a year forward
+	  *             ==> Answers 1/1/2010, a year forward
 	  */
 	method minusYears(_years) native
 	

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -264,6 +264,9 @@ class Pair {
 	}
 	method key() = x
 	method value() = y
+
+	/** String representation of a Pair */
+	override method toString() = x.toString() + " -> " + y.toString()
 }
 
 /**

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -2475,10 +2475,10 @@ class Date {
 	  *
 	  * Example:
 	  *     new Date(day = 12, month = 5, year = 2018).plusDays(1) 
-	  *        ==> Answers a Date[day = 13, month = 5, year = 2018], a day forward
+	  *        ==> Answers 13/5/18, a day forward
 	  *     
 	  *     new Date(day = 12, month = 5, year = 2018).plusDays(-1)
-	  *        ==> Answers a Date[day = 11, month = 5, year = 2018], a day back
+	  *        ==> Answers 11/5/18, a day back
 	  */
 	method plusDays(_days) native
 	
@@ -2489,10 +2489,10 @@ class Date {
 	  *
 	  * Example:
 	  *     new Date(day = 31, month = 1, year = 2018).plusMonths(1)
-      *        ==> Answers a Date[day = 28, month = 2, year = 2018], a month forward 
+      *        ==> Answers 28/2/18, a month forward 
 	  *     
 	  *     new Date(day = 12, month = 5, year = 2018).plusMonths(-1)
-	  *        ==> Answers a Date[day = 12, month = 4, year = 2018], a month back
+	  *        ==> Answers 12/4/18, a month back
 	  */
 	method plusMonths(_months) native
 	
@@ -2503,10 +2503,10 @@ class Date {
 	  *
 	  * Example:
 	  *     new Date(day = 31, month = 1, year = 2018).plusYears(1)
-      *        ==> Answers a Date[day = 31, month = 1, year = 2019], a year forward 
+      *        ==> Answers 31/1/19, a year forward 
 	  *     
 	  *     new Date(day = 12, month = 5, year = 2018).plusYears(-1)
-	  *        ==> Answers a Date[day = 12, month = 5, year = 2017], a year back
+	  *        ==> Answers 12/5/17, a year back
 	  */
 	method plusYears(_years) native
 	
@@ -2555,10 +2555,10 @@ class Date {
      *
 	 * Examples:
 	 * 		new Date(day = 1, month = 1, year = 2009).minusDays(1) 
-	 *          ==> Answers a Date[day = 31, month = 12, year = 2008], a day back 
+	 *          ==> Answers 31/12/08, a day back 
 	 *
 	 * 		new Date(day = 1, month = 1, year = 2009).minusDays(-1) 
-	 *          ==> Answers a Date[day = 2, month = 1, year = 2009], a day forward 
+	 *          ==> Answers 2/1/09, a day forward 
 	 */
 	method minusDays(_days) native
 	
@@ -2569,10 +2569,10 @@ class Date {
 	  *
 	  * Examples:
 	  * 		new Date(day = 1, month = 1, year = 2009).minusMonths(1) 
-	  *             ==> Answers a Date[day = 1, month = 12, year = 2008], a month back
+	  *             ==> Answers 1/12/08, a month back
 	  *
 	  * 		new Date(day = 1, month = 1, year = 2009).minusMonths(-1) 
-	  *             ==> Answers a Date[day = 1, month = 2, year = 2009], a month forward
+	  *             ==> Answers 1/2/09, a month forward
 	  */
 	method minusMonths(_months) native
 	
@@ -2583,10 +2583,10 @@ class Date {
 	  *
 	  * Examples:
 	  * 		new Date(day = 1, month = 1, year = 2009).minusYears(1) 
-	  *             ==> Answers a Date[day = 1, month = 1, year = 2008], a year back
+	  *             ==> Answers 1/1/08, a year back
 	  *
 	  * 		new Date(day = 1, month = 1, year = 2009).minusYears(-1) 
-	  *             ==> Answers a Date[day = 1, month = 1, year = 2010], a year forward
+	  *             ==> Answers 1/1/10, a year forward
 	  */
 	method minusYears(_years) native
 	
@@ -2606,16 +2606,16 @@ class Date {
 
 	/** Shows nicely an internal representation of a date **/
 	override method toSmartString(alreadyShown) =
-		"a Date[day = " + day + ", month = " + month + ", year = " + year + "]"
+		self.shortDescription()
 
 	/** 
 	  * Shows a short, internal representation of a date 
+	  * (the result varies depending on user's locale)
 	  * 
 	  * Example:
 	  *     new Date(day = 2, month = 4, year = 2018).shortDescription()
-	  *         ==> Answers "2/4/2018"
+	  *         ==> Answers 2/4/2018
 	  */
-	override method shortDescription() =
-		"" + day + "/" + month + "/" + year
+	override method shortDescription() native
 
 }

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WDate.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WDate.xtend
@@ -2,8 +2,11 @@ package wollok.lang
 
 import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.chrono.IsoChronology
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
 import java.time.format.FormatStyle
+import java.util.Locale
 import org.uqbar.project.wollok.interpreter.WollokInterpreter
 import org.uqbar.project.wollok.interpreter.core.WollokObject
 import org.uqbar.project.wollok.interpreter.nativeobj.NativeMessage
@@ -19,7 +22,7 @@ import static extension org.uqbar.project.wollok.utils.WollokObjectUtils.*
  */
 class WDate extends AbstractJavaWrapper<LocalDate> {
 	
-	var public static FORMATTER = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
+	var public static FORMATTER = DateTimeFormatter.ofPattern(WDate.getLocalizedFormat(Locale.^default))
 
 	new(WollokObject obj, WollokInterpreter interpreter) {
 		super(obj, interpreter)
@@ -116,4 +119,9 @@ class WDate extends AbstractJavaWrapper<LocalDate> {
 		getWrapped.format(FORMATTER)
 	}
 	
+	def static getLocalizedFormat(Locale locale) {
+		return DateTimeFormatterBuilder
+			.getLocalizedDateTimePattern(FormatStyle.SHORT, null, IsoChronology.INSTANCE, locale)
+			.replaceFirst("/yy$", "/yyyy")
+	}
 }

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WDate.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WDate.xtend
@@ -1,16 +1,15 @@
 package wollok.lang
 
 import java.math.BigDecimal
-
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import org.uqbar.project.wollok.interpreter.WollokInterpreter
 import org.uqbar.project.wollok.interpreter.core.WollokObject
 import org.uqbar.project.wollok.interpreter.nativeobj.NativeMessage
 
-import static extension org.uqbar.project.wollok.utils.WollokObjectUtils.*
 import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions.*
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
+import static extension org.uqbar.project.wollok.utils.WollokObjectUtils.*
 
 /**
  * Native implementation of the date wollok class

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WDate.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WDate.xtend
@@ -9,6 +9,8 @@ import org.uqbar.project.wollok.interpreter.nativeobj.NativeMessage
 
 import static extension org.uqbar.project.wollok.utils.WollokObjectUtils.*
 import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJavaConversions.*
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 /**
  * Native implementation of the date wollok class
@@ -17,6 +19,8 @@ import static extension org.uqbar.project.wollok.interpreter.nativeobj.WollokJav
  * @author dodain
  */
 class WDate extends AbstractJavaWrapper<LocalDate> {
+	
+	var public static FORMATTER = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
 
 	new(WollokObject obj, WollokInterpreter interpreter) {
 		super(obj, interpreter)
@@ -107,6 +111,10 @@ class WDate extends AbstractJavaWrapper<LocalDate> {
 	def wollokIdentityEquals(WollokObject other) {
 		val wDate = other.getNativeObject(WDate) as WDate
 		wDate !== null && getWrapped == wDate.getWrapped
+	}
+	
+	def shortDescription() {
+		getWrapped.format(FORMATTER)
 	}
 	
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/base/AbstractWollokParameterizedInterpreterTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/base/AbstractWollokParameterizedInterpreterTest.xtend
@@ -3,8 +3,8 @@ package org.uqbar.project.wollok.tests.base
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.uqbar.project.wollok.tests.interpreter.AbstractWollokInterpreterTestCase
 import org.uqbar.project.wollok.tests.injectors.WollokTestInjectorProvider
+import org.uqbar.project.wollok.tests.interpreter.AbstractWollokInterpreterTestCase
 
 /**
  * Helper class to allow parameterized interpreter tests

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/AbstractWollokInterpreterTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/AbstractWollokInterpreterTestCase.xtend
@@ -3,6 +3,7 @@ package org.uqbar.project.wollok.tests.interpreter
 import com.google.inject.Inject
 import java.io.File
 import java.io.FileInputStream
+import java.time.format.DateTimeFormatter
 import org.eclipse.emf.common.util.URI
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.testing.InjectWith
@@ -15,6 +16,7 @@ import org.junit.runner.RunWith
 import org.uqbar.project.wollok.interpreter.WollokInterpreter
 import org.uqbar.project.wollok.interpreter.core.WollokProgramExceptionWrapper
 import org.uqbar.project.wollok.tests.injectors.WollokTestInjectorProvider
+import wollok.lang.WDate
 
 /**
  * Abstract base class for all interpreter tests cases.
@@ -35,6 +37,9 @@ abstract class AbstractWollokInterpreterTestCase extends Assert {
 	@Before
 	def void setUp() {
 		interpreter.classLoader = AbstractWollokInterpreterTestCase.classLoader
+
+		// This makes the Date string representation independent of the current user's locale
+		WDate.FORMATTER = DateTimeFormatter.ofPattern("d/M/yy")
 
 		new File("target/test-files").mkdirs
 		new File("target/test-files/WOLLOK.ROOT").createNewFile

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/DateTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/DateTestCase.xtend
@@ -201,8 +201,8 @@ class DateTestCase extends AbstractWollokInterpreterTestCase {
 	def void toStringDefaultTest() {
 		'''
 		const aDay = new Date(day = 28, month = 12, year = 2016)
-		assert.equals("a Date[day = 28, month = 12, year = 2016]", aDay.toString())
-		assert.equals("a Date[day = 28, month = 12, year = 2016]", aDay.toSmartString(false))
+		assert.equals("28/12/16", aDay.toString())
+		assert.equals("28/12/16", aDay.toSmartString(false))
 		'''.test
 	}
 	
@@ -210,8 +210,8 @@ class DateTestCase extends AbstractWollokInterpreterTestCase {
 	def void toStringWithA1DigitMonthTest() {
 		'''
 		const aDay = new Date(day = 28, month = 2, year = 2016)
-		assert.equals("a Date[day = 28, month = 2, year = 2016]", aDay.toString())
-		assert.equals("a Date[day = 28, month = 2, year = 2016]", aDay.toSmartString(false))
+		assert.equals("28/2/16", aDay.toString())
+		assert.equals("28/2/16", aDay.toSmartString(false))
 		'''.test
 	}
 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/NumberTestCase.xtend
@@ -35,7 +35,7 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void addWithFailingParameters() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 18, month = 12, year = 2017]", { 3 + new Date(day = 18, month = 12, year = 2017) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 18/12/17", { 3 + new Date(day = 18, month = 12, year = 2017) })
 		assert.throwsExceptionWithMessage("Operation doesn't support parameter pepe", { 3 + "pepe" })
 		'''.test
 	}
@@ -57,7 +57,7 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void maxFailingParameter() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 21, month = 12, year = 2017]", { 4.min(new Date(day = 21, month = 12, year = 2017)) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 21/12/17", { 4.min(new Date(day = 21, month = 12, year = 2017)) })
 		'''.test
 	}
 
@@ -78,7 +78,7 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void minFailingParameter() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 21, month = 12, year = 2017]", { 4.min(new Date(day = 21, month = 12, year = 2017)) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 21/12/17", { 4.min(new Date(day = 21, month = 12, year = 2017)) })
 		'''.test
 	}
 	
@@ -418,7 +418,7 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void gcdForInvalidArguments() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 1, month = 1, year = 2018]", { 4.gcd(new Date(day = 1, month = 1, year = 2018)) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 1/1/18", { 4.gcd(new Date(day = 1, month = 1, year = 2018)) })
 		'''.test
 	}
 	
@@ -472,7 +472,7 @@ class NumberTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void lcmForInvalidArguments() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 1, month = 1, year = 2018]", { 4.lcm(new Date(day = 1, month = 1, year = 2018)) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 1/1/18", { 4.lcm(new Date(day = 1, month = 1, year = 2018)) })
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/PairTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/PairTestCase.xtend
@@ -1,0 +1,112 @@
+package org.uqbar.project.wollok.tests.interpreter
+
+import org.junit.Test
+
+class PairTestCase extends AbstractWollokInterpreterTestCase {
+	
+	@Test
+	def void smokeTest() {
+		'''
+		const pair = new Pair(1, 1)
+		assert.equals(pair, pair)
+		'''.test
+	}
+	
+	@Test
+	def void testNewContructor() {
+		'''
+		const pair = new Pair(1, 2)
+		assert.equals(1, pair.x())
+		assert.equals(2, pair.y())
+		'''.test
+	}
+	
+	@Test
+	def void testArrowContructor() {
+		'''
+		const pair = 1->2
+		assert.equals(1, pair.x())
+		assert.equals(2, pair.y())
+		'''.test
+	}
+	
+	@Test
+	def void testXGetter() {
+		'''
+		const pair = "1"->2
+		assert.equals("1", pair.x())
+		'''.test
+	}
+	
+	@Test
+	def void testYGetter() {
+		'''
+		const pair = 1->"2"
+		assert.equals("2", pair.y())
+		'''.test
+	}
+	
+	@Test
+	def void testXSetterThrowsCannotModifyConstantPropertyException() {
+		'''
+		const pair = 1->2
+		assert.throwsExceptionWithMessage("Cannot modify constant property x", { pair.x(10) })
+		'''.test
+	}
+	
+	@Test
+	def void testYSetterThrowsCannotModifyConstantPropertyException() {
+		'''
+		const pair = 1->2
+		assert.throwsExceptionWithMessage("Cannot modify constant property y", { pair.y(20) })
+		'''.test
+	}
+	
+	@Test
+	def void testKeyGetter() {
+		'''
+		const pair = 10->20
+		assert.equals(10, pair.key())
+		'''.test
+	}
+	
+	@Test
+	def void testValueGetter() {
+		'''
+		const pair = 10->20
+		assert.equals(20, pair.value())
+		'''.test
+	}
+	
+	@Test
+	def void testKeySetterThrowsMessageNotUnderstoodException() {
+		'''
+		const pair = 1->2
+		assert.throwsExceptionWithType(new MessageNotUnderstoodException(), { pair.key(10) })
+		'''.test
+	}
+	
+	@Test
+	def void testValueSetterThrowsMessageNotUnderstoodException() {
+		'''
+		const pair = 1->2
+		assert.throwsExceptionWithType(new MessageNotUnderstoodException(), { pair.value(20) })
+		'''.test
+	}
+	
+	@Test
+	def void testToStringRepresentation() {
+		'''
+		const pair = 10->20
+		assert.equals("10 -> 20", pair.toString())
+		'''.test
+	}
+	
+	@Test
+	def void testShortDescriptionRepresentation() {
+		'''
+		const pair = 10->20
+		assert.equals("10 -> 20", pair.shortDescription())
+		'''.test
+	}
+}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/StringTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/StringTestCase.xtend
@@ -287,7 +287,7 @@ class StringTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void startsWithFail() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 1, month = 1, year = 2018]", { "hola".startsWith(new Date(day = 1, month = 1, year = 2018)) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 1/1/18", { "hola".startsWith(new Date(day = 1, month = 1, year = 2018)) })
 		'''.test
 	}
 	
@@ -308,7 +308,7 @@ class StringTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void endsWithFail() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 1, month = 1, year = 2018]", { "hola".endsWith(new Date(day = 1, month = 1, year = 2018)) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 1/1/18", { "hola".endsWith(new Date(day = 1, month = 1, year = 2018)) })
 		'''.test
 	}
 	
@@ -329,7 +329,7 @@ class StringTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void indexOfFail() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 1, month = 1, year = 2018]", { "hola".indexOf(new Date(day = 1, month = 1, year = 2018)) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 1/1/18", { "hola".indexOf(new Date(day = 1, month = 1, year = 2018)) })
 		'''.test
 	}
 
@@ -343,7 +343,7 @@ class StringTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void lastIndexOfFail() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 1, month = 1, year = 2018]", { "hola".lastIndexOf(new Date(day = 1, month = 1, year = 2018)) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 1/1/18", { "hola".lastIndexOf(new Date(day = 1, month = 1, year = 2018)) })
 		'''.test
 	}
 
@@ -357,7 +357,7 @@ class StringTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void containsFail() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 1, month = 1, year = 2018]", { "hola".contains(new Date(day = 1, month = 1, year = 2018)) })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 1/1/18", { "hola".contains(new Date(day = 1, month = 1, year = 2018)) })
 		'''.test
 	}
 
@@ -399,7 +399,7 @@ class StringTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void equalsIgnoreCaseFail() {
 		'''
-		assert.throwsExceptionWithMessage("a Date[day = 1, month = 1, year = 2018] does not understand toUpperCase()", { "hola".equalsIgnoreCase(new Date(day = 1, month = 1, year = 2018)) })
+		assert.throwsExceptionWithMessage("1/1/18 does not understand toUpperCase()", { "hola".equalsIgnoreCase(new Date(day = 1, month = 1, year = 2018)) })
 		'''.test
 	}
 
@@ -414,7 +414,7 @@ class StringTestCase extends AbstractWollokInterpreterTestCase {
 	@Test
 	def void replaceFail() {
 		'''
-		assert.throwsExceptionWithMessage("Operation doesn't support parameter a Date[day = 1, month = 1, year = 2018], a", { "hola".replace(new Date(day = 1, month = 1, year = 2018), "a") })
+		assert.throwsExceptionWithMessage("Operation doesn't support parameter 1/1/18, a", { "hola".replace(new Date(day = 1, month = 1, year = 2018), "a") })
 		'''.test
 	}
 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/WollokXPectTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/WollokXPectTest.xtend
@@ -1,15 +1,17 @@
 package org.uqbar.project.wollok.tests.xpect
 
+import java.time.format.DateTimeFormatter
 import org.eclipse.xtext.testing.InjectWith
 import org.junit.runner.RunWith
 import org.junit.runner.Runner
 import org.junit.runner.notification.RunNotifier
 import org.junit.runners.model.InitializationError
+import org.uqbar.project.wollok.tests.injectors.WollokTestInjectorProvider
 import org.xpect.runner.XpectRunner
 import org.xpect.xtext.lib.tests.XtextTests
-import org.uqbar.project.wollok.tests.injectors.WollokTestInjectorProvider
 import wollok.lang.WDate
-import java.time.format.DateTimeFormatter
+
+import static wollok.lang.WDate.*
 
 /**
  * @author jfernandes

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/WollokXPectTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/WollokXPectTest.xtend
@@ -8,6 +8,8 @@ import org.junit.runners.model.InitializationError
 import org.xpect.runner.XpectRunner
 import org.xpect.xtext.lib.tests.XtextTests
 import org.uqbar.project.wollok.tests.injectors.WollokTestInjectorProvider
+import wollok.lang.WDate
+import java.time.format.DateTimeFormatter
 
 /**
  * @author jfernandes
@@ -20,6 +22,8 @@ class WollokXPectTest extends XtextTests {
 class WollokXpectRunner extends XpectRunner {
 	new(Class<?> testClass) throws InitializationError {
 		super(testClass)
+		// This makes the Date string representation independent of the current user's locale
+		WDate.FORMATTER = DateTimeFormatter.ofPattern("d/M/yy")
 	}
 
 	override runChild(Runner child, RunNotifier notifier) {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/WollokXPectTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/WollokXPectTest.xtend
@@ -1,6 +1,5 @@
 package org.uqbar.project.wollok.tests.xpect
 
-import java.time.format.DateTimeFormatter
 import org.eclipse.xtext.testing.InjectWith
 import org.junit.runner.RunWith
 import org.junit.runner.Runner
@@ -9,9 +8,6 @@ import org.junit.runners.model.InitializationError
 import org.uqbar.project.wollok.tests.injectors.WollokTestInjectorProvider
 import org.xpect.runner.XpectRunner
 import org.xpect.xtext.lib.tests.XtextTests
-import wollok.lang.WDate
-
-import static wollok.lang.WDate.*
 
 /**
  * @author jfernandes
@@ -24,8 +20,6 @@ class WollokXPectTest extends XtextTests {
 class WollokXpectRunner extends XpectRunner {
 	new(Class<?> testClass) throws InitializationError {
 		super(testClass)
-		// This makes the Date string representation independent of the current user's locale
-		WDate.FORMATTER = DateTimeFormatter.ofPattern("d/M/yy")
 	}
 
 	override runChild(Runner child, RunNotifier notifier) {


### PR DESCRIPTION
La idea de este PR es hacer que el toString del Date de Wollok en lugar de imprimir
`>> a Date[day = 23, month = 1, year = 2019]`
imprima
`>> 23/1/19`
En sí el cambio está terminado. El problema que estoy teniendo viene por decisiones que tomamos al definir el formato para el toString. Decidimos hacer que el toString respete el locale del usuario, es decir, que lo formatee según la región del usuario. Esta decisión respeta mejor los formatos estándar pero requiere ciertas consideraciones al correr los tests, por ejemplo, que dependiendo de la máquina que corra los tests (en particular del locale de la maquina) los tests van a pasar o no.
Bueno, para evitar que esto pase es que intenté cambiar el formateador que usa el WDate (el objeto java que se encarga de hacer este toString por detrás) al instanciar al WollokRunner para que siempre imprima el mismo formato independiente del locale (en este caso d/M/yy -> ej 23/1/19) y funcionó.. pero solo cuando lo corro desde el eclipse. Si se corren los test desde el maven por linea de comandos, esto no funciona. El mensaje de error que arroja es juntamente que lo esperado no coincide con lo devuelto, en otras palabras, no está usando ese runner (asumo yo) o por algún motivo se pierde el nuevo formatter que se le asigna.

![image](https://user-images.githubusercontent.com/31070486/62013744-50672780-b16d-11e9-92bb-f88c3dad08d9.png)

Cómo proponen que se puede arreglar? 
Cuál sería el mejor lugar para meter ese nuevo formatter al WDate?
o Cuál es es la mejor manera de evitar que esto pase (que los tests dependan del locale)?