### PR TITLE
Fix #1743 - without duplicates de list no respeta el orden

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -921,7 +921,7 @@ class Set inherits Collection {
 	 *		#{1, 2, 3}.asSet() => Answers #{1, 2, 3}
 	 * 		#{}.asSet()        => Answers #{} 
 	 */
-	override method asSet() = self
+	override method asSet() native
 
 	/**
 	 * Answers any element of a non-empty collection
@@ -1188,11 +1188,7 @@ class List inherits Collection {
 	 *
 	 * @see Set
 	 */
-	override method asSet() { 
-		const result = #{}
-		result.addAll(self)
-		return result
-	}
+	override method asSet() native
 	
 	/** 
 	 * Answers a view of the portion of this list between the specified fromIndex 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -915,11 +915,11 @@ class Set inherits Collection {
 	}
 	
 	/**
-	 * Converts an object to a Set. No effect on Sets.
+	 * Returns a new copy of current Set.
 	 *
 	 * Examples
-	 *		#{1, 2, 3}.asSet() => Answers #{1, 2, 3}
-	 * 		#{}.asSet()        => Answers #{} 
+	 *		#{1, 2, 3}.asSet() => Answers #{1, 2, 3}, which is a copy of original set
+	 * 		#{}.asSet()        => Answers #{}, also a copy of original #{}
 	 */
 	override method asSet() native
 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
@@ -98,6 +98,10 @@ class WCollection<T extends Collection<WollokObject>> {
 		wrapped.map[ if (it instanceof WCallable) call("toString") else toString ].join(separator)
 	}
 	
+	def asSet(){
+		wrapped.toSet
+	}
+	
 	@NativeMessage("==")
 	def wollokEqualsEquals(WollokObject other) { wollokEquals(other) }
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/ListTestCase.xtend
@@ -148,8 +148,8 @@ class ListTestCase extends CollectionTestCase {
 	@Test
 	def void withoutDuplicates() {
 		'''
-		assert.equals([1, 3, 1, 5, 1, 3, 2, 5].withoutDuplicates(), [1, 2, 3, 5])
-		assert.equals([1, 3, 5, 2].withoutDuplicates(), [1, 2, 3, 5])
+		assert.equals([1, 3, 1, 5, 1, 3, 2, 5].withoutDuplicates(), [1, 3, 5, 2])
+		assert.equals([1, 3, 5, 2].withoutDuplicates(), [1, 3, 5, 2])
 		'''.test
 	}	
 	


### PR DESCRIPTION
Mi idea fue ponerle native a asSet y usar el toSet de IterableExtensions que respeta el orden.

![withoutDuplicates](https://user-images.githubusercontent.com/26492157/63471591-f2fd8800-c445-11e9-9bad-f717ee0f6d18.PNG)