### PR TITLE
Fix #1779 - replace unique method name

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/game.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/game.wlk
@@ -151,7 +151,7 @@ object game {
 	/**
 	 * Returns the unique object that is in same position of given object.
 	 */	
-	method uniqueCollider(visual) = self.colliders(visual).unique()
+	method uniqueCollider(visual) = self.colliders(visual).uniqueElement()
 
 	/**
 	 * Stops render the board and finish the game.

--- a/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
+++ b/org.uqbar.project.wollok.lib/src/wollok/lang.wlk
@@ -441,15 +441,15 @@ class Collection {
 	  * If collection has more than one element, an error is thrown.
 	  *
 	  * Example:
-	  *       [1].unique() 	=>  Answers 1
-	  *       [].unique()  	=>  Throws error, list must not be empty
-	  *       [1, 2].unique()  	=>  Throws error, list must have one element
+	  *       [1].uniqueElement()    => Answers 1
+	  *       [].uniqueElement()     => Throws error, list must not be empty
+	  *       [1, 2].uniqueElement() => Throws error, list must have one element
 	  */
-	method unique() {
-		self.validateNotEmpty("unique")
+	method uniqueElement() {
+		self.validateNotEmpty("uniqueElement")
 		const size = self.size()
 		if (size > 1)
-			throw new Exception(message = "Illegal operation 'unique' on collection with " + size.toString() + " elements")
+			throw new Exception(message = "Illegal operation 'uniqueElement' on collection with " + size.toString() + " elements")
 		return self.anyOne()		
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/CollectionTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/CollectionTestCase.xtend
@@ -164,23 +164,23 @@ class CollectionTestCase extends AbstractWollokInterpreterTestCase {
 	}
 
 	@Test
-	def void unique() {
+	def void uniqueElement() {
 		'''
-		assert.equals(1, [1].unique())
+		assert.equals(1, [1].uniqueElement())
 		'''.test
 	}
 
 	@Test
-	def void uniqueWithEmptyCollection() {
+	def void uniqueElementWithEmptyCollection() {
 		'''
-		assert.throwsExceptionWithMessage("Illegal operation 'unique' on empty collection", { => [].unique() })
+		assert.throwsExceptionWithMessage("Illegal operation 'uniqueElement' on empty collection", { => [].uniqueElement() })
 		'''.test
 	}	
 
 	@Test
-	def void uniqueWithManyElements() {
+	def void uniqueElementWithManyElements() {
 		'''
-		assert.throwsExceptionWithMessage("Illegal operation 'unique' on collection with 2 elements", { => [1, 2].unique() })
+		assert.throwsExceptionWithMessage("Illegal operation 'uniqueElement' on collection with 2 elements", { => [1, 2].uniqueElement() })
 		'''.test
 	}
 

--- a/org.uqbar.project.wollok.typeSystem/META-INF/MANIFEST.MF
+++ b/org.uqbar.project.wollok.typeSystem/META-INF/MANIFEST.MF
@@ -9,6 +9,7 @@ Require-Bundle: org.uqbar.project.wollok,
  org.eclipse.xtext.ui;bundle-version="2.11.0"
 Export-Package: org.uqbar.project.wollok.typesystem,
  org.uqbar.project.wollok.typesystem.constraints,
+ org.uqbar.project.wollok.typesystem.constraints.variables,
  org.uqbar.project.wollok.typesystem.preferences
 Bundle-Activator: org.uqbar.project.wollok.typesystem.WollokTypeSystemActivator
 Bundle-ActivationPolicy: lazy

--- a/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/CollectionTypeDeclarations.xtend
+++ b/org.uqbar.project.wollok.typeSystem/src/org/uqbar/project/wollok/typesystem/annotations/CollectionTypeDeclarations.xtend
@@ -71,7 +71,7 @@ class CollectionTypeDeclarations extends TypeDeclarations {
 		C.sumableCollection(E)
 		C.clear
 
-		C >> "unique" === #[] => E
+		C >> "uniqueElement" === #[] => E
 
 		C >> "join" === #[String] => String
 		C >> "join" === #[] => String


### PR DESCRIPTION
Fixes #1779 

Also fixes `tsVarOrParam` method for type system @PalumboN 