### PR TITLE
Fix referenciable linking error

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/namedobjects/NamedObjectTestCase.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/interpreter/namedobjects/NamedObjectTestCase.xtend
@@ -51,7 +51,7 @@ class NamedObjectTestCase extends AbstractWollokInterpreterTestCase {
 			fail("Linking should have failed, 'n' from class Pepe shouldn't have been resolved !")
 		}
 		catch (AssertionError e) {
-			assertTrue(e.message.startsWith("Expected no errors, but got :ERROR (org.eclipse.xtext.diagnostics.Diagnostic.Linking) 'Couldn't resolve reference to Referenciable 'n'.' on WVariableReference"))
+			assertTrue(e.message.startsWith("Expected no errors, but got :ERROR (org.eclipse.xtext.diagnostics.Diagnostic.Linking) 'Couldn't resolve reference to 'n'.' on WVariableReference"))
 		}
 	}
 	

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckVarReferences.wpgm.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/CheckVarReferences.wpgm.xt
@@ -4,19 +4,19 @@ program p {
 	// XPECT warnings --> "Unused variable" at "a"
 	const a = 23
 	
-	// XPECT errors --> "Couldn't resolve reference to Referenciable 'x'." at "x"
+	// XPECT errors --> "Couldn't resolve reference to 'x'." at "x"
 	console.println(x)
 	
 	// XPECT warnings --> "Unused variable" at "objetin"
 	const objetin = object {
 		var l = "ele"
 		method algoConLYZNoExiste() {
-			// XPECT errors --> "Couldn't resolve reference to Referenciable 'z'." at "z"
+			// XPECT errors --> "Couldn't resolve reference to 'z'." at "z"
 			l = l + z
 			
 			/* XPECT errors ---
-				"Couldn't resolve reference to Referenciable 'z'." at "z"
-				"Couldn't resolve reference to Referenciable 'z'." at "z"
+				"Couldn't resolve reference to 'z'." at "z"
+				"Couldn't resolve reference to 'z'." at "z"
 			--- */
 			z = z + 1    // z no existe !
 		}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ConstructorAndConsts.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/ConstructorAndConsts.wlk.xt
@@ -48,7 +48,7 @@ class A {
 
 	constructor(e) { energia = e }
 	method energia() = energia
-	// XPECT errors --> "Couldn't resolve reference to Referenciable 'e'." at "e"
+	// XPECT errors --> "Couldn't resolve reference to 'e'." at "e"
 	method setEnergia() { energia = e }
 }
 

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NamedParameters.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/NamedParameters.wlk.xt
@@ -88,7 +88,7 @@ class Villano inherits AntiHeroe {
 class ReVillano inherits AntiHeroe {
 	var nivelMaldad
 	/* XPECT errors ---
-		"Couldn't resolve reference to Referenciable 'ciudadesQueAma'." at "ciudadesQueAma"
+		"Couldn't resolve reference to 'ciudadesQueAma'." at "ciudadesQueAma"
 		"Named parameters are not allowed here" at "ciudadesQueAma = ["New York"]"
 	--- */
 	constructor(_fraseCabecera) = super(ciudadesQueAma = ["New York"]) {
@@ -106,14 +106,14 @@ class A {
 		a = _a
 	}
 	/* XPECT errors ---
-		"Couldn't resolve reference to Referenciable '_a'." at "_a"
+		"Couldn't resolve reference to '_a'." at "_a"
 		"Named parameters are not allowed here" at "_a = x"
 	--- */
 	constructor(x, y) = self(_a = x) {
 		b = y
 	}
 	/* XPECT errors ---
-		"Couldn't resolve reference to Referenciable 'inexistente'." at "inexistente"
+		"Couldn't resolve reference to 'inexistente'." at "inexistente"
 		"Named parameters are not allowed here" at "x = y, inexistente = 3"
 	--- */
 	constructor(x, y, z) = self(x = y, inexistente = 3) {

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/parserErrors/MisplacedInstanceVariable.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/parserErrors/MisplacedInstanceVariable.wlk.xt
@@ -1,6 +1,6 @@
 /* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
 class Golondrina {
-	// XPECT errors --> "Couldn't resolve reference to Referenciable 'energia'." at "energia"
+	// XPECT errors --> "Couldn't resolve reference to 'energia'." at "energia"
 	method energia() = energia
 	
 	// XPECT! errors --> "You should declare references before constructors, methods and tests." at "var"

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/HumanReadableUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/HumanReadableUtils.xtend
@@ -13,7 +13,6 @@ import org.uqbar.project.wollok.wollokDsl.WMethodContainer
 import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
 import org.uqbar.project.wollok.wollokDsl.WNamedObject
 import org.uqbar.project.wollok.wollokDsl.WObjectLiteral
-import org.uqbar.project.wollok.wollokDsl.WReferenciable
 import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
 
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
@@ -29,14 +28,16 @@ class HumanReadableUtils {
 	// ************************************************************************
 	
 	// default: removes the "W" prefix and uses the class name
-	def static dispatch modelTypeDescription(EObject it) { eClass.modelTypeName }
 	def static dispatch modelTypeDescription(WNamedObject it) { "Object" }
 	def static dispatch modelTypeDescription(WObjectLiteral it) { "Object" }
 	def static dispatch modelTypeDescription(WMethodDeclaration it) { "Method" }
 	def static dispatch modelTypeDescription(WVariableDeclaration it) { if (writeable) "Variable" else "Constant" }
+	def static dispatch modelTypeDescription(EObject it) { eClass.modelTypeName }
 	
-	def static modelTypeName(WReferenciable it) { "reference " + name }
-	def static modelTypeName(EClass it) { if(name.startsWith("W")) name.substring(1) else name }
+	def static modelTypeName(EClass it) {
+		if (name.equals("WReferenciable")) return ""
+		if (name.startsWith("W")) name.substring(1) else name
+	}
 	
 	
 	// ************************************************************************

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/HumanReadableUtils.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/errorHandling/HumanReadableUtils.xtend
@@ -13,6 +13,7 @@ import org.uqbar.project.wollok.wollokDsl.WMethodContainer
 import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
 import org.uqbar.project.wollok.wollokDsl.WNamedObject
 import org.uqbar.project.wollok.wollokDsl.WObjectLiteral
+import org.uqbar.project.wollok.wollokDsl.WReferenciable
 import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
 
 import static extension org.uqbar.project.wollok.model.WMethodContainerExtensions.*
@@ -34,6 +35,7 @@ class HumanReadableUtils {
 	def static dispatch modelTypeDescription(WMethodDeclaration it) { "Method" }
 	def static dispatch modelTypeDescription(WVariableDeclaration it) { if (writeable) "Variable" else "Constant" }
 	
+	def static modelTypeName(WReferenciable it) { "reference " + name }
 	def static modelTypeName(EClass it) { if(name.startsWith("W")) name.substring(1) else name }
 	
 	

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/linking/WollokLinkingDiagnosticMessageProvider.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/linking/WollokLinkingDiagnosticMessageProvider.xtend
@@ -37,7 +37,9 @@ class WollokLinkingDiagnosticMessageProvider extends LinkingDiagnosticMessagePro
 			}
 		}
 		if (msg.equals("")) {
-			msg = LINKING_COULD_NOT_RESOLVE_REFERENCE + referenceType.modelTypeName + " '" + linkText + "'."
+			val modelTypeName = referenceType.modelTypeName
+			val separator = if (modelTypeName === "") "" else " "
+			msg = LINKING_COULD_NOT_RESOLVE_REFERENCE + modelTypeName + separator + "'" + linkText + "'."
 		}
 		new DiagnosticMessage(msg, Severity.ERROR, Diagnostic.LINKING_DIAGNOSTIC)
 	}


### PR DESCRIPTION
Bueno, algo que me molestaba desde hace tiempo es que diga "Referenciable" en los mensajes de error cuando el linker no encuentra una referencia. Creo que lo mejor es simplemente remover esa palabra, con el contexto del código y el mensaje actual creo que es suficiente.