### PR TITLE
Fix Babel Repository moved to archived one

### DIFF
--- a/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
+++ b/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
@@ -8,7 +8,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.babel.nls_eclipse_es.feature.group" version="4.12.0.v20190713060001" />
-			<repository location="http://archive.eclipse.org/technology/babel/update-site/R0.17.0/2019-06/" />
+			<repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.0/2019-06/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0" />

--- a/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
+++ b/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
@@ -8,7 +8,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.babel.nls_eclipse_es.feature.group" version="4.12.0.v20190713060001" />
-			<repository location="https://download.eclipse.org/technology/babel/update-site/R0.17.0/2019-06/" />
+			<repository location="https://archive.eclipse.org/technology/babel/babel_language_packs/R0.17.0/2019-06/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0" />

--- a/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
+++ b/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
@@ -7,8 +7,8 @@
 			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.20.0/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.babel.nls_eclipse_es.feature.group" version="4.12.0.v20190713060001" />
-			<repository location="https://archive.eclipse.org/technology/babel/update-site/R0.17.0/2019-06/" />
+			<unit id="org.eclipse.babel.nls_eclipse_es.feature.group" version="4.12.0.v20200711011026" />
+			<repository location="https://download.eclipse.org/technology/babel/update-site/R0.18.0/2020-06/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0" />

--- a/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
+++ b/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
@@ -8,7 +8,7 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.babel.nls_eclipse_es.feature.group" version="4.12.0.v20190713060001" />
-			<repository location="https://archive.eclipse.org/technology/babel/babel_language_packs/R0.17.0/2019-06/" />
+			<repository location="http://archive.eclipse.org/technology/babel/update-site/R0.17.0/2019-06/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0" />

--- a/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
+++ b/org.uqbar.project.wollok.targetplatform/org.uqbar.project.wollok.targetplatform.target
@@ -7,7 +7,7 @@
 			<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.20.0/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.babel.nls_eclipse_es.feature.group" version="4.12.0.v20200711011026" />
+			<unit id="org.eclipse.babel.nls_eclipse_es.feature.group" version="4.16.0.v20200711020001" />
 			<repository location="https://download.eclipse.org/technology/babel/update-site/R0.18.0/2020-06/" />
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">


### PR DESCRIPTION
Bueno, la gente de Babel liberó el 15/07/2020 la versión 0.18.0 y movió el repositorio p2 a archived. Este PR arregla el build que funciona todavía en Travis pero no en AppVeyor.