### PR TITLE
fix #1739 - Definición de una constante por fuera de un container me pide que inicie en minúscula

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckOnNameStyles.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckOnNameStyles.wlk.xt
@@ -1,6 +1,6 @@
 /* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
 
-const LOTI = 2
+	const LOTI = 2
 
 	// XPECT warnings --> "Object name should start with lowercase" at "Juancete"
 	object Juancete { }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckOnNameStyles.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckOnNameStyles.wlk.xt
@@ -1,5 +1,7 @@
 /* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
 
+const LOTI = 2
+
 	// XPECT warnings --> "Object name should start with lowercase" at "Juancete"
 	object Juancete { }
 	

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -214,7 +214,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(WARN)
 	@CheckGroup(WollokCheckGroup.NAMING_CONVENTION)
 	def referenciableNameMustStartWithLowerCase(WVariable c) {
-		if(Character.isUpperCase(c.name.charAt(0)) && c.container instanceof WMethodContainer) report(WollokDslValidator_VARIABLE_NAME_MUST_START_LOWERCASE, c,
+		if(Character.isUpperCase(c.name.charAt(0)) && !c.isGlobal) report(WollokDslValidator_VARIABLE_NAME_MUST_START_LOWERCASE, c,
 			WNAMED__NAME, VARIABLE_NAME_MUST_START_LOWERCASE)
 	}
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -214,7 +214,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(WARN)
 	@CheckGroup(WollokCheckGroup.NAMING_CONVENTION)
 	def referenciableNameMustStartWithLowerCase(WVariable c) {
-		if(Character.isUpperCase(c.name.charAt(0))) report(WollokDslValidator_VARIABLE_NAME_MUST_START_LOWERCASE, c,
+		if(Character.isUpperCase(c.name.charAt(0)) && c.container instanceof WMethodContainer) report(WollokDslValidator_VARIABLE_NAME_MUST_START_LOWERCASE, c,
 			WNAMED__NAME, VARIABLE_NAME_MUST_START_LOWERCASE)
 	}
 


### PR DESCRIPTION
![fix-1739-](https://user-images.githubusercontent.com/26492157/63566434-8c5e9400-c543-11e9-9387-bf7a311e5403.gif)