### PR TITLE
Fix #1817 - adding attributes to wollokdoc

### DIFF
--- a/org.uqbar.project.wollok.launch/Generate WollokDoc.launch
+++ b/org.uqbar.project.wollok.launch/Generate WollokDoc.launch
@@ -9,7 +9,8 @@
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
 <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.uqbar.project.wollok.wollokDoc.WollokDocParser"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;/home/fernando/workspace/wollok-dev/wollok/org.uqbar.project.wollok.lib/src/wollok/&quot; -folder &quot;/home/fernando/workspace/wollok-site/documentacion/wollokdoc&quot;"/>
+<stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.uqbar.project.wollok.launch"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;/home/dodain/workspace/wollok-dev/wollok/org.uqbar.project.wollok.lib/src/wollok/&quot; -folder &quot;/home/dodain/workspace/wollok-site/documentacion/wollokdoc&quot;"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.uqbar.project.wollok.launch"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
 </launchConfiguration>

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/wollokDoc/WollokDocParser.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/wollokDoc/WollokDocParser.xtend
@@ -19,6 +19,7 @@ import org.uqbar.project.wollok.wollokDsl.WConstructor
 import org.uqbar.project.wollok.wollokDsl.WFile
 import org.uqbar.project.wollok.wollokDsl.WMethodContainer
 import org.uqbar.project.wollok.wollokDsl.WMethodDeclaration
+import org.uqbar.project.wollok.wollokDsl.WVariableDeclaration
 
 import static org.uqbar.project.wollok.sdk.WollokSDK.*
 
@@ -198,11 +199,20 @@ class WollokDocParser extends WollokChecker {
 			writeFile(TABLE_ROW_ON)
 			val abstractDescription = if (m.abstract) badge("abstract", "light-blue") + SPACE else ""
 			val nativeDescription = if (m.native) badge("native", "indigo") else ""
-			writeFile("<td title=\"" + m.declaringContext.name + "\" width=\"30%\"id=\"" + m.anchor + "\">" + CODE_ON + BOLD_ON + m.name + BOLD_OFF + m.parametersAsString + CODE_OFF + SPACE +
+			writeFile("<td title=\"" + m.declaringContext.name + "\" width=\"30%\" id=\"" + m.anchor + "\">" + CODE_ON + BOLD_ON + m.name + BOLD_OFF + m.parametersAsString + CODE_OFF + SPACE +
 				abstractDescription + SPACE + SPACE + nativeDescription + SPACE + TABLE_DATA_OFF +
 				TABLE_DATA_ON +	comment + TABLE_DATA_OFF)
 			writeFile(TABLE_ROW_OFF)
 		}
+	}
+
+	def dispatch void generateWollokDoc(WVariableDeclaration v) {
+		val comment = v.comment
+		writeFile(TABLE_ROW_ON)
+		writeFile("<td title=\"" + v.variable.name + "\" width=\"30%\">" + CODE_ON + BOLD_ON + v.variable.name + BOLD_OFF + CODE_OFF + SPACE +
+			SPACE + TABLE_DATA_OFF +
+			TABLE_DATA_ON +	comment + TABLE_DATA_OFF)
+		writeFile(TABLE_ROW_OFF)
 	}
 	
 	def dispatch getDefinedConstructors(WMethodContainer mc) { newArrayList }
@@ -217,6 +227,14 @@ class WollokDocParser extends WollokChecker {
 			header2("Constructors")
 			writeFile(TABLE_ON)
 			constructors.forEach [ generateWollokDoc ]
+			writeFile(TABLE_OFF)
+			writeFile(HORIZONTAL_LINE)
+		}
+		val attributes = mc.variableDeclarations
+		if (!attributes.isEmpty) {
+			header2("Attributes")
+			writeFile(TABLE_ON)
+			attributes.forEach [ generateWollokDoc ]
 			writeFile(TABLE_OFF)
 			writeFile(HORIZONTAL_LINE)
 		}


### PR DESCRIPTION
Como segundo paso, hay que agregar el wollokdoc a los pocos atributos que tenemos en wollok-language...

En un rato deberíamos poder verlo en producción: www.wollok.org/ 