### PR TITLE
Fix #1894 Cannot return assignment with +=

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/cannotReturnAssignment.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/cannotReturnAssignment.wlk.xt
@@ -7,8 +7,18 @@ object a {
 		// XPECT errors --> "Cannot return an assignment" at "ahorro = ahorro * 0.20"
 		return ahorro = ahorro * 0.20
 	}
+	
+	method m1() {
+		// XPECT errors --> "Cannot return an assignment" at "ahorro += 0.20"
+		return ahorro += 0.20
+	}
 
-	method m2(param) {
+	method m2() {
+		// XPECT errors --> "Cannot return an assignment" at "ahorro *= 0.20"
+		return ahorro *= 0.20
+	}
+
+	method m3(param) {
 		ahorro += param
 	}
 }
@@ -23,6 +33,6 @@ object foo {
 	 }
 	 method bar2() {
 	 	// XPECT errors --> "Can't use 'return' expression as argument. Tip: remove 'return' keyword." at "9"
-	 	a.m2(return 9)
+	 	a.m3(return 9)
 	 }
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WollokModelExtensions.xtend
@@ -869,6 +869,10 @@ class WollokModelExtensions {
 		a.fqn == b.fqn || (b.parent !== null && a.isSuperTypeOf(b.parent))
 	}
 
+	static def dispatch isAssignment(WBinaryOperation operation) { operation.isMultiOpAssignment }
+	static def dispatch isAssignment(WAssignment a) { true }
+	static def dispatch isAssignment(EObject o) { false }
+	 
 	// ************************************************************************
 	// ** Compound assignments (+=, -=, *=, /=)
 	// ************************************************************************

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -1225,7 +1225,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(ERROR)
 	@NotConfigurable
 	def cannotReturnAssignment(WReturnExpression it) {
-		if (expression !== null && expression instanceof WAssignment)
+		if (expression !== null && expression.isAssignment)
 			report(WollokDslValidator_CANNOT_RETURN_ASSIGNMENT, it, WRETURN_EXPRESSION__EXPRESSION)
 	}
 


### PR DESCRIPTION
Eso, le incorporé la validación reemplazando el `instanceof` por una solución polimórfica. De paso agregué tests, y sirve para cualquier operación binaria con asignación (ya estaba determinado esto por una expresión regular).