### PR TITLE
Fix #1841 test runner

### DIFF
--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/DefaultWollokTestsReporter.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/tests/DefaultWollokTestsReporter.xtend
@@ -83,11 +83,20 @@ class DefaultWollokTestsReporter implements WollokTestsReporter {
 	}
 	
 	def testFinished(WTest test) {
-		testTimeElapsed.get(test).to = System.currentTimeMillis
+		if (test.hasTimeElapsedRecord) {
+			testTimeElapsed.get(test).to = System.currentTimeMillis
+		}
 	}
 	
 	def getTotalTime(WTest test) {
-		testTimeElapsed.get(test).totalTime
+		if (test.hasTimeElapsedRecord) testTimeElapsed.get(test).totalTime else 0
+	}
+	
+	/**
+	 * If there was an error in the fixture, or in variable initialization, we won't be able to get the test in the map
+	 */
+	def hasTimeElapsedRecord(WTest test) {
+		testTimeElapsed.get(test) !== null
 	}
 }
 


### PR DESCRIPTION
@npasserini is this a better approach? Now you see all errors in the final report:

![image](https://user-images.githubusercontent.com/4549002/66703076-fe05c380-ece4-11e9-951c-2c2f8db97ab8.png)

This PR also fixes a problem when an exception is thrown in fixture or test/describe initialization.
You can check this changes, I'd like to ship it for next release (Oct 20th maybe?)