### PR TITLE
Fix #1771 - inconsistencias en list.asSet()

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -922,11 +922,11 @@ class Set inherits Collection {
 	}
 	
 	/**
-	 * Returns a new copy of current Set.
+	 * Converts an object to a Set. No effect on Sets.
 	 *
 	 * Examples
-	 *		#{1, 2, 3}.asSet() => Answers #{1, 2, 3}, which is a copy of original set
-	 * 		#{}.asSet()        => Answers #{}, also a copy of original #{}
+	 *		#{1, 2, 3}.asSet() => Answers #{1, 2, 3}
+	 * 		#{}.asSet()        => Answers #{}
 	 */
 	override method asSet() = self
 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -273,7 +273,7 @@ class Pair {
 	method value() = y
 
 	/** 
-	 * Two pairs are equals if they have the same values
+	 * Two pairs are equal if they have the same values
 	 *
 	 * Example:
 	 *		new Pair(1, 2) == new Pair(1, 2)  ==> Answers true
@@ -1595,7 +1595,7 @@ class Dictionary {
 	}
 
 	/** 
-	 * Two dictionaries are equals if they have the same values
+	 * Two dictionaries are equal if they have the same keys and values
 	 */
 	override method equals(other) {
 		self.checkNotNull(other, "equals")

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -771,8 +771,23 @@ class Collection {
 	/** Converts a collection to a list */
 	method asList()
 	
-	/** Converts a collection to a set (no duplicates) */
-	method asSet()
+	/** Converts a collection to a set (removing duplicates if necessary)
+	 *
+	 * Examples:	
+	 *		[1, 2, 3].asSet()       => Answers #{1, 2, 3}
+	 *      [].asSet()              => Answers #{}
+	 *      [1, 2, 1, 1, 2].asSet() => Answers #{1, 2}	
+	 *
+	 *		#{1, 2, 3}.asSet() => Answers #{1, 2, 3}
+	 * 		#{}.asSet()        => Answers #{}
+	 *
+	 * @see Set
+	 */
+	method asSet() {
+		const result = #{}
+		result.addAll(self)
+		return result
+	}
 
 	/**
 	 * Answers a new collection of the same type and with the same content 
@@ -933,15 +948,6 @@ class Set inherits Collection {
 		return result
 	}
 	
-	/**
-	 * Converts an object to a Set. No effect on Sets.
-	 *
-	 * Examples
-	 *		#{1, 2, 3}.asSet() => Answers #{1, 2, 3}
-	 * 		#{}.asSet()        => Answers #{}
-	 */
-	override method asSet() = self
-
 	/**
 	 * Answers any element of a non-empty collection
 	 *
@@ -1196,22 +1202,6 @@ class List inherits Collection {
 	 * @see List
 	 */
 	override method asList() = self
-	
-	/**
-	 * Converts this list to a set (removing duplicate elements)
-	 *
-	 * Examples:	
-	 *		[1, 2, 3].asSet()       => Answers #{1, 2, 3}
-	 *      [].asSet()              => Answers #{}
-	 *      [1, 2, 1, 1, 2].asSet() => Answers #{1, 2}	
-	 *
-	 * @see Set
-	 */
-	override method asSet() {
-		const result = #{}
-		result.addAll(self)
-		return result
-	}
 	
 	/** 
 	 * Answers a view of the portion of this list between the specified fromIndex 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -895,9 +895,7 @@ class Collection {
 	 * with default element separator (",")
 	 */
 	method join()
-	
-	method <(other) 
-	method >(other)
+
 }
 
 /**
@@ -1112,9 +1110,6 @@ class Set inherits Collection {
 	 * @see Object#==
 	 */
 	override method ==(other) native
-	
-	override method <(other) native
-	override method >(other) native
 	
 }
 
@@ -1424,9 +1419,6 @@ class List inherits Collection {
 	 * [].withoutDuplicates()                       => Answers []
 	 */
 	method withoutDuplicates() native
-	
-	override method <(other) native
-	override method >(other) native
 
 }
 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -895,6 +895,9 @@ class Collection {
 	 * with default element separator (",")
 	 */
 	method join()
+	
+	method <(other) 
+	method >(other)
 }
 
 /**
@@ -1109,6 +1112,9 @@ class Set inherits Collection {
 	 * @see Object#==
 	 */
 	override method ==(other) native
+	
+	override method <(other) native
+	override method >(other) native
 	
 }
 
@@ -1418,6 +1424,9 @@ class List inherits Collection {
 	 * [].withoutDuplicates()                       => Answers []
 	 */
 	method withoutDuplicates() native
+	
+	override method <(other) native
+	override method >(other) native
 
 }
 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -1406,11 +1406,7 @@ class List inherits Collection {
 	 * [1, 3, 1, 5, 1, 3, 2, 5].withoutDuplicates() => Answers [1, 2, 3, 5]
 	 * [].withoutDuplicates()                       => Answers []
 	 */
-	method withoutDuplicates() {
-		const result = new List()
-		self.forEach { elem => if (!result.contains(elem)) result.add(elem) }
-		return result
-	}
+	method withoutDuplicates() native
 
 }
 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -1401,9 +1401,9 @@ class List inherits Collection {
 	override method ==(other) native
 
 	/**
-	 * Answers the list without duplicate elements
+	 * Answers the list without duplicate elements. Preserves order of elements.
 	 *
-	 * [1, 3, 1, 5, 1, 3, 2, 5].withoutDuplicates() => Answers [1, 2, 3, 5]
+	 * [1, 3, 1, 5, 1, 3, 2, 5].withoutDuplicates() => Answers [1, 3, 5, 2]
 	 * [].withoutDuplicates()                       => Answers []
 	 */
 	method withoutDuplicates() native

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -928,7 +928,7 @@ class Set inherits Collection {
 	 *		#{1, 2, 3}.asSet() => Answers #{1, 2, 3}, which is a copy of original set
 	 * 		#{}.asSet()        => Answers #{}, also a copy of original #{}
 	 */
-	override method asSet() native
+	override method asSet() = self
 
 	/**
 	 * Answers any element of a non-empty collection
@@ -1195,7 +1195,11 @@ class List inherits Collection {
 	 *
 	 * @see Set
 	 */
-	override method asSet() native
+	override method asSet() {
+		const result = #{}
+		result.addAll(self)
+		return result
+	}
 	
 	/** 
 	 * Answers a view of the portion of this list between the specified fromIndex 
@@ -1402,7 +1406,11 @@ class List inherits Collection {
 	 * [1, 3, 1, 5, 1, 3, 2, 5].withoutDuplicates() => Answers [1, 2, 3, 5]
 	 * [].withoutDuplicates()                       => Answers []
 	 */
-	method withoutDuplicates() = self.asSet().asList()
+	method withoutDuplicates() {
+		const result = new List()
+		self.forEach { elem => if (!result.contains(elem)) result.add(elem) }
+		return result
+	}
 
 }
 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -276,7 +276,7 @@ class Pair {
 	 * Two pairs are equal if they have the same values
 	 *
 	 * Example:
-	 *		new Pair(1, 2) == new Pair(1, 2)  ==> Answers true
+	 *		new Pair(1, 2).equals(new Pair(1, 2))  ==> Answers true
 	 */
 	override method equals(other) {
 		self.checkNotNull(other, "equals")
@@ -1600,7 +1600,7 @@ class Dictionary {
 	 */
 	override method equals(other) {
 		self.checkNotNull(other, "equals")
-		return self.keys() == other.keys() && self.values() && other.values()
+		return self.keys() == other.keys() && self.values() == other.values()
 	}
 		
 }

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -272,6 +272,17 @@ class Pair {
 	method key() = x
 	method value() = y
 
+	/** 
+	 * Two pairs are equals if they have the same values
+	 *
+	 * Example:
+	 *		new Pair(1, 2) == new Pair(1, 2)  ==> Answers true
+	 */
+	override method equals(other) {
+		self.checkNotNull(other, "equals")
+		return x == other.x() && y == other.y()
+	}
+ 
 	/** String representation of a Pair */
 	override method toString() = x.toString() + " -> " + y.toString()
 }
@@ -1394,12 +1405,12 @@ class List inherits Collection {
 	 *
 	 *
 	 * Examples:
-	 * 		[].equals([])         => Answers true
-	 *      [1, 2].equals([2, 1]) => Answers false
-	 *      [1, 2].equals([1, 2]) => Answers true
+	 * 		[] == []         => Answers true
+	 *      [1, 2] == [2, 1] => Answers false
+	 *      [1, 2] == [1, 2] => Answers true
 	 */
 	override method ==(other) native
-
+	
 	/**
 	 * Answers the list without duplicate elements. Preserves order of elements.
 	 *
@@ -1582,7 +1593,15 @@ class Dictionary {
 		if (self.size() > 0) result = result.substring(0, result.length() - 2) 
 		return result + "]"
 	}
-	
+
+	/** 
+	 * Two dictionaries are equals if they have the same values
+	 */
+	override method equals(other) {
+		self.checkNotNull(other, "equals")
+		return self.keys() == other.keys() && self.values() && other.values()
+	}
+		
 }
 
 /**

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
@@ -98,10 +98,6 @@ class WCollection<T extends Collection<WollokObject>> {
 		wrapped.map[ if (it instanceof WCallable) call("toString") else toString ].join(separator)
 	}
 	
-	def asSet(){
-		wrapped.toSet
-	}
-	
 	@NativeMessage("==")
 	def wollokEqualsEquals(WollokObject other) { wollokEquals(other) }
 	

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
@@ -113,24 +113,6 @@ class WCollection<T extends Collection<WollokObject>> {
 		verifyWollokElementsContained(other.getNativeCollection, wrapped)
 	}
 	
-	@NativeMessage("<")
-	def lessThan(WollokObject other) {
-		other.checkNotNull("<")
-		val otherCollection = other.getNativeCollection
-
-		!wollokEquals(other) && (wrapped.size < otherCollection.size ||
-			(wrapped.size == otherCollection.size && wrapped.toString < otherCollection.toString))
-	}
-
-	@NativeMessage(">")
-	def greaterThan(WollokObject other) {
-		other.checkNotNull(">")
-		val otherCollection = other.getNativeCollection
-
-		!wollokEquals(other) && (wrapped.size > otherCollection.size ||
-			(wrapped.size == otherCollection.size && wrapped.toString > otherCollection.toString))
-	}
-	
 	protected def hasNativeType(WollokObject it) {
 		hasNativeType(this.class.name)
 	}

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
@@ -99,7 +99,9 @@ class WCollection<T extends Collection<WollokObject>> {
 	}
 	
 	@NativeMessage("==")
-	def wollokEqualsEquals(WollokObject other) { wollokEquals(other) }
+	def wollokEqualsEquals(WollokObject other) { 
+		wollokEquals(other)
+	}
 	
 	@NativeMessage("equals")
 	def wollokEquals(WollokObject other) {

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WCollection.xtend
@@ -113,6 +113,23 @@ class WCollection<T extends Collection<WollokObject>> {
 		verifyWollokElementsContained(other.getNativeCollection, wrapped)
 	}
 	
+	@NativeMessage("<")
+	def lessThan(WollokObject other) {
+		other.checkNotNull("<")
+		val otherCollection = other.getNativeCollection
+
+		!wollokEquals(other) && (wrapped.size < otherCollection.size ||
+			(wrapped.size == otherCollection.size && wrapped.toString < otherCollection.toString))
+	}
+
+	@NativeMessage(">")
+	def greaterThan(WollokObject other) {
+		other.checkNotNull(">")
+		val otherCollection = other.getNativeCollection
+
+		!wollokEquals(other) && (wrapped.size > otherCollection.size ||
+			(wrapped.size == otherCollection.size && wrapped.toString > otherCollection.toString))
+	}
 	
 	protected def hasNativeType(WollokObject it) {
 		hasNativeType(this.class.name)

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WList.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WList.xtend
@@ -48,12 +48,10 @@ class WList extends WCollection<List<WollokObject>> implements JavaWrapper<List<
 	
 	def withoutDuplicates() {
 		val result = newArrayList
-		val set = new TreeSet<WollokObject>(new WollokObjectComparator)
+		val comparator = new WollokObjectComparator
 		for (var i = 0; i < wrapped.size; i++) {
 			val element = wrapped.get(i)
-			if (set.add(element)) {
-				result.add(element)
-			}
+			if (result.forall [ newElement | comparator.compare(newElement, element) !== 0 ]) result.add(element)
 		}
 		result
 	}

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WList.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WList.xtend
@@ -45,6 +45,16 @@ class WList extends WCollection<List<WollokObject>> implements JavaWrapper<List<
 		}
 		wrapped = wrapped.sortWith(comparator)
 	}
+	
+	def withoutDuplicates() {
+		val result = newArrayList
+		val set = new TreeSet<WollokObject>(new WollokObjectComparator)
+		for (var i = 0; i < wrapped.size; i++) {
+			val element = wrapped.get(i)
+			if(set.add(element)) result.add(element)
+		}
+		result
+	}
 
 	def max() {
 		if (wrapped.isEmpty) throw new RuntimeException(NLS.bind(Messages.WollokRuntime_WrongMessage_EMPTY_LIST, "max"))

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WList.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WList.xtend
@@ -51,7 +51,9 @@ class WList extends WCollection<List<WollokObject>> implements JavaWrapper<List<
 		val set = new TreeSet<WollokObject>(new WollokObjectComparator)
 		for (var i = 0; i < wrapped.size; i++) {
 			val element = wrapped.get(i)
-			if(set.add(element)) result.add(element)
+			if (set.add(element)) {
+				result.add(element)
+			}
 		}
 		result
 	}

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WSet.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WSet.xtend
@@ -29,7 +29,7 @@ class WSet extends WCollection<Set<WollokObject>> implements JavaWrapper<Set<Wol
 	
 	override protected def verifyWollokElementsContained(Collection<WollokObject> set, Collection<WollokObject> set2) {
 		set2.forall [ elem |
-			set.exists[ it.wollokEquals(elem) ]
+			set.exists[ it.wollokEqualsMethod(elem) ]
 		]
 	}
 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WollokObjectComparator.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WollokObjectComparator.xtend
@@ -34,7 +34,7 @@ class WollokObjectComparator implements Comparator<WollokObject> {
 			val comparator = comparisonsStrategy.get(o1.kind.fqn) ?: new WollokObjectEqualsComparator		
 			return comparator.compare(o1, o2)
 		} catch (RuntimeException e) {
-			return o1.hashCode.compareTo(o2.hashCode)
+			return (o1.kind.hashCode).compareTo(o2.kind.hashCode)
 		}
 	}
 	

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WollokObjectComparator.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WollokObjectComparator.xtend
@@ -12,6 +12,7 @@ import static org.uqbar.project.wollok.sdk.WollokSDK.*
 
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
 import static extension org.uqbar.project.wollok.model.WollokModelExtensions.*
+import static extension wollok.lang.WollokObjectComparator.*
 
 /**
  * Definition for performance
@@ -28,16 +29,35 @@ class WollokObjectComparator implements Comparator<WollokObject> {
 	
 	override compare(WollokObject o1, WollokObject o2) {
 		try {
+			if (o1 === o2) return 0
 			if (o1 === null && o2 === null) return 0
 			if (o1 === null && o2 !== null) return -1
 			if (o1 !== null && o2 === null) return 1
 			val comparator = comparisonsStrategy.get(o1.kind.fqn) ?: new WollokObjectEqualsComparator		
 			return comparator.compare(o1, o2)
 		} catch (RuntimeException e) {
-			return (o1.kind.hashCode).compareTo(o2.kind.hashCode)
+			return o1.defaultOrderingCompare(o2)
 		}
 	}
 	
+	/**
+	 * So, we tried everything and the two objects are not comparable, so we'll impose just any arbitrary but consistent order.
+	 * The objective of this ordering is to guarantee that, in a set of non-comparable objects (e.g. objects of different kind or objects 
+	 * not comparable by nature such as lists or sets), if you later add an object that is comparable to any one of the already existing ones,
+	 * the new object will be compared to the right objects.
+	 * 
+	 * This is achieved by the concatenation of:
+	 * (a) the object's kind's fully qualified name (to group objects of the same kind),
+	 * (b) the object's to string (that means that the toString of non comparable objects should be consistent with equality)
+	 * (c) the object's hashCode (just to ensure that any two objects that arrive here are considered different from each other).
+	 */
+	static def defaultOrderingCompare(WollokObject o1, WollokObject o2) {
+		return o1.defaultOrderingKey.compareTo(o2.defaultOrderingKey)
+	}
+
+	static def defaultOrderingKey(WollokObject object) {
+		object.kind.fqn + object.toString + object.hashCode
+	}	
 }
 
 /**
@@ -47,17 +67,20 @@ class WollokObjectEqualsComparator implements Comparator<WollokObject> {
 	protected extension WollokInterpreterAccess = new WollokInterpreterAccess
 
 	override compare(WollokObject o1, WollokObject o2) {
-		if (o1.hasEqualsMethod) {
-			return if (o1.wollokEqualsMethod(o2)) 0 else o1.compareGreaterThan(o2)
+		if (o1.hasEqualsMethod && o1.wollokEqualsMethod(o2)) {
+			return 0
+		} 
+		if (o2.hasEqualsMethod && o2.wollokEqualsMethod(o1)) {
+			return 0 
 		}
-		// default case
-		return o1.hashCode.compareTo(o2.hashCode)
-	}
-
-	def compareGreaterThan(WollokObject o1, WollokObject o2) {
 		if (o1.hasGreaterThanMethod) {
-			 if (o1.wollokGreaterThan(o2)) 1 else -1
-		} else 1
+			return if (o1.wollokGreaterThan(o2)) 1 else -1
+		}
+		if (o2.hasGreaterThanMethod) {
+			return if (o2.wollokGreaterThan(o1)) -1 else 1
+		}
+
+		return o1.defaultOrderingCompare(o2)
 	}
 }
 

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WollokObjectComparator.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WollokObjectComparator.xtend
@@ -48,7 +48,7 @@ class WollokObjectEqualsComparator implements Comparator<WollokObject> {
 
 	override compare(WollokObject o1, WollokObject o2) {
 		if (o1.hasEqualsMethod) {
-			return if (o1.wollokEquals(o2)) 0 else 1 // o1.compareGreaterThan(o2)
+			return if (o1.wollokEqualsMethod(o2)) 0 else 1 // o1.compareGreaterThan(o2)
 		}
 		// default case
 		return o1.hashCode.compareTo(o2.hashCode)

--- a/org.uqbar.project.wollok.lib/src/wollok/lang/WollokObjectComparator.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang/WollokObjectComparator.xtend
@@ -48,7 +48,7 @@ class WollokObjectEqualsComparator implements Comparator<WollokObject> {
 
 	override compare(WollokObject o1, WollokObject o2) {
 		if (o1.hasEqualsMethod) {
-			return if (o1.wollokEqualsMethod(o2)) 0 else 1 // o1.compareGreaterThan(o2)
+			return if (o1.wollokEqualsMethod(o2)) 0 else o1.compareGreaterThan(o2)
 		}
 		// default case
 		return o1.hashCode.compareTo(o2.hashCode)

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/SetTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/SetTestCase.xtend
@@ -4,6 +4,9 @@ import org.junit.Test
 
 /**
  * @author matifreyre
+ * @author nicoviotti
+ * @author fdodino
+ * 
  */
 class SetTestCase extends CollectionTestCase {
 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/SetTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/SetTestCase.xtend
@@ -6,7 +6,77 @@ import org.junit.Test
  * @author matifreyre
  */
 class SetTestCase extends CollectionTestCase {
+
+	@Test
+	def void aSetWithObjectsOfSameClassAreNotAddedIfEqualEqualSetToTrue() {
+		'''
+		class C {
+			override method ==(other) = true
+		}
+		
+		test "issue 1771" {
+			const aSet = #{new C(), new C()}
+			assert.equals(1, aSet.size())
+		}
+		'''.interpretPropagatingErrors
+	}
+
+	@Test
+	def void aSetWithObjectsOfSameClassAreNotAddedIfEqualsSetToTrue() {
+		'''
+		class C {
+			override method equals(other) = true
+		}
+		
+		test "issue 1771" {
+			const aSet = #{new C(), new C()}
+			assert.equals(1, aSet.size())
+		}
+		'''.interpretPropagatingErrors
+	}
 	
+	@Test
+	def void aSetWithObjectsInDifferentHierarchyAreNotAddedIfEqualsSetToTrue() {
+		'''
+		class Animal {
+			override method equals(other) = true
+		}
+		
+		class Perro inherits Animal {
+		}
+		
+		class Gato inherits Animal {
+			
+		}
+		
+		test "issue 1771" {
+			const aSet = #{new Perro(), new Perro(), new Gato()}
+			assert.equals(1, aSet.size())
+		}
+		'''.interpretPropagatingErrors
+	}	
+
+	@Test
+	def void aSetWithObjectsInDifferentHierarchyAreNotAddedIfEqualEqualSetToTrue() {
+		'''
+		class Animal {
+			override method ==(other) = true
+		}
+		
+		class Perro inherits Animal {
+		}
+		
+		class Gato inherits Animal {
+			
+		}
+		
+		test "issue 1771" {
+			const aSet = #{new Perro(), new Perro(), new Gato()}
+			assert.equals(1, aSet.size())
+		}
+		'''.interpretPropagatingErrors
+	}	
+
 	@Test
 	def void unionWithEmptySet() {
 		'''

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -240,31 +240,28 @@ class ListTest extends ListTestCase {
 		'''.test
 	}
 	
-	//  ESTE TEST FALLA (Expected [3] but found [4]). [6,7,8,9,22,12] estaría quedando duplicado luego del withoutDuplicates.
-//	@Test
-//	def void testListOfListWithoutDuplicates() {
-//		'''
-//		var lista = new List()
-//		lista.addAll([1,2,3])
-//		const list = [[6,7,8,9,22,12], [1,2,3], [1,2,3,4,5], [1,2,3], [6,7,8,9,22,12]]
-//		assert.equals(3, list.withoutDuplicates().size())
-//		assert.equals([[6,7,8,9,22,12], [1,2,3], [1,2,3,4,5] ], list.withoutDuplicates())
-//		'''.test
-//	}
+	@Test
+	def void testListOfListWithoutDuplicates() {
+		'''
+		const lista = new List()
+		lista.addAll([1,2,3])
+		const list = [[6,7,8,9,22,12], [1,2,3], [1,2,3,4,5], [1,2,3], [6,7,8,9,22,12]]
+		assert.equals([[6,7,8,9,22,12], [1,2,3], [1,2,3,4,5] ], list.withoutDuplicates())
+		assert.equals(3, list.withoutDuplicates().size())
+		'''.test
+	}
 	
 	
-//  ESTE TEST FALLA (Expected [3] but found [4]).  #{1,44,55,33,27,12} estaría quedando duplicado luego del withoutDuplicates.
-
-//	@Test
-//	def void testListOfSetWithoutDuplicates() {
-//		'''
-//		var set = new Set()
-//		set.addAll([1,2,3])
-//		const list = [#{1,44,55,33,27,12}, set, #{1,2,3,4,5,6}, #{1,2,3}, #{1,2,3,4,5,6}, #{1,44,55,33,27,12}]
-//		assert.equals(3, list.withoutDuplicates().size())
-//		assert.equals([#{1,44,55,33,27,12}, #{1,2,3}, #{1,2,3,4,5,6}], list.withoutDuplicates())
-//		'''.test
-//	}
+	@Test
+	def void testListOfSetWithoutDuplicates() {
+		'''
+		const set = new Set()
+		set.addAll([1,2,3])
+		const list = [#{1,44,55,33,27,12}, set, #{1,2,3,4,5,6}, #{1,2,3}, #{1,2,3,4,5,6}, #{1,44,55,33,27,12}]
+		assert.equals(3, list.withoutDuplicates().size())
+		assert.equals([#{1,44,55,33,27,12}, #{1,2,3}, #{1,2,3,4,5,6}], list.withoutDuplicates())
+		'''.test
+	}
 	
 	@Test
 	def void testListOfDictionaryWithoutDuplicates() {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -166,16 +166,21 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfUserDefinedClassAsSetConversionRedefiningEqualEqual() {
 		'''
-		class C {
-			override method ==(other) = self.kindName() == other.kindName()
+		class Animal {
+			override method ==(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
+			method getNombre()
 		}
-			
-		class D {
-			override method ==(other) = self.kindName() == other.kindName()
+				
+		class Perro inherits Animal {
+			override method getNombre() = "Firulais"
+		}
+				
+		class Gato inherits Animal {
+			override method getNombre() = "Garfield"
 		}
 		
 		test "issue 1771" {
-			assert.equals(2, [new C(), new D(), new C(), new D()].asSet().size())
+			assert.equals(2, [new Perro(), new Gato(), new Perro(), new Gato()].asSet().size())
 		}
 		'''.interpretPropagatingErrors
 	}
@@ -183,55 +188,21 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfUserDefinedClassAsSetConversionRedefiningEquals() {
 		'''
-		class C {
-			override method equals(other) = self.kindName() == other.kindName()
+		class Animal {
+			override method ==(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
+			method getNombre()
 		}
-			
-		class D {
-			override method equals(other) = self.kindName() == other.kindName()
+					
+		class Perro inherits Animal {
+			override method getNombre() = "Firulais"
+		}
+					
+		class Gato inherits Animal {
+			override method getNombre() = "Garfield"
 		}
 		
 		test "issue 1771" {
-			assert.equals(2, [new C(), new D(), new C(), new D()].asSet().size())
-		}
-		'''.interpretPropagatingErrors
-	}
-	
-	@Test
-	def void testListOfDifferentTypesAsSetConversion() {
-		'''
-		import wollok.game.Position
-		
-		class C {
-			var property nombre = "federico"
-			
-			override method equals(other) {
-				return self.nombre() == other.nombre()
-			} 
-		}
-		class D {
-			var property nombre = "gabriel"
-			
-			override method equals(other) {
-				return self.nombre() == other.nombre()
-			} 
-		}
-
-		test "issue 1771" {
-			const dictionary = new Dictionary()
-			const anotherDictionary = new Dictionary()
-			dictionary.put("1", "hola")
-			anotherDictionary.put("1", "hola")
-			var defaultPosition = new Position()
-			var anotherPosition = new Position()
-			anotherPosition = anotherPosition.up(2)
-		
-			const list = [1,"1", defaultPosition, new Pair(5,6), new C(), "hola", new Dictionary(), "1", 
-			new Dictionary(), "ho" + "la", true, new Date(day=21, month=10, year=2018), defaultPosition, 
-			dictionary, "true", 2/2, !false, false, new C(), new Date(day=21, month=10, year=2018), anotherDictionary, new Pair(1,2), 
-			new Date(day=2, month=5, year=2014), new Pair(1,2), anotherPosition, new D()]
-			
-			assert.equals(16, list.asSet().size())
+			assert.equals(2, [new Perro(), new Gato(), new Perro(), new Gato()].asSet().size())
 		}
 		'''.interpretPropagatingErrors
 	}
@@ -359,17 +330,22 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfUserDefinedClassWithoutDuplicatesRedefiningEqualEqual() {
 		'''
-		class C {
-			override method ==(other) = self.kindName() == other.kindName()
+		class Animal {
+			override method ==(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
+			method getNombre()
 		}
-		
-		class D {
-			override method ==(other) = self.kindName() == other.kindName()
+			
+		class Perro inherits Animal {
+			override method getNombre() = "Firulais"
+		}
+			
+		class Gato inherits Animal {
+			override method getNombre() = "Garfield"
 		}
 		
 		test "issue 1771" {
-			const list = [new D(), new C(), new D(), new C()]
-			const result = [new D(), new C()]
+			const list = [new Perro(), new Gato(), new Perro(), new Gato()]
+			const result = [new Perro(), new Gato()]
 			const withoutDuplicates = list.withoutDuplicates()
 			assert.equals(2, withoutDuplicates.size())
 			(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
@@ -380,57 +356,24 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfUserDefinedClassWithoutDuplicatesRedefiningEquals() {
 		'''
-		class C {
-			override method equals(other) = self.kindName() == other.kindName()
+		class Animal {
+			override method equals(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
+			method getNombre()
 		}
-				
-		class D {
-			override method equals(other) = self.kindName() == other.kindName()
+			
+		class Perro inherits Animal {
+			override method getNombre() = "Firulais"
+		}
+			
+		class Gato inherits Animal {
+			override method getNombre() = "Garfield"
 		}
 		
 		test "issue 1771" {
-			const list = [new D(), new C(), new D(), new C()]
-			const result = [new D(), new C()]
+			const list = [new Perro(), new Gato(), new Perro(), new Gato()]
+			const result = [new Perro(), new Gato()]
 			const withoutDuplicates = list.withoutDuplicates()
 			assert.equals(2, withoutDuplicates.size())
-			(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
-		}
-		'''.interpretPropagatingErrors
-	}
-	
-	@Test
-	def void testListOfDifferentTypesWithoutDuplicates() {
-		'''
-		import wollok.game.Position
-		
-		class C {
-			override method equals(other) = self.kindName() == other.kindName()
-		}
-		class D {
-			override method equals(other) = self.kindName() == other.kindName()
-		}
-
-		test "issue 1771" {
-			const dictionary = new Dictionary()
-			const anotherDictionary = new Dictionary()
-			dictionary.put("1", "hola")
-			anotherDictionary.put("1", "hola")
-			var defaultPosition = new Position()
-			var anotherPosition = new Position()
-			anotherPosition = anotherPosition.up(2)
-		
-			const list = [1,"1", defaultPosition, new Pair(5,6), new C(), "hola", new Dictionary(), "1", new Dictionary(), 
-			"ho" + "la", true, new D(), new Date(day=21, month=10, year=2018), defaultPosition, dictionary, "true", 2/2, 
-			!false, false, new C(), new Date(day=21, month=10, year=2018), anotherDictionary, new Pair(1,2), 
-			new Date(day=2, month=5, year=2014), new Pair(1,2), anotherPosition]
-		
-			const result = [1, "1", defaultPosition, new Pair(5,6),new C(), "hola", new Dictionary(), true, new D(), 
-			new Date(day=21, month=10, year=2018), dictionary, "true", false, new Pair(1,2), 
-			new Date(day=2, month=5, year=2014), anotherPosition]
-		
-			const withoutDuplicates = list.withoutDuplicates()
-		
-			assert.equals(16, withoutDuplicates.size())
 			(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		}
 		'''.interpretPropagatingErrors

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -80,74 +80,96 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfNumberAsSetConversion() {
 		'''
-		assert.equals(1, [1,1].asSet().size())
+		assert.equals(1, [1, 2/2].asSet().size())
 		'''.test
 	}
 	
 	@Test
 	def void testListOfStringAsSetConversion() {
 		'''
-		assert.equals(1, ["hola","hola"].asSet().size())
+		assert.equals(1, ["hola", "ho" + "la"].asSet().size())
 		'''.test
 	}
 	
 	@Test
 	def void testListOfBooleanAsSetConversion() {
 		'''
-		assert.equals(1, [true,true].asSet().size())
+		assert.equals(1, [true, 2 == 2].asSet().size())
 		'''.test
 	}
 	
 	@Test
 	def void testListOfDateAsSetConversion() {
 		'''
-		const a = new Date(day=12, month=5, year=2019)
-		const b = new Date(day=12, month=5, year=2019)
-		assert.equals(1,[a,b].asSet().size())
+		assert.equals(1, [new Date(day=1, month=4, year=2018), new Date(day=1, month=4, year=2018)].asSet().size())
 		'''.test
 	}
 	
 	@Test
 	def void testListOfListAsSetConversion() {
 		'''
-		assert.equals(1, [[1,2,3],[1,2,3]].asSet().size())
+		var list = new List()
+		list.addAll([1,2,3])
+		assert.equals(1, [list, [1,2,3]].asSet().size())
 		'''.test
 	}
+
+//  ESTE TEST FALLA (Expected [1] but found [2])
+
+//	@Test
+//	def void testListOfDictionaryAsSetConversion() {
+//		'''
+//		assert.equals(1, [new Dictionary(), new Dictionary()].asSet().size())
+//		'''.test
+//	}
 	
-	@Test
-	def void testListOfDictionaryAsSetConversion() {
-		'''
-		const dictionary = new Dictionary()
-		assert.equals(1, [dictionary,dictionary].asSet().size())
-		'''.test
-	}
-	
-	@Test
-	def void testListOfPairAsSetConversion() {
-		'''
-		const pair = new Pair(1,2)
-		assert.equals(1, [pair,pair].asSet().size())
-		'''.test
-	}
+//  ESTE TEST FALLA (Expected [1] but found [2])
+
+//	@Test
+//	def void testListOfPairAsSetConversion() {
+//		'''
+//		assert.equals(1, [new Pair(1,2), new Pair(1,2)].asSet().size())
+//		'''.test
+//	}
 	
 	@Test
 	def void testListOfPositionAsSetConversion() {
 		'''
-		const a = new Position()
-		const b = new Position()
-		assert.equals(1, [a,b].asSet().size())
+		assert.equals(1, [new Position() ,new Position()].asSet().size())
 		'''.test
 	}
 	
 	@Test
-	def void testListOfUserDefinedClassAsSetConversion() {
+	def void testListOfUserDefinedClassAsSetConversionRedefiningEqualEqual() {
 		'''
-		class MiClase {}
-		program a {
-			const miClase = new MiClase()
-			assert.equals(1, [miClase,miClase].asSet().size())
+		class C {
+			override method ==(other) = self.kindName() == other.kindName()
+		}
+			
+		class D {
+			override method ==(other) = self.kindName() == other.kindName()
 		}
 		
+		test "issue 1771" {
+			assert.equals(2, [new C(), new D(), new C()].asSet().size())
+		}
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void testListOfUserDefinedClassAsSetConversionRedefiningEquals() {
+		'''
+		class C {
+			override method equals(other) = self.kindName() == other.kindName()
+		}
+			
+		class D {
+			override method equals(other) = self.kindName() == other.kindName()
+		}
+		
+		test "issue 1771" {
+			assert.equals(2, [new C(), new D(), new C()].asSet().size())
+		}
 		'''.interpretPropagatingErrors
 	}
 	
@@ -172,23 +194,33 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfNumberWithoutDuplicates() {
 		'''
-		assert.equals(1, [1,1].withoutDuplicates().size())
+		const list = [1, 3, 1, 5, 1, 3, 2, 5]
+		const result = [1, 3, 5, 2]
+		const withoutDuplicates = list.withoutDuplicates()
+		assert.equals(4, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i=> assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
 	
 	@Test
 	def void testListOfStringWithoutDuplicates() {
 		'''
-		assert.equals(1, ["hola","hola"].withoutDuplicates().size())
+		const list = ["amigo", "carpeta", "beca", "amigo", "carpeta"]
+		const result = ["amigo", "carpeta", "beca"]
+		const withoutDuplicates = list.withoutDuplicates()
+		assert.equals(3, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
 	
 	@Test
 	def void testListOfDateWithoutDuplicates() {
 		'''
-		const a = new Date(day=1, month=4, year=2018)
-		const b = new Date(day=1, month=4, year=2018)
-		assert.equals(1, [a,b].withoutDuplicates().size())
+		const list = [new Date(day=22, month=9, year=2020), new Date(day=1, month=4, year=2018), new Date(day=22, month=9, year=2020)]
+		const result = [new Date(day=22, month=9, year=2020), new Date(day=1, month=4, year=2018)]
+		const withoutDuplicates = list.withoutDuplicates()
+		assert.equals(2, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
 	
@@ -199,67 +231,108 @@ class ListTest extends ListTestCase {
 		'''.test
 	}
 	
-	@Test
-	def void testListOfListWithoutDuplicates() {
-		'''
-		assert.equals(1, [[1,2,3],[1,2,3]].withoutDuplicates().size())
-		'''.test
-	}
+//  ESTE TEST FALLA (Expected [3] but found [4]). [6,7,8,9,22,12] estaría quedando duplicado luego del withoutDuplicates.
 	
-	@Test
-	def void testListOfSetWithoutDuplicates() {
-		'''
-		assert.equals(1, [#{1,2,3},#{1,2,3}].withoutDuplicates().size())
-		'''.test
-	}
+//	@Test
+//	def void testListOfListWithoutDuplicates() {
+//		'''
+//		var lista = new List()
+//		lista.addAll([1,2,3])
+//		const list = [[6,7,8,9,22,12], [1,2,3], [1,2,3,4,5], [1,2,3], [6,7,8,9,22,12]]
+//		assert.equals(3, list.withoutDuplicates().size())
+//		assert.equals([[6,7,8,9,22,12], [1,2,3], [1,2,3,4,5] ], list.withoutDuplicates())
+//		'''.test
+//	}
 	
-	@Test
-	def void testListOfDictionaryWithoutDuplicates() {
-		'''
-		const a = new Dictionary()
-		assert.equals(1, [a,a].withoutDuplicates().size())
-		'''.test
-	}
 	
-	@Test
-	def void testListOfPairWithoutDuplicates() {
-		'''
-		const a = new Pair(1,2)
-		assert.equals(1, [a,a].withoutDuplicates().size())
-		'''.test
-	}
+//  ESTE TEST FALLA (Expected [3] but found [4]).  #{1,44,55,33,27,12} estaría quedando duplicado luego del withoutDuplicates.
+
+//	@Test
+//	def void testListOfSetWithoutDuplicates() {
+//		'''
+//		var set = new Set()
+//		set.addAll([1,2,3])
+//		const list = [#{1,44,55,33,27,12}, set, #{1,2,3,4,5,6}, #{1,2,3}, #{1,2,3,4,5,6}, #{1,44,55,33,27,12}]
+//		assert.equals(3, list.withoutDuplicates().size())
+//		assert.equals([#{1,44,55,33,27,12}, #{1,2,3}, #{1,2,3,4,5,6}], list.withoutDuplicates())
+//		'''.test
+//	}
+	
+//  ESTE TEST FALLA (Expected [1] but found [2])
+
+//	@Test
+//	def void testListOfDictionaryWithoutDuplicates() {
+//		'''
+//		assert.equals(1, [new Dictionary(), new Dictionary()].withoutDuplicates().size())
+//		'''.test
+//	}
+	
+//  ESTE TEST FALLA (Expected [1] but found [2])	
+	
+//	@Test
+//	def void testListOfPairWithoutDuplicates() {
+//		'''
+//		assert.equals(1, [new Pair(1,2), new Pair(1,2)].withoutDuplicates().size())
+//		'''.test
+//	}
 	
 	@Test
 	def void testListOfPositionWithoutDuplicates() {
 		'''
-		const a = new Position()
-		const b = new Position()
-		assert.equals(1, [a,b].withoutDuplicates().size())
+		assert.equals(1, [new Position(), new Position()].withoutDuplicates().size())
 		'''.test
 	}
 	
 	@Test
-	def void testListOfUserDefinedClassWithoutDuplicates() {
+	def void testListOfUserDefinedClassWithoutDuplicatesRedefiningEqualEqual() {
 		'''
-		class MiClase {}
-		program a {
-			const a = new MiClase()
-			assert.equals(1, [a,a].withoutDuplicates().size())
+		class C {
+			override method ==(other) = self.kindName() == other.kindName()
 		}
 		
+		class D {
+			override method ==(other) = self.kindName() == other.kindName()
+		}
+		
+		test "issue 1771" {
+			const list = [new D(), new C(), new D(), new C()]
+			const result = [new D(), new C()]
+			const withoutDuplicates = list.withoutDuplicates()
+			assert.equals(2, withoutDuplicates.size())
+			(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
+		}
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void testListOfUserDefinedClassWithoutDuplicatesRedefiningEquals() {
+		'''
+		class C {
+			override method equals(other) = self.kindName() == other.kindName()
+		}
+				
+		class D {
+			override method equals(other) = self.kindName() == other.kindName()
+		}
+		
+		test "issue 1771" {
+			const list = [new D(), new C(), new D(), new C()]
+			const result = [new D(), new C()]
+			const withoutDuplicates = list.withoutDuplicates()
+			assert.equals(2, withoutDuplicates.size())
+			(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
+		}
 		'''.interpretPropagatingErrors
 	}
 	
 	@Test
 	def void testListOfDifferentTypesWithoutDuplicates() {
 		'''
-		const list = new List()
-		list.add(1)
-		list.add("hola")
-		list.add(true)
-		list.add(1)
-		list.add("hola")
-		assert.equals(3, list.withoutDuplicates().size())
+		const list = [2, "hola", true, 2, "casa", "hola", 1]
+		const result = [2, "hola", true, "casa", 1]
+		const withoutDuplicates = list.withoutDuplicates()
+		assert.equals(5, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -183,38 +183,44 @@ class ListTest extends ListTestCase {
 		'''.interpretPropagatingErrors
 	}
 	
-// ESTE TEST FALLA!. Al hacer list.asSet() queda duplicado C.
+	@Test
+	def void testListOfDifferentTypesAsSetConversion() {
+		'''
+		import wollok.game.Position
+		
+		class C {
+			var property nombre = "federico"
+			
+			override method equals(other) {
+				return self.nombre() == other.nombre()
+			} 
+		}
+		class D {
+			var property nombre = "gabriel"
+			
+			override method equals(other) {
+				return self.nombre() == other.nombre()
+			} 
+		}
 
-//	@Test
-//	def void testListOfDifferentTypesAsSetConversion() {
-//		'''
-//		import wollok.game.Position
-//		
-//		class C {
-//			override method equals(other) = self.kindName() == other.kindName()
-//		}
-//		class D {
-//			override method equals(other) = self.kindName() == other.kindName()
-//		}
-//
-//		test "issue 1771" {
-//			const dictionary = new Dictionary()
-//			const anotherDictionary = new Dictionary()
-//			dictionary.put("1", "hola")
-//			anotherDictionary.put("1", "hola")
-//			var defaultPosition = new Position()
-//			var anotherPosition = new Position()
-//			anotherPosition = anotherPosition.up(2)
-//		
-//			const list = [1,"1", defaultPosition, new Pair(5,6), new C(), "hola", new Dictionary(), "1", 
-//			new Dictionary(), "ho" + "la", true, new D(), new Date(day=21, month=10, year=2018), defaultPosition, 
-//			dictionary, "true", 2/2, !false, false, new C(), new Date(day=21, month=10, year=2018), anotherDictionary, new Pair(1,2), 
-//			new Date(day=2, month=5, year=2014), new Pair(1,2), anotherPosition]
-//			
-//			assert.equals(16, list.asSet().size())
-//		}
-//		'''.interpretPropagatingErrors
-//	}
+		test "issue 1771" {
+			const dictionary = new Dictionary()
+			const anotherDictionary = new Dictionary()
+			dictionary.put("1", "hola")
+			anotherDictionary.put("1", "hola")
+			var defaultPosition = new Position()
+			var anotherPosition = new Position()
+			anotherPosition = anotherPosition.up(2)
+		
+			const list = [1,"1", defaultPosition, new Pair(5,6), new C(), "hola", new Dictionary(), "1", 
+			new Dictionary(), "ho" + "la", true, new Date(day=21, month=10, year=2018), defaultPosition, 
+			dictionary, "true", 2/2, !false, false, new C(), new Date(day=21, month=10, year=2018), anotherDictionary, new Pair(1,2), 
+			new Date(day=2, month=5, year=2014), new Pair(1,2), anotherPosition, new D()]
+			
+			assert.equals(16, list.asSet().size())
+		}
+		'''.interpretPropagatingErrors
+	}
 	
 	@Test
 	def void testListOfNumberWithoutDuplicates() {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -66,15 +66,200 @@ class ListTest extends ListTestCase {
 		'''.test
 	}
 	
-		@Test
+	@Test
 	def void testAsSetConversion() {
 		'''
 		const set = #{}
 		set.add(1)
 		set.add(2)
 		set.add(3)
-		
 		assert.equals(set, set.asSet())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfNumberAsSetConversion() {
+		'''
+		assert.equals(1, [1,1].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfStringAsSetConversion() {
+		'''
+		assert.equals(1, ["hola","hola"].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfBooleanAsSetConversion() {
+		'''
+		assert.equals(1, [true,true].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfDateAsSetConversion() {
+		'''
+		const a = new Date(day=12, month=5, year=2019)
+		const b = new Date(day=12, month=5, year=2019)
+		assert.equals(1,[a,b].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfListAsSetConversion() {
+		'''
+		assert.equals(1, [[1,2,3],[1,2,3]].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfDictionaryAsSetConversion() {
+		'''
+		const dictionary = new Dictionary()
+		assert.equals(1, [dictionary,dictionary].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfPairAsSetConversion() {
+		'''
+		const pair = new Pair(1,2)
+		assert.equals(1, [pair,pair].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfPositionAsSetConversion() {
+		'''
+		const a = new Position()
+		const b = new Position()
+		assert.equals(1, [a,b].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfUserDefinedClassAsSetConversion() {
+		'''
+		class MiClase {}
+		program a {
+			const miClase = new MiClase()
+			assert.equals(1, [miClase,miClase].asSet().size())
+		}
+		
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void testListOfDifferentTypesAsSetConversion() {
+		'''
+			var list = []
+			list.add(1)
+			list.add("1")
+			list.add(true)
+			list.add("1")
+			list.add(new Date())
+			list.add(true)
+			list.add(new Date().toString())
+			list.add("true")
+			list.add(1)
+			list.add(new Date())
+			assert.equals(6, list.asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfNumberWithoutDuplicates() {
+		'''
+		assert.equals(1, [1,1].withoutDuplicates().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfStringWithoutDuplicates() {
+		'''
+		assert.equals(1, ["hola","hola"].withoutDuplicates().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfDateWithoutDuplicates() {
+		'''
+		const a = new Date(day=1, month=4, year=2018)
+		const b = new Date(day=1, month=4, year=2018)
+		assert.equals(1, [a,b].withoutDuplicates().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfBooleanWithoutDuplicates() {
+		'''
+		assert.equals(1, [true,!false].withoutDuplicates().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfListWithoutDuplicates() {
+		'''
+		assert.equals(1, [[1,2,3],[1,2,3]].withoutDuplicates().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfSetWithoutDuplicates() {
+		'''
+		assert.equals(1, [#{1,2,3},#{1,2,3}].withoutDuplicates().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfDictionaryWithoutDuplicates() {
+		'''
+		const a = new Dictionary()
+		assert.equals(1, [a,a].withoutDuplicates().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfPairWithoutDuplicates() {
+		'''
+		const a = new Pair(1,2)
+		assert.equals(1, [a,a].withoutDuplicates().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfPositionWithoutDuplicates() {
+		'''
+		const a = new Position()
+		const b = new Position()
+		assert.equals(1, [a,b].withoutDuplicates().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfUserDefinedClassWithoutDuplicates() {
+		'''
+		class MiClase {}
+		program a {
+			const a = new MiClase()
+			assert.equals(1, [a,a].withoutDuplicates().size())
+		}
+		
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void testListOfDifferentTypesWithoutDuplicates() {
+		'''
+		const list = new List()
+		list.add(1)
+		list.add("hola")
+		list.add(true)
+		list.add(1)
+		list.add("hola")
+		assert.equals(3, list.withoutDuplicates().size())
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -116,6 +116,20 @@ class ListTest extends ListTestCase {
 	}
 
 	@Test
+	def void testListOfEmptyListAsSetConversion() {
+		'''
+		assert.equals(1, [[], []].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfEmptySetAsSetConversion() {
+		'''
+		assert.equals(1, [#{}, #{}].asSet().size())
+		'''.test
+	}
+	
+	@Test
 	def void testListOfEmptyDictionaryAsSetConversion() {
 		'''
 		assert.equals(1, [new Dictionary(), new Dictionary()].asSet().size())
@@ -279,6 +293,15 @@ class ListTest extends ListTestCase {
 	}
 	
 	@Test
+	def void testListOfEmptyListWithoutDuplicates() {
+		'''
+		const withoutDuplicates = [[],[]].withoutDuplicates()
+		assert.equals(1, withoutDuplicates.size())
+		assert.equals([[]], withoutDuplicates)
+		'''.test
+	}
+	
+	@Test
 	def void testListOfSetWithoutDuplicates() {
 		'''
 		const set = #{1,2,3}
@@ -287,6 +310,15 @@ class ListTest extends ListTestCase {
 		const withoutDuplicates = list.withoutDuplicates()
 		assert.equals(3, withoutDuplicates.size())
 		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
+		'''.test
+	}
+	
+	@Test
+	def void testListOfEmptySetWithoutDuplicates() {
+		'''
+		const withoutDuplicates = [#{}, #{}].withoutDuplicates()
+		assert.equals(1, withoutDuplicates.size())
+		assert.equals([#{}], withoutDuplicates)
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -167,16 +167,16 @@ class ListTest extends ListTestCase {
 	def void testListOfUserDefinedClassAsSetConversionRedefiningEqualEqual() {
 		'''
 		class Animal {
-			override method ==(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
-			method getNombre()
+			override method ==(otroAnimal) = self.nombre() == otroAnimal.nombre()
+			method nombre()
 		}
 				
 		class Perro inherits Animal {
-			override method getNombre() = "Firulais"
+			override method nombre() = "Firulais"
 		}
 				
 		class Gato inherits Animal {
-			override method getNombre() = "Garfield"
+			override method nombre() = "Garfield"
 		}
 		
 		test "issue 1771" {
@@ -189,16 +189,16 @@ class ListTest extends ListTestCase {
 	def void testListOfUserDefinedClassAsSetConversionRedefiningEquals() {
 		'''
 		class Animal {
-			override method ==(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
-			method getNombre()
+			override method ==(otroAnimal) = self.nombre() == otroAnimal.nombre()
+			method nombre()
 		}
 					
 		class Perro inherits Animal {
-			override method getNombre() = "Firulais"
+			override method nombre() = "Firulais"
 		}
 					
 		class Gato inherits Animal {
-			override method getNombre() = "Garfield"
+			override method nombre() = "Garfield"
 		}
 		
 		test "issue 1771" {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -114,23 +114,32 @@ class ListTest extends ListTestCase {
 		'''.test
 	}
 
-//  ESTE TEST FALLA (Expected [1] but found [2])
+	@Test
+	def void testListOfEmptyDictionaryAsSetConversion() {
+		'''
+		assert.equals(1, [new Dictionary(), new Dictionary()].asSet().size())
+		'''.test
+	}
 
-//	@Test
-//	def void testListOfDictionaryAsSetConversion() {
-//		'''
-//		assert.equals(1, [new Dictionary(), new Dictionary()].asSet().size())
-//		'''.test
-//	}
-	
-//  ESTE TEST FALLA (Expected [1] but found [2])
-
-//	@Test
-//	def void testListOfPairAsSetConversion() {
-//		'''
-//		assert.equals(1, [new Pair(1,2), new Pair(1,2)].asSet().size())
-//		'''.test
-//	}
+	@Test
+	def void testListOfNonEmptyDictionaryAsSetConversion() {
+		'''
+		const firstDictionary = new Dictionary()
+		firstDictionary.put(1, "hola")
+		firstDictionary.put(2, "chau")
+		const secondDictionary = new Dictionary()
+		secondDictionary.put(1, "hola")
+		secondDictionary.put(2, "chau")
+		assert.equals(1, [firstDictionary, secondDictionary].asSet().size())
+		'''.test
+	}
+		
+	@Test
+	def void testListOfPairAsSetConversion() {
+		'''
+		assert.equals(1, [new Pair(1,2), new Pair(1,2)].asSet().size())
+		'''.test
+	}
 	
 	@Test
 	def void testListOfPositionAsSetConversion() {
@@ -231,8 +240,7 @@ class ListTest extends ListTestCase {
 		'''.test
 	}
 	
-//  ESTE TEST FALLA (Expected [3] but found [4]). [6,7,8,9,22,12] estaría quedando duplicado luego del withoutDuplicates.
-	
+	//  ESTE TEST FALLA (Expected [3] but found [4]). [6,7,8,9,22,12] estaría quedando duplicado luego del withoutDuplicates.
 //	@Test
 //	def void testListOfListWithoutDuplicates() {
 //		'''
@@ -258,23 +266,19 @@ class ListTest extends ListTestCase {
 //		'''.test
 //	}
 	
-//  ESTE TEST FALLA (Expected [1] but found [2])
-
-//	@Test
-//	def void testListOfDictionaryWithoutDuplicates() {
-//		'''
-//		assert.equals(1, [new Dictionary(), new Dictionary()].withoutDuplicates().size())
-//		'''.test
-//	}
+	@Test
+	def void testListOfDictionaryWithoutDuplicates() {
+		'''
+		assert.equals(1, [new Dictionary(), new Dictionary()].withoutDuplicates().size())
+		'''.test
+	}
 	
-//  ESTE TEST FALLA (Expected [1] but found [2])	
-	
-//	@Test
-//	def void testListOfPairWithoutDuplicates() {
-//		'''
-//		assert.equals(1, [new Pair(1,2), new Pair(1,2)].withoutDuplicates().size())
-//		'''.test
-//	}
+	@Test
+	def void testListOfPairWithoutDuplicates() {
+		'''
+		assert.equals(1, [new Pair(1,2), new Pair(1,2)].withoutDuplicates().size())
+		'''.test
+	}
 	
 	@Test
 	def void testListOfPositionWithoutDuplicates() {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -109,9 +109,8 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfListAsSetConversion() {
 		'''
-		var list = new List()
-		list.addAll([1,2,3])
-		assert.equals(3, [list, [4,5], [1,2,3], [6,7,8], [4,5]].asSet().size())
+		var list = [[1,2,3],[5,6],[7,8],[1,2,3],[5,6]]
+		assert.equals(3, list.asSet().size())
 		'''.test
 	}
 
@@ -119,6 +118,14 @@ class ListTest extends ListTestCase {
 	def void testListOfEmptyListAsSetConversion() {
 		'''
 		assert.equals(1, [[], []].asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testListOfSetAsSetConversion() {
+		'''
+		var list = [#{1,2,3},#{5,6},#{7,8},#{1,2,3},#{5,6}]
+		assert.equals(3, list.asSet().size())
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -331,16 +331,16 @@ class ListTest extends ListTestCase {
 	def void testListOfUserDefinedClassWithoutDuplicatesRedefiningEqualEqual() {
 		'''
 		class Animal {
-			override method ==(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
-			method getNombre()
+			override method ==(otroAnimal) = self.nombre() == otroAnimal.nombre()
+			method nombre()
 		}
 			
 		class Perro inherits Animal {
-			override method getNombre() = "Firulais"
+			override method nombre() = "Firulais"
 		}
 			
 		class Gato inherits Animal {
-			override method getNombre() = "Garfield"
+			override method nombre() = "Garfield"
 		}
 		
 		test "issue 1771" {
@@ -357,16 +357,16 @@ class ListTest extends ListTestCase {
 	def void testListOfUserDefinedClassWithoutDuplicatesRedefiningEquals() {
 		'''
 		class Animal {
-			override method equals(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
-			method getNombre()
+			override method equals(otroAnimal) = self.nombre() == otroAnimal.nombre()
+			method nombre()
 		}
 			
 		class Perro inherits Animal {
-			override method getNombre() = "Firulais"
+			override method nombre() = "Firulais"
 		}
 			
 		class Gato inherits Animal {
-			override method getNombre() = "Garfield"
+			override method nombre() = "Garfield"
 		}
 		
 		test "issue 1771" {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/ListTest.xtend
@@ -80,28 +80,29 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfNumberAsSetConversion() {
 		'''
-		assert.equals(1, [1, 2/2].asSet().size())
+		assert.equals(3, [1, 2/2, 3, 4, 6/2].asSet().size())
 		'''.test
 	}
 	
 	@Test
 	def void testListOfStringAsSetConversion() {
 		'''
-		assert.equals(1, ["hola", "ho" + "la"].asSet().size())
+		assert.equals(3, ["hola", "chau", "ho" + "la", "c" + "hau", "bye"].asSet().size())
 		'''.test
 	}
 	
 	@Test
 	def void testListOfBooleanAsSetConversion() {
 		'''
-		assert.equals(1, [true, 2 == 2].asSet().size())
+		assert.equals(2, [true, 1==2, 2==2, 3==4 ].asSet().size())
 		'''.test
 	}
 	
 	@Test
 	def void testListOfDateAsSetConversion() {
 		'''
-		assert.equals(1, [new Date(day=1, month=4, year=2018), new Date(day=1, month=4, year=2018)].asSet().size())
+		assert.equals(2, [new Date(day=1, month=4, year=2018),new Date(day=12, month=7, year=2020), 
+		new Date(day=1, month=4, year=2018)].asSet().size())
 		'''.test
 	}
 	
@@ -110,7 +111,7 @@ class ListTest extends ListTestCase {
 		'''
 		var list = new List()
 		list.addAll([1,2,3])
-		assert.equals(1, [list, [1,2,3]].asSet().size())
+		assert.equals(3, [list, [4,5], [1,2,3], [6,7,8], [4,5]].asSet().size())
 		'''.test
 	}
 
@@ -137,7 +138,7 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfPairAsSetConversion() {
 		'''
-		assert.equals(1, [new Pair(1,2), new Pair(1,2)].asSet().size())
+		assert.equals(2, [new Pair(1,2), new Pair(4,5), new Pair(1,2)].asSet().size())
 		'''.test
 	}
 	
@@ -160,7 +161,7 @@ class ListTest extends ListTestCase {
 		}
 		
 		test "issue 1771" {
-			assert.equals(2, [new C(), new D(), new C()].asSet().size())
+			assert.equals(2, [new C(), new D(), new C(), new D()].asSet().size())
 		}
 		'''.interpretPropagatingErrors
 	}
@@ -177,28 +178,43 @@ class ListTest extends ListTestCase {
 		}
 		
 		test "issue 1771" {
-			assert.equals(2, [new C(), new D(), new C()].asSet().size())
+			assert.equals(2, [new C(), new D(), new C(), new D()].asSet().size())
 		}
 		'''.interpretPropagatingErrors
 	}
 	
-	@Test
-	def void testListOfDifferentTypesAsSetConversion() {
-		'''
-			var list = []
-			list.add(1)
-			list.add("1")
-			list.add(true)
-			list.add("1")
-			list.add(new Date())
-			list.add(true)
-			list.add(new Date().toString())
-			list.add("true")
-			list.add(1)
-			list.add(new Date())
-			assert.equals(6, list.asSet().size())
-		'''.test
-	}
+// ESTE TEST FALLA!. Al hacer list.asSet() queda duplicado C.
+
+//	@Test
+//	def void testListOfDifferentTypesAsSetConversion() {
+//		'''
+//		import wollok.game.Position
+//		
+//		class C {
+//			override method equals(other) = self.kindName() == other.kindName()
+//		}
+//		class D {
+//			override method equals(other) = self.kindName() == other.kindName()
+//		}
+//
+//		test "issue 1771" {
+//			const dictionary = new Dictionary()
+//			const anotherDictionary = new Dictionary()
+//			dictionary.put("1", "hola")
+//			anotherDictionary.put("1", "hola")
+//			var defaultPosition = new Position()
+//			var anotherPosition = new Position()
+//			anotherPosition = anotherPosition.up(2)
+//		
+//			const list = [1,"1", defaultPosition, new Pair(5,6), new C(), "hola", new Dictionary(), "1", 
+//			new Dictionary(), "ho" + "la", true, new D(), new Date(day=21, month=10, year=2018), defaultPosition, 
+//			dictionary, "true", 2/2, !false, false, new C(), new Date(day=21, month=10, year=2018), anotherDictionary, new Pair(1,2), 
+//			new Date(day=2, month=5, year=2014), new Pair(1,2), anotherPosition]
+//			
+//			assert.equals(16, list.asSet().size())
+//		}
+//		'''.interpretPropagatingErrors
+//	}
 	
 	@Test
 	def void testListOfNumberWithoutDuplicates() {
@@ -236,7 +252,10 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfBooleanWithoutDuplicates() {
 		'''
-		assert.equals(1, [true,!false].withoutDuplicates().size())
+		const result = [true, false]
+		const withoutDuplicates = [true, false, !false].withoutDuplicates()
+		assert.equals(2, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
 	
@@ -246,41 +265,56 @@ class ListTest extends ListTestCase {
 		const lista = new List()
 		lista.addAll([1,2,3])
 		const list = [[6,7,8,9,22,12], [1,2,3], [1,2,3,4,5], [1,2,3], [6,7,8,9,22,12]]
-		assert.equals([[6,7,8,9,22,12], [1,2,3], [1,2,3,4,5] ], list.withoutDuplicates())
-		assert.equals(3, list.withoutDuplicates().size())
+		const result = [[6,7,8,9,22,12], [1,2,3], [1,2,3,4,5]]
+		const withoutDuplicates = list.withoutDuplicates()
+		assert.equals(3, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
-	
 	
 	@Test
 	def void testListOfSetWithoutDuplicates() {
 		'''
-		const set = new Set()
-		set.addAll([1,2,3])
+		const set = #{1,2,3}
+		const result = [#{1,44,55,33,27,12}, set, #{1,2,3,4,5,6}]
 		const list = [#{1,44,55,33,27,12}, set, #{1,2,3,4,5,6}, #{1,2,3}, #{1,2,3,4,5,6}, #{1,44,55,33,27,12}]
-		assert.equals(3, list.withoutDuplicates().size())
-		assert.equals([#{1,44,55,33,27,12}, #{1,2,3}, #{1,2,3,4,5,6}], list.withoutDuplicates())
+		const withoutDuplicates = list.withoutDuplicates()
+		assert.equals(3, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
 	
 	@Test
 	def void testListOfDictionaryWithoutDuplicates() {
 		'''
-		assert.equals(1, [new Dictionary(), new Dictionary()].withoutDuplicates().size())
+		const dictionary = new Dictionary()
+		dictionary.put(1, "hola")
+		const result = [dictionary, new Dictionary()]
+		const withoutDuplicates = [dictionary, new Dictionary(), dictionary, new Dictionary()].withoutDuplicates()
+		assert.equals(2, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
 	
 	@Test
 	def void testListOfPairWithoutDuplicates() {
 		'''
-		assert.equals(1, [new Pair(1,2), new Pair(1,2)].withoutDuplicates().size())
+		const result = [new Pair(1,2), new Pair(5,6)]
+		const withoutDuplicates = [new Pair(1,2), new Pair(5,6), new Pair(1,2), new Pair(5,6)].withoutDuplicates()
+		assert.equals(2, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
 	
 	@Test
 	def void testListOfPositionWithoutDuplicates() {
 		'''
-		assert.equals(1, [new Position(), new Position()].withoutDuplicates().size())
+		var position = new Position()
+		position = position.up(2)
+		const result = [position, new Position()]
+		const withoutDuplicates = [position, new Position(), position, new Position()].withoutDuplicates()
+		assert.equals(2, withoutDuplicates.size())
+		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
 		'''.test
 	}
 	
@@ -329,12 +363,39 @@ class ListTest extends ListTestCase {
 	@Test
 	def void testListOfDifferentTypesWithoutDuplicates() {
 		'''
-		const list = [2, "hola", true, 2, "casa", "hola", 1]
-		const result = [2, "hola", true, "casa", 1]
-		const withoutDuplicates = list.withoutDuplicates()
-		assert.equals(5, withoutDuplicates.size())
-		(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
-		'''.test
+		import wollok.game.Position
+		
+		class C {
+			override method equals(other) = self.kindName() == other.kindName()
+		}
+		class D {
+			override method equals(other) = self.kindName() == other.kindName()
+		}
+
+		test "issue 1771" {
+			const dictionary = new Dictionary()
+			const anotherDictionary = new Dictionary()
+			dictionary.put("1", "hola")
+			anotherDictionary.put("1", "hola")
+			var defaultPosition = new Position()
+			var anotherPosition = new Position()
+			anotherPosition = anotherPosition.up(2)
+		
+			const list = [1,"1", defaultPosition, new Pair(5,6), new C(), "hola", new Dictionary(), "1", new Dictionary(), 
+			"ho" + "la", true, new D(), new Date(day=21, month=10, year=2018), defaultPosition, dictionary, "true", 2/2, 
+			!false, false, new C(), new Date(day=21, month=10, year=2018), anotherDictionary, new Pair(1,2), 
+			new Date(day=2, month=5, year=2014), new Pair(1,2), anotherPosition]
+		
+			const result = [1, "1", defaultPosition, new Pair(5,6),new C(), "hola", new Dictionary(), true, new D(), 
+			new Date(day=21, month=10, year=2018), dictionary, "true", false, new Pair(1,2), 
+			new Date(day=2, month=5, year=2014), anotherPosition]
+		
+			const withoutDuplicates = list.withoutDuplicates()
+		
+			assert.equals(16, withoutDuplicates.size())
+			(0..result.size()-1).forEach{ i => assert.that(withoutDuplicates.get(i).equals(result.get(i))) }
+		}
+		'''.interpretPropagatingErrors
 	}
 	
 	@Test

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -130,7 +130,8 @@ class SetTest extends CollectionTestCase {
 		'''
 		const set = #{}
 		const a = [1,2,3]
-		const b = [1,2,3]
+		const b = new List()
+		b.addAll([1,2,3])
 		set.add(a)
 		set.add(b)
 		assert.equals(1, set.size())
@@ -144,7 +145,8 @@ class SetTest extends CollectionTestCase {
 		'''
 		const set = #{}
 		const a = #{1,2,3}
-		const b = #{1,2,3}
+		const b = new Set()
+		b.addAll([1,2,3])
 		set.add(a)
 		set.add(b)
 		assert.equals(1, set.size())
@@ -153,33 +155,37 @@ class SetTest extends CollectionTestCase {
 		'''.test
 	}
 	
-	@Test
-	def void testSetOfDictionarySize() {
-		'''
-		const set = #{}
-		const a = new Dictionary()
-		const b = a
-		set.add(a)
-		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
-		'''.test
-	}
-	
-	@Test
-	def void testSetOfPairSize() {
-		'''
-		const set = new Set()
-		const a = new Pair(1,2)
-		const b = a
-		set.add(a)
-		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
-		'''.test
-	}
+//  ESTE TEST FALLA (Expected [1] but found [2])
+
+//	@Test
+//	def void testSetOfDictionarySize() {
+//		'''
+//		const set = #{}
+//		const a = new Dictionary()
+//		const b = new Dictionary()
+//		set.add(a)
+//		set.add(b)
+//		assert.equals(1, set.size())
+//		assert.equals(set, #{a})
+//		assert.equals(#{a}, #{b})
+//		'''.test
+//	}
+
+//  ESTE TEST FALLA (Expected [1] but found [2])
+
+//	@Test
+//	def void testSetOfPairSize() {
+//		'''
+//		const set = new Set()
+//		const a = new Pair(1,2)
+//		const b = new Pair(1,2)
+//		set.add(a)
+//		set.add(b)
+//		assert.equals(1, set.size())
+//		assert.equals(set, #{a})
+//		assert.equals(#{a}, #{b})
+//		'''.test
+//	}
 	
 	@Test
 	def void testSetOfPositionSize() {
@@ -196,20 +202,39 @@ class SetTest extends CollectionTestCase {
 	}
 	
 	@Test
-	def void testSetOftUserDefinedClassSize() {
+	def void testSetOfUserDefinedClassSizeIfEqualEqualSetToTrue() {
 		'''
-		class MiClase {}
-		program a {
+		class C {
+			override method ==(other) = true
+		}
+		test "issue 1771" {
 			const set = new Set()
-			const a = new MiClase()
-			const b = a
+			const a = new C()
+			const b = new C()
 			set.add(a)
 			set.add(b)
 			assert.equals(1, set.size())
 			assert.equals(set, #{a})
 			assert.equals(#{a}, #{b})
 		}
-		
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void testSetOfUserDefinedClassSizeIfEqualsSetToTrue() {
+		'''
+		class C {
+			override method equals(other) = true
+		}
+		test "issue 1771" {
+			const set = new Set()
+			const a = new C()
+			const b = new C()
+			set.add(a)
+			set.add(b)
+			assert.equals(1, set.size())
+			assert.equals(set, #{a})
+		}
 		'''.interpretPropagatingErrors
 	}
 	
@@ -217,8 +242,7 @@ class SetTest extends CollectionTestCase {
 	def void testSetOfListsOfDifferentTypesSize() {
 		'''
 		const set = new Set()
-		const a = new List()
-		a.addAll([1,"hola",true,new Date()])
+		const a = [1,"hola",true,new Date()]
 		const b = new List()
 		b.addAll([1,"hola",true,new Date()])
 		set.add(a)
@@ -232,14 +256,18 @@ class SetTest extends CollectionTestCase {
 	@Test
 	def void testSetOfListAsSetConversion() {
 		'''
-		assert.equals(1, #{[1,2,3],[1,2,3]}.asSet().size())
+		var list = new List()
+		list.addAll([1,2,3])
+		assert.equals(1, #{list,[1,2,3]}.asSet().size())
 		'''.test
 	}
 	
 	@Test
 	def void testSetOfSetsAsSetConversion() {
 		'''
-		assert.equals(1, #{#{1,2,3},#{1,2,3}}.asSet().size())
+		var set = new Set()
+		set.addAll([1,2,3])
+		assert.equals(1, #{set, #{1,2,3}}.asSet().size())
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -147,6 +147,20 @@ class SetTest extends CollectionTestCase {
 		assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
+
+	@Test
+	def void testSetOfEmptyListSize() {
+		'''
+		const set = #{}
+		const a = []
+		const b = new List()
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
 	
 	@Test
 	def void testSetOfSetSize() {
@@ -162,6 +176,20 @@ class SetTest extends CollectionTestCase {
 		assert.equals(2, set.size())
 		assert.equals(set, #{a,c})
 		assert.equals(#{a,c}, #{b,c})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfEmptySetSize() {
+		'''
+		const set = #{}
+		const a = #{}
+		const b = #{}
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -246,25 +246,30 @@ class SetTest extends CollectionTestCase {
 	@Test
 	def void testSetOfUserDefinedClassSizeRedefiningEqualEqual() {
 		'''
-		class C {
-			override method ==(other) = self.kindName() == other.kindName()
+		class Animal {
+			override method ==(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
+			method getNombre()
 		}
 		
-		class D {
-			override method ==(other) = self.kindName() == other.kindName()
+		class Perro inherits Animal {
+			override method getNombre() = "Firulais"
+		}
+		
+		class Gato inherits Animal {
+			override method getNombre() = "Garfield"
 		}
 		
 		test "issue 1771" {
 			const set = new Set()
-			const a = new C()
-			const b = new C()
-			const d = new D()
-			set.add(a)
-			set.add(b)
-			set.add(d)
+			const perro = new Perro()
+			const otroPerro = new Perro()
+			const gato = new Gato()
+			set.add(perro)
+			set.add(otroPerro)
+			set.add(gato)
 			assert.equals(2, set.size())
-			assert.equals(set, #{a,d})
-			assert.equals(#{a,d}, #{b,d})
+			assert.equals(set, #{perro,gato})
+			assert.equals(#{perro,gato}, #{otroPerro,gato})
 		}
 		'''.interpretPropagatingErrors
 	}
@@ -272,62 +277,32 @@ class SetTest extends CollectionTestCase {
 	@Test
 	def void testSetOfUserDefinedClassSizeRedefiningEquals() {
 		'''
-		class C {
-			override method ==(other) = self.kindName() == other.kindName()
+		class Animal {
+			override method equals(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
+			method getNombre()
 		}
 		
-		class D {
-			override method ==(other) = self.kindName() == other.kindName()
+		class Perro inherits Animal {
+			override method getNombre() = "Firulais"
+		}
+		
+		class Gato inherits Animal {
+			override method getNombre() = "Garfield"
 		}
 		
 		test "issue 1771" {
 			const set = new Set()
-			const a = new C()
-			const b = new C()
-			const d = new D()
-			set.add(a)
-			set.add(b)
-			set.add(d)
+			const perro = new Perro()
+			const otroPerro = new Perro()
+			const gato = new Gato()
+			set.add(perro)
+			set.add(otroPerro)
+			set.add(gato)
 			assert.equals(2, set.size())
-			assert.equals(set, #{a,d})
-			assert.equals(#{a,d}, #{b,d})
+			assert.equals(set, #{perro,gato})
+			assert.equals(#{perro,gato}, #{otroPerro,gato})
 		}
 		'''.interpretPropagatingErrors
-	}
-	
-	@Test
-	def void testSetOfDifferentTypesSize() {
-		'''
-		const dictionary = new Dictionary()
-		const anotherDictionary = new Dictionary()
-		var position = new Position()
-		position = position.up(2)
-		dictionary.put("1", "hola")
-		anotherDictionary.put("1", "hola")
-		
-		const set = #{1,"1", new Pair(5,6), "hola", new Position(), new Dictionary(), "1", new Dictionary(), 
-		"ho" + "la", true, new Position(), new Date(day=21, month=10, year=2018), position, dictionary, "true", 2/2, 
-		!false, false, new Date(day=21, month=10, year=2018), anotherDictionary, new Pair(1,2), 
-		new Date(day=2, month=5, year=2014), new Pair(1,2)}
-		
-		assert.equals(14, set.size())
-		'''.test
-	}
-	
-	// Si se agregan a las listas positions, dictionaries y/o clases definidas por el usuario deja de andar...
-	@Test
-	def void testSetOfListsOfDifferentTypesSize() {
-		'''
-		const set = new Set()
-		const a = [1,"hola",true,new Date()]
-		const b = new List()
-		b.addAll([1,"hola",true,new Date()])
-		set.add(a)
-		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
-		'''.test
 	}
 	
 	@Test

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -89,11 +89,13 @@ class SetTest extends CollectionTestCase {
 		const set = new Set()
 		const a = 2
 		const b = 1 + 1
+		const c = 3
 		set.add(a)
 		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
+		set.add(c)
+		assert.equals(2, set.size())
+		assert.equals(set, #{a,c})
+		assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
 	
@@ -103,11 +105,13 @@ class SetTest extends CollectionTestCase {
 		const set = new Set()
 		const a = "hola"
 		const b = "ho" + "la"
+		const c = "chau"
 		set.add(a)
 		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
+		set.add(c)
+		assert.equals(2, set.size())
+		assert.equals(set, #{a,c})
+		assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
 	
@@ -117,11 +121,13 @@ class SetTest extends CollectionTestCase {
 		const set = new Set()
 		const a = true
 		const b = !false
+		const c = false
 		set.add(a)
 		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
+		set.add(c)
+		assert.equals(2, set.size())
+		assert.equals(set, #{a,c})
+		assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
 	
@@ -131,12 +137,14 @@ class SetTest extends CollectionTestCase {
 		const set = #{}
 		const a = [1,2,3]
 		const b = new List()
+		const c = [3,4,5]
 		b.addAll([1,2,3])
 		set.add(a)
 		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
+		set.add(c)
+		assert.equals(2, set.size())
+		assert.equals(set, #{a,c})
+		assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
 	
@@ -146,12 +154,14 @@ class SetTest extends CollectionTestCase {
 		const set = #{}
 		const a = #{1,2,3}
 		const b = new Set()
+		const c = #{4,5,6}
 		b.addAll([1,2,3])
 		set.add(a)
 		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
+		set.add(c)
+		assert.equals(2, set.size())
+		assert.equals(set, #{a,c})
+		assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
 	
@@ -161,11 +171,14 @@ class SetTest extends CollectionTestCase {
 		const set = #{}
 		const a = new Dictionary()
 		const b = new Dictionary()
+		const c = new Dictionary()
+		c.put(1, "hola")
 		set.add(a)
 		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		//assert.equals(#{a}, #{b})
+		set.add(c)
+		assert.equals(2, set.size())
+		assert.equals(set, #{a,c})
+		//assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
 
@@ -175,11 +188,13 @@ class SetTest extends CollectionTestCase {
 		const set = new Set()
 		const a = new Pair(x = 1, y = 2)
 		const b = new Pair(x = 1, y = 2)
+		const c = new Pair(x = 3, y = 4)
 		set.add(a)
 		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
+		set.add(c)
+		assert.equals(2, set.size())
+		assert.equals(set, #{a,c})
+		assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
 	
@@ -189,51 +204,89 @@ class SetTest extends CollectionTestCase {
 		const set = new Set()
 		const a = new Position()
 		const b = new Position()
+		var c = new Position()
+		c = c.up(2)
 		set.add(a)
 		set.add(b)
-		assert.equals(1, set.size())
-		assert.equals(set, #{a})
-		assert.equals(#{a}, #{b})
+		set.add(c)
+		assert.equals(2, set.size())
+		assert.equals(set, #{a,c})
+		assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
 	
 	@Test
-	def void testSetOfUserDefinedClassSizeIfEqualEqualSetToTrue() {
+	def void testSetOfUserDefinedClassSizeRedefiningEqualEqual() {
 		'''
 		class C {
-			override method ==(other) = true
+			override method ==(other) = self.kindName() == other.kindName()
 		}
+		
+		class D {
+			override method ==(other) = self.kindName() == other.kindName()
+		}
+		
 		test "issue 1771" {
 			const set = new Set()
 			const a = new C()
 			const b = new C()
+			const d = new D()
 			set.add(a)
 			set.add(b)
-			assert.equals(1, set.size())
-			assert.equals(set, #{a})
-			assert.equals(#{a}, #{b})
+			set.add(d)
+			assert.equals(2, set.size())
+			assert.equals(set, #{a,d})
+			assert.equals(#{a,d}, #{b,d})
 		}
 		'''.interpretPropagatingErrors
 	}
 	
 	@Test
-	def void testSetOfUserDefinedClassSizeIfEqualsSetToTrue() {
+	def void testSetOfUserDefinedClassSizeRedefiningEquals() {
 		'''
 		class C {
-			override method equals(other) = true
+			override method ==(other) = self.kindName() == other.kindName()
 		}
+		
+		class D {
+			override method ==(other) = self.kindName() == other.kindName()
+		}
+		
 		test "issue 1771" {
 			const set = new Set()
 			const a = new C()
 			const b = new C()
+			const d = new D()
 			set.add(a)
 			set.add(b)
-			assert.equals(1, set.size())
-			assert.equals(set, #{a})
+			set.add(d)
+			assert.equals(2, set.size())
+			assert.equals(set, #{a,d})
+			assert.equals(#{a,d}, #{b,d})
 		}
 		'''.interpretPropagatingErrors
 	}
 	
+	@Test
+	def void testSetOfDifferentTypesSize() {
+		'''
+		const dictionary = new Dictionary()
+		const anotherDictionary = new Dictionary()
+		var position = new Position()
+		position = position.up(2)
+		dictionary.put("1", "hola")
+		anotherDictionary.put("1", "hola")
+		
+		const set = #{1,"1", new Pair(5,6), "hola", new Position(), new Dictionary(), "1", new Dictionary(), 
+		"ho" + "la", true, new Position(), new Date(day=21, month=10, year=2018), position, dictionary, "true", 2/2, 
+		!false, false, new Date(day=21, month=10, year=2018), anotherDictionary, new Pair(1,2), 
+		new Date(day=2, month=5, year=2014), new Pair(1,2)}
+		
+		assert.equals(14, set.size())
+		'''.test
+	}
+	
+	// Si se agregan a las listas positions, dictionaries y/o clases definidas por el usuario deja de andar...
 	@Test
 	def void testSetOfListsOfDifferentTypesSize() {
 		'''

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -134,17 +134,8 @@ class SetTest extends CollectionTestCase {
 	@Test
 	def void testSetOfListSize() {
 		'''
-		const set = #{}
-		const a = [1,2,3]
-		const b = new List()
-		const c = [3,4,5]
-		b.addAll([1,2,3])
-		set.add(a)
-		set.add(b)
-		set.add(c)
-		assert.equals(2, set.size())
-		assert.equals(set, #{a,c})
-		assert.equals(#{a,c}, #{b,c})
+		const set = #{[1,2,3],[5,6],[7,8],[1,2,3],[5,6]}
+		assert.equals(3, set.size())
 		'''.test
 	}
 
@@ -165,17 +156,8 @@ class SetTest extends CollectionTestCase {
 	@Test
 	def void testSetOfSetSize() {
 		'''
-		const set = #{}
-		const a = #{1,2,3}
-		const b = new Set()
-		const c = #{4,5,6}
-		b.addAll([1,2,3])
-		set.add(a)
-		set.add(b)
-		set.add(c)
-		assert.equals(2, set.size())
-		assert.equals(set, #{a,c})
-		assert.equals(#{a,c}, #{b,c})
+		const set = #{#{1,2,3},#{5,6},#{7,8},#{1,2,3},#{5,6}}
+		assert.equals(3, set.size())
 		'''.test
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -206,7 +206,7 @@ class SetTest extends CollectionTestCase {
 		set.add(c)
 		assert.equals(2, set.size())
 		assert.equals(set, #{a,c})
-		//assert.equals(#{a,c}, #{b,c})
+		assert.equals(#{a,c}, #{b,c})
 		'''.test
 	}
 
@@ -247,16 +247,16 @@ class SetTest extends CollectionTestCase {
 	def void testSetOfUserDefinedClassSizeRedefiningEqualEqual() {
 		'''
 		class Animal {
-			override method ==(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
-			method getNombre()
+			override method ==(otroAnimal) = self.nombre() == otroAnimal.nombre()
+			method nombre()
 		}
 		
 		class Perro inherits Animal {
-			override method getNombre() = "Firulais"
+			override method nombre() = "Firulais"
 		}
 		
 		class Gato inherits Animal {
-			override method getNombre() = "Garfield"
+			override method nombre() = "Garfield"
 		}
 		
 		test "issue 1771" {
@@ -278,16 +278,16 @@ class SetTest extends CollectionTestCase {
 	def void testSetOfUserDefinedClassSizeRedefiningEquals() {
 		'''
 		class Animal {
-			override method equals(otroAnimal) = self.getNombre() == otroAnimal.getNombre()
-			method getNombre()
+			override method equals(otroAnimal) = self.nombre() == otroAnimal.nombre()
+			method nombre()
 		}
 		
 		class Perro inherits Animal {
-			override method getNombre() = "Firulais"
+			override method nombre() = "Firulais"
 		}
 		
 		class Gato inherits Animal {
-			override method getNombre() = "Garfield"
+			override method nombre() = "Garfield"
 		}
 		
 		test "issue 1771" {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -84,6 +84,166 @@ class SetTest extends CollectionTestCase {
 	}
 	
 	@Test
+	def void testSetOfNumberSize() {
+		'''
+		const set = new Set()
+		const a = 2
+		const b = 1 + 1
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfStringSize() {
+		'''
+		const set = new Set()
+		const a = "hola"
+		const b = "ho" + "la"
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfBooleanSize() {
+		'''
+		const set = new Set()
+		const a = true
+		const b = !false
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfListSize() {
+		'''
+		const set = #{}
+		const a = [1,2,3]
+		const b = [1,2,3]
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfSetSize() {
+		'''
+		const set = #{}
+		const a = #{1,2,3}
+		const b = #{1,2,3}
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfDictionarySize() {
+		'''
+		const set = #{}
+		const a = new Dictionary()
+		const b = a
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfPairSize() {
+		'''
+		const set = new Set()
+		const a = new Pair(1,2)
+		const b = a
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfPositionSize() {
+		'''
+		const set = new Set()
+		const a = new Position()
+		const b = new Position()
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOftUserDefinedClassSize() {
+		'''
+		class MiClase {}
+		program a {
+			const set = new Set()
+			const a = new MiClase()
+			const b = a
+			set.add(a)
+			set.add(b)
+			assert.equals(1, set.size())
+			assert.equals(set, #{a})
+			assert.equals(#{a}, #{b})
+		}
+		
+		'''.interpretPropagatingErrors
+	}
+	
+	@Test
+	def void testSetOfListsOfDifferentTypesSize() {
+		'''
+		const set = new Set()
+		const a = new List()
+		a.addAll([1,"hola",true,new Date()])
+		const b = new List()
+		b.addAll([1,"hola",true,new Date()])
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfListAsSetConversion() {
+		'''
+		assert.equals(1, #{[1,2,3],[1,2,3]}.asSet().size())
+		'''.test
+	}
+	
+	@Test
+	def void testSetOfSetsAsSetConversion() {
+		'''
+		assert.equals(1, #{#{1,2,3},#{1,2,3}}.asSet().size())
+		'''.test
+	}
+	
+	@Test
 	override removeAll() {
 		'''
 		«instantiateCollectionAsNumbersVariable»

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/sdk/SetTest.xtend
@@ -155,37 +155,33 @@ class SetTest extends CollectionTestCase {
 		'''.test
 	}
 	
-//  ESTE TEST FALLA (Expected [1] but found [2])
+	@Test
+	def void testSetOfDictionarySize() {
+		'''
+		const set = #{}
+		const a = new Dictionary()
+		const b = new Dictionary()
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		//assert.equals(#{a}, #{b})
+		'''.test
+	}
 
-//	@Test
-//	def void testSetOfDictionarySize() {
-//		'''
-//		const set = #{}
-//		const a = new Dictionary()
-//		const b = new Dictionary()
-//		set.add(a)
-//		set.add(b)
-//		assert.equals(1, set.size())
-//		assert.equals(set, #{a})
-//		assert.equals(#{a}, #{b})
-//		'''.test
-//	}
-
-//  ESTE TEST FALLA (Expected [1] but found [2])
-
-//	@Test
-//	def void testSetOfPairSize() {
-//		'''
-//		const set = new Set()
-//		const a = new Pair(1,2)
-//		const b = new Pair(1,2)
-//		set.add(a)
-//		set.add(b)
-//		assert.equals(1, set.size())
-//		assert.equals(set, #{a})
-//		assert.equals(#{a}, #{b})
-//		'''.test
-//	}
+	@Test
+	def void testSetOfPairSize() {
+		'''
+		const set = new Set()
+		const a = new Pair(x = 1, y = 2)
+		const b = new Pair(x = 1, y = 2)
+		set.add(a)
+		set.add(b)
+		assert.equals(1, set.size())
+		assert.equals(set, #{a})
+		assert.equals(#{a}, #{b})
+		'''.test
+	}
 	
 	@Test
 	def void testSetOfPositionSize() {

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/api/WollokInterpreterAccess.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/api/WollokInterpreterAccess.xtend
@@ -15,20 +15,20 @@ class WollokInterpreterAccess {
 	
 	public static val INSTANCE = new WollokInterpreterAccess
 	
-	/**
-	 * Helper method for simple access to wollok equality between objects, 
-	 * which is needed in different parts of the interpreter 
-	 */
 	def boolean wollokEquals(WollokObject a, WollokObject b) {
-		operations.asBinaryOperation(EQUALITY).apply(a, [|b]).isTrue
+		callBinaryOperation(a, b, EQUALITY)
 	}
 
-	/**
-	 * Helper method for simple access to wollok number comparison, 
-	 * which is needed in different parts of the interpreter 
-	 */
+	def boolean wollokEqualsMethod(WollokObject a, WollokObject b) {
+		callBinaryOperation(a, b, "equals")
+	}
+
 	def boolean wollokGreaterThan(WollokObject a, WollokObject b) {
-		operations.asBinaryOperation(GREATER_THAN).apply(a, [|b]).isTrue
+		callBinaryOperation(a, b, GREATER_THAN)
+	}
+
+	def callBinaryOperation(WollokObject a, WollokObject b, String binaryOperation) {
+		operations.asBinaryOperation(binaryOperation).apply(a, [|b]).isTrue
 	}
 
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -283,8 +283,12 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 		c.allUntypedMethods.findMethodIgnoreCase(methodName, argumentsSize) 
 	}
 
+	def static ownerOf(WollokObject o, String methodName) {
+		o.behavior.lookupMethod(methodName, #[o], false).wollokClass.fqn
+	}
+	
 	def static hasEqualsMethod(WollokObject o) {
-		o.behavior.methods.hasMethodIgnoreCase(EQUALITY, 1) || o.behavior.methods.hasMethodIgnoreCase("equals", 1)  
+		!o.ownerOf(EQUALITY).equals(OBJECT) || !o.ownerOf("equals").equals(OBJECT)
 	}
 	
 	def static hasGreaterThanMethod(WollokObject o) {


### PR DESCRIPTION
### **Cambios:**

- `asSet()` deja de ser native y `withoutDuplicates()` ya no lo usa. 

- Agrego tests para `asSet()` y `withoutDuplicates()`

Después de arreglar las inconsistencias relativas al issue, note este caso que seguía pasando:

![set-with-duplicated-bug](https://user-images.githubusercontent.com/26492157/64678307-b246cc80-d44f-11e9-868e-e4bf5f49c522.PNG)

Cuando el set era de distintos tipos, cada tanto se "comía" un duplicado (siempre eran Strings y Dates).

Lo pude solucionar con un cambio en el método `compare()` de `WollokObjectComparator`. Hay que revisarlo.

Fixes #1771 and #1783