### PR TITLE
Fix #1769 reload source repl

### DIFF
--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
@@ -34,7 +34,6 @@ class WollokRepl {
 	val WollokInterpreter interpreter
 	val File mainFile
 	val reader = new BufferedReader(new InputStreamReader(System.in))
-	val static prompt = ">>> "
 	var static whiteSpaces = ""
 	val WFile parsedMainFile
 	val extension ReplOutputFormatter formatter
@@ -73,7 +72,7 @@ class WollokRepl {
 	}
 
 	def synchronized printPrompt() {
-		print(prompt.messageStyle)
+		print(REPL_PROMPT.messageStyle)
 	}
 
 	def synchronized void printEndStructure() {
@@ -228,10 +227,6 @@ class WollokRepl {
 
 	def dispatch void handleException(WollokInterpreterException e) {
 		printlnIdent(e.convertToString.errorStyle)
-	}
-
-	def getPrompt() {
-		prompt.messageStyle.toString
 	}
 
 }

--- a/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
+++ b/org.uqbar.project.wollok.launch/src/org/uqbar/project/wollok/launch/repl/WollokRepl.xtend
@@ -114,14 +114,13 @@ class WollokRepl {
 		'''
 	}
 	
-
 	def synchronized executeInput(String input) {
 		var isImport = input.startsWith("import") 
 		
 		try {
 			val returnValue = interpreter.interpret(input.createReplExpression(isImport).parseRepl(mainFile), true)
 			
-			if (isImport ) 
+			if (isImport) 
 				// Parsing didn't fail, commit adding manual import to global list.
 				// No need to print nothing
 				manualImports += input 	

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsole.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsole.xtend
@@ -25,10 +25,10 @@ import org.uqbar.project.wollok.ui.console.editor.WollokReplConsolePartitioner
 import org.uqbar.project.wollok.ui.launch.Activator
 import org.uqbar.project.wollok.ui.launch.shortcut.WollokLaunchShortcut
 
+import static org.uqbar.project.wollok.WollokConstants.*
 import static org.uqbar.project.wollok.ui.console.RunInBackground.*
 import static org.uqbar.project.wollok.ui.console.RunInUI.*
 
-import static extension org.uqbar.project.wollok.WollokConstants.*
 import static extension org.uqbar.project.wollok.ui.launch.WollokLaunchConstants.*
 import static extension org.uqbar.project.wollok.utils.WEclipseUtils.*
 
@@ -100,20 +100,24 @@ class WollokReplConsole extends TextConsole {
 		streamsProxy.outputStreamMonitor.addListener [ text, monitor |
 			runInUI("WollokReplConsole-UpdateText") [
 				if (page !== null && page.viewer !== null && page.viewer.textWidget !== null) {
-					page.viewer.textWidget.append(text)
-					outputTextEnd = page.viewer.textWidget.charCount
-					inputBufferStartOffset = page.viewer.textWidget.text.length
-					page.viewer.textWidget.selection = outputTextEnd
-					updateInputBuffer
-					activate
-				}
-				val promptReady = text.contains(REPL_PROMPT)
-				if (this.restartingLastSession && promptReady && !this.lastSessionCommandsToRun.isEmpty) {
-					val nextCommand = this.lastSessionCommandsToRun.remove(0)
-					nextCommand.execute
+					text.processInput
+					val promptReady = text.contains(REPL_PROMPT)
+					if (this.restartingLastSession && promptReady && !this.lastSessionCommandsToRun.isEmpty) {
+						val nextCommand = this.lastSessionCommandsToRun.remove(0)
+						nextCommand.execute
+					}
 				}
 			]
 		]
+	}
+	
+	def processInput(String text) {
+		page.viewer.textWidget.append(text)
+		outputTextEnd = page.viewer.textWidget.charCount
+		inputBufferStartOffset = page.viewer.textWidget.text.length
+		page.viewer.textWidget.selection = outputTextEnd
+		updateInputBuffer
+		activate
 	}
 
 	def restart() {
@@ -216,7 +220,7 @@ class WollokReplConsole extends TextConsole {
 	}
 
 	def addCommandToHistory() {
-		if (!inputBuffer.empty) {
+		if (!inputBuffer.trim.empty) {
 			lastCommands => [
 				remove(inputBuffer)
 				add(inputBuffer)

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsolePage.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/WollokReplConsolePage.xtend
@@ -15,6 +15,7 @@ import org.eclipse.ui.console.IScrollLockStateProvider
 import org.eclipse.ui.console.TextConsole
 import org.eclipse.ui.console.TextConsolePage
 import org.eclipse.ui.console.TextConsoleViewer
+import org.eclipse.xtend.lib.annotations.Accessors
 import org.uqbar.project.wollok.ui.console.editor.WollokReplStyledText
 
 /**
@@ -30,7 +31,7 @@ class WollokReplConsolePage extends TextConsolePage implements KeyListener {
 	static val KEY_RETURN = 0x0d
 	val WollokReplConsole console
 	val IConsoleView view
-	var int historyPosition = -1
+	@Accessors var int historyPosition = -1
 
 	new(WollokReplConsole console, IConsoleView view) {
 		super(console, view)

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/actions/WollokReplConsoleActionsParticipant.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/actions/WollokReplConsoleActionsParticipant.xtend
@@ -35,6 +35,8 @@ class WollokReplConsoleActionsParticipant implements IConsolePageParticipant {
 	Action export
 	Action clearHistory
 	Action stop
+	Action restart
+	Action restartState
 	IActionBars bars
 	WollokReplConsole console
 	IResourceChangeListener resourceListener
@@ -68,6 +70,7 @@ class WollokReplConsoleActionsParticipant implements IConsolePageParticipant {
 				if (resourceDelta === null) {
 					return;
 				}
+				println("WARNING! The original file changed, this could lead to misleading behavior.")
 				_self.outdated.markOutdated
 			}
 
@@ -75,6 +78,8 @@ class WollokReplConsoleActionsParticipant implements IConsolePageParticipant {
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(resourceListener, IResourceChangeEvent.POST_CHANGE)
 
 		createTerminateAllButton
+		createRestartButton
+		createRestartStateButton
 		createRemoveButton
 		createClearHistory
 		this.outdated = new ShowOutdatedAction(this)
@@ -87,6 +92,8 @@ class WollokReplConsoleActionsParticipant implements IConsolePageParticipant {
 				appendToGroup(IConsoleConstants.LAUNCH_GROUP, outdated)
 				appendToGroup(IConsoleConstants.LAUNCH_GROUP, new Separator)
 				appendToGroup(IConsoleConstants.LAUNCH_GROUP, stop)
+				appendToGroup(IConsoleConstants.LAUNCH_GROUP, restart)
+				appendToGroup(IConsoleConstants.LAUNCH_GROUP, restartState)
 				appendToGroup(IConsoleConstants.LAUNCH_GROUP, new Separator)
 				appendToGroup(IConsoleConstants.LAUNCH_GROUP, export)
 				appendToGroup(IConsoleConstants.LAUNCH_GROUP, clearHistory)
@@ -103,6 +110,26 @@ class WollokReplConsoleActionsParticipant implements IConsolePageParticipant {
 			override run() {
 				this.enabled = false
 				console.shutdown
+			}
+		}
+	}
+
+	def createRestartButton() {
+		val imageDescriptor = ImageDescriptor.createFromURL(new URL("platform:/plugin/org.eclipse.ui.cheatsheets/icons/elcl16/start_ccs_task.png"))
+		this.restart = new Action(WollokRepl_RESTART_TITLE, imageDescriptor) {
+			override run() {
+				this.enabled = false
+				console.restart
+			}
+		}
+	}
+
+	def createRestartStateButton() {
+		val imageDescriptor = ImageDescriptor.createFromURL(new URL("platform:/plugin/org.eclipse.ui.cheatsheets/icons/elcl16/start_cheatsheet.png"))
+		this.restartState = new Action(WollokRepl_RESTART_STATE_TITLE, imageDescriptor) {
+			override run() {
+				this.enabled = false
+				console.restartLastSession
 			}
 		}
 	}

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokCodeHighLightLineStyleListener.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/console/highlight/WollokCodeHighLightLineStyleListener.xtend
@@ -3,6 +3,7 @@ package org.uqbar.project.wollok.ui.console.highlight
 import com.google.inject.Inject
 import java.io.ByteArrayInputStream
 import java.util.List
+import org.eclipse.jface.text.TextAttribute
 import org.eclipse.swt.SWT
 import org.eclipse.swt.custom.LineStyleEvent
 import org.eclipse.swt.custom.LineStyleListener
@@ -12,16 +13,15 @@ import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculat
 import org.eclipse.xtext.resource.XtextResource
 import org.eclipse.xtext.resource.XtextResourceSet
 import org.eclipse.xtext.ui.editor.syntaxcoloring.TextAttributeProvider
-import org.uqbar.project.wollok.launch.WollokChecker
 import org.uqbar.project.wollok.ui.launch.Activator
-import org.eclipse.jface.text.TextAttribute
 
-import static extension org.uqbar.project.wollok.WollokConstants.*
+import static org.uqbar.project.wollok.WollokConstants.*
+import static org.uqbar.project.wollok.ui.console.highlight.WollokConsoleHighlighter.*
+
 import static extension org.uqbar.project.wollok.ui.console.highlight.AnsiUtils.*
 import static extension org.uqbar.project.wollok.ui.console.highlight.WTextExtensions.*
 import static extension org.uqbar.project.wollok.ui.quickfix.QuickFixUtils.*
 import static extension org.uqbar.project.wollok.utils.XTextExtensions.*
-import static extension org.uqbar.project.wollok.ui.console.highlight.WollokConsoleHighlighter.*
 
 /**
  * A line style listener for the console to highlight code
@@ -36,7 +36,6 @@ import static extension org.uqbar.project.wollok.ui.console.highlight.WollokCons
  * @author jfernandes
  */
 class WollokCodeHighLightLineStyleListener implements LineStyleListener {
-	val static PROMPT = ">>> " // duplicated from WollokRepl
 	val static PROMPT_REPLACEMENT = "    "
 	
 	val static PROMPT_ANSI = "\u001b[36m>>> [m"
@@ -53,12 +52,10 @@ class WollokCodeHighLightLineStyleListener implements LineStyleListener {
 	@Inject TextAttributeProvider stylesProvider
 	@Inject XtextResourceSet resourceSet
 	WollokConsoleHighlighter highlighter
-	WollokChecker checker
 	
 	new() {
 		Activator.getDefault.injector.injectMembers(this)
 		highlighter = new WollokConsoleHighlighter // TODO: inject
-		checker = new WollokChecker
 	}
 	
 	override lineGetStyle(LineStyleEvent event) {
@@ -150,8 +147,8 @@ class WollokCodeHighLightLineStyleListener implements LineStyleListener {
 		]
 	}
 
-	def static escape(String text) { text.escapeAnsi.replaceAll(PROMPT, PROMPT_REPLACEMENT) }
+	def static escape(String text) { text.escapeAnsi.replaceAll(REPL_PROMPT, PROMPT_REPLACEMENT) }
 
-	def isCodeInputLine(LineStyleEvent it) { lineText.startsWith(PROMPT) || lineText.startsWith(PROMPT_ANSI) }
+	def isCodeInputLine(LineStyleEvent it) { lineText.startsWith(REPL_PROMPT) || lineText.startsWith(PROMPT_ANSI) }
 
 }

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/WollokLaunchUIMessages.java
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/WollokLaunchUIMessages.java
@@ -50,6 +50,7 @@ public class WollokLaunchUIMessages extends NLS {
 	public static String WollokRepl_OUTDATED_MESSAGE;
 	public static String WollokRepl_SYNCED_TOOLTIP;
 	public static String WollokRepl_OUTDATED_TOOLTIP;
+	public static String WollokRepl_OUTDATED_WARNING_MESSAGE_IN_REPL;
 	
 	static {
 		// initialize resource bundle

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/WollokLaunchUIMessages.java
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/WollokLaunchUIMessages.java
@@ -42,6 +42,8 @@ public class WollokLaunchUIMessages extends NLS {
 	public static String WollokTestState_ASSERT_WAS_NOT_DIFFERENT;
 	
 	public static String WollokRepl_STOP_TITLE;
+	public static String WollokRepl_RESTART_TITLE;
+	public static String WollokRepl_RESTART_STATE_TITLE;
 	public static String WollokRepl_EXPORT_HISTORY_TITLE;
 	public static String WollokRepl_CLEAR_HISTORY_TITLE;
 	public static String WollokRepl_SYNCED_MESSAGE;

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/messages.properties
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/messages.properties
@@ -38,6 +38,8 @@ WollokTestState_PENDING = Pending
 WollokTestState_RUNNING = Running
 
 WollokRepl_STOP_TITLE = Stop
+WollokRepl_RESTART_TITLE = Fresh restart
+WollokRepl_RESTART_STATE_TITLE = Restart and run last session commands
 WollokRepl_EXPORT_HISTORY_TITLE = Export History
 WollokRepl_CLEAR_HISTORY_TITLE = Clear History
 WollokRepl_SYNCED_MESSAGE = Synced

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/messages.properties
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/messages.properties
@@ -45,4 +45,5 @@ WollokRepl_CLEAR_HISTORY_TITLE = Clear History
 WollokRepl_SYNCED_MESSAGE = Synced
 WollokRepl_OUTDATED_MESSAGE = Outdated
 WollokRepl_SYNCED_TOOLTIP = Project {0} is synced with REPL session
-WollokRepl_OUTDATED_TOOLTIP = Project {0} is not synced. Changes you made will not be available in your REPL session until you run it again 
+WollokRepl_OUTDATED_TOOLTIP = Project {0} is not synced. Changes you made will not be available in your REPL session until you restart it
+WollokRepl_OUTDATED_WARNING_MESSAGE_IN_REPL = WARNING! Original file was updated. Changes will not be reflected until you restart the session.

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/messages_es.properties
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/messages_es.properties
@@ -43,4 +43,5 @@ WollokRepl_CLEAR_HISTORY_TITLE = Borrar el historial de comandos ejecutados
 WollokRepl_SYNCED_MESSAGE = Sincronizado
 WollokRepl_OUTDATED_MESSAGE = Desactualizado
 WollokRepl_SYNCED_TOOLTIP = El proyecto {0} est\u00E1 sincronizado con la sesi\u00F3n de la consola REPL
-WollokRepl_OUTDATED_TOOLTIP = El proyecto {0} no est\u00E1 sincronizado con la sesi\u00F3n de la consola REPL. Los cambios que hiciste no estar\u00E1n disponibles en la consola hasta que no lo vuelvas a ejecutar. 
+WollokRepl_OUTDATED_TOOLTIP = El proyecto {0} no est\u00E1 sincronizado con la sesi\u00F3n de la consola REPL. Los cambios que hiciste no estar\u00E1n disponibles en la consola hasta que la reinicies. 
+WollokRepl_OUTDATED_WARNING_MESSAGE_IN_REPL = \u00A1ATENCI\u00F3N! El archivo original fue modificado, los cambios no tomar\u00E1n efecto hasta que no reinicies la sesi\u00F3n.

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/messages_es.properties
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/i18n/messages_es.properties
@@ -36,6 +36,8 @@ WollokTestState_PENDING = Pendiente
 WollokTestState_RUNNING = Corriendo
 
 WollokRepl_STOP_TITLE = Detener la consola
+WollokRepl_RESTART_TITLE = Reiniciar la consola de cero
+WollokRepl_RESTART_STATE_TITLE = Reiniciar la consola y volver a ejecutar todos los comandos de esta sesión
 WollokRepl_EXPORT_HISTORY_TITLE = Exportar el historial de comandos ejecutados
 WollokRepl_CLEAR_HISTORY_TITLE = Borrar el historial de comandos ejecutados
 WollokRepl_SYNCED_MESSAGE = Sincronizado

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/WollokLaunchConstants.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/WollokLaunchConstants.xtend
@@ -1,5 +1,6 @@
 package org.uqbar.project.wollok.ui.launch
 
+import java.util.List
 import org.eclipse.debug.core.ILaunchConfiguration
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
 
@@ -30,6 +31,8 @@ class WollokLaunchConstants {
 	public static val ATTR_WOLLOK_DEBUG_EVENT_PORT = "WOLLOK_DEBUG_EVENT_PORT"
 	public static val ATTR_WOLLOK_FOLDER = "ATTR_WOLLOK_FOLDER"
 	public static val ATTR_WOLLOK_LIBS = "ATTR_WOLLOK_LIBS"
+	public static val ATTR_RESTARTING_STATE = "ATTR_RESTARTING_STATE"
+	public static val ATTR_LAST_COMMANDS = "ATTR_LAST_COMMANDS"
 	
 	static def getCommandPort(ILaunchConfiguration config) {
 		config.getAttribute(ATTR_WOLLOK_DEBUG_COMMAND_PORT, -1) // -1 ?
@@ -47,6 +50,14 @@ class WollokLaunchConstants {
 		config.setAttribute(ATTR_WOLLOK_DEBUG_EVENT_PORT, port)
 	}
 	
+	static def setRestartingState(ILaunchConfigurationWorkingCopy config, boolean restartingState) {
+		config.setAttribute(ATTR_RESTARTING_STATE, restartingState)
+	}
+
+	static def setLastCommands(ILaunchConfigurationWorkingCopy config, List<String> lastCommands) {
+		config.setAttribute(ATTR_LAST_COMMANDS, lastCommands)
+	}
+
 	static def getWollokFile(ILaunchConfiguration config){
 		config.getAttribute(ATTR_WOLLOK_FILE,"")
 	}
@@ -62,7 +73,15 @@ class WollokLaunchConstants {
 	static def getWollokProject(ILaunchConfiguration config){
 		config.getAttribute(ATTR_WOLLOK_PROJECT, "")
 	}
-	
+
+	static def isRestartingState(ILaunchConfiguration config) {
+		config.getAttribute(ATTR_RESTARTING_STATE, false)		
+	}
+
+	static def getLastCommands(ILaunchConfiguration config) {
+		config.getAttribute(ATTR_LAST_COMMANDS, <String>newArrayList)		
+	}
+
 	def static isWollokFileExtension(String xt) {
 		xt !== null && EXTENSIONS.contains(xt)
 	}

--- a/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/shortcut/WollokLaunchDelegate.xtend
+++ b/org.uqbar.project.wollok.ui.launch/src/org/uqbar/project/wollok/ui/launch/shortcut/WollokLaunchDelegate.xtend
@@ -23,9 +23,9 @@ import org.uqbar.project.wollok.ui.preferences.WollokNumbersConfigurationBlock
 import static org.uqbar.project.wollok.launch.io.IOUtils.*
 
 import static extension org.uqbar.project.wollok.ui.launch.WollokLaunchConstants.*
+import static extension org.uqbar.project.wollok.ui.launch.extensions.WollokConsoleExtensions.*
 import static extension org.uqbar.project.wollok.ui.launch.shortcut.LauncherExtensions.*
 import static extension org.uqbar.project.wollok.ui.launch.shortcut.WDebugExtensions.*
-import static extension org.uqbar.project.wollok.ui.launch.extensions.WollokConsoleExtensions.*
 
 /**
  * Launches the process to execute the interpreter.
@@ -41,13 +41,14 @@ class WollokLaunchDelegate extends JavaLaunchDelegate {
 	
 	@Inject
 	IPreferenceStoreAccess preferenceStoreAccess
+	
+	WollokReplConsole console
 
 	// Use RefreshUtil after switching to debug >= 3.6
 	static final String ATTR_REFRESH_SCOPE = DebugPlugin.getUniqueIdentifier() + ".ATTR_REFRESH_SCOPE";
 
 	override launch(ILaunchConfiguration configuration, String mode, ILaunch launch,
 		IProgressMonitor monitor) throws CoreException {
-
 		if (mode.isDebug && configuration.getAttribute(ATTR_REFRESH_SCOPE, null as String) !== null) {
 			DebugPlugin.getDefault.addDebugEventListener(createListener(configuration))
 		}
@@ -59,9 +60,9 @@ class WollokLaunchDelegate extends JavaLaunchDelegate {
 			val consoleManager = ConsolePlugin.getDefault().consoleManager
 			consoleManager.consoles.forEach [ shutdown ]
 			consoleManager.removeConsoles(consoleManager.consoles)
-			val console = new WollokReplConsole
+			this.console = new WollokReplConsole(configuration, mode)
 			consoleManager.addConsoles(#[console])
-			console.startForProcess(launch.processes.get(0))
+			this.console.startForProcess(launch.processes.get(0))
 		}
 
 		if (mode.isDebug) {

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokConstants.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokConstants.xtend
@@ -28,7 +28,8 @@ class WollokConstants {
 	public static val METAINF_FOLDER = "META-INF"
 	public static val HIDDEN_FOLDERS = #[DIAGRAMS_FOLDER, SETTINGS_FOLDER, BIN_FOLDER, METAINF_FOLDER]
 	
-	public static val REPL_FILE = "wollokREPL.wlk" 
+	public static val REPL_FILE = "wollokREPL.wlk"
+	public static val REPL_PROMPT = ">>> " 
 	public static val SYNTHETIC_FILE = "__synthetic"
 	
 	public static val PATH_SEPARATOR = "/"

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokConstants.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/WollokConstants.xtend
@@ -29,7 +29,7 @@ class WollokConstants {
 	public static val HIDDEN_FOLDERS = #[DIAGRAMS_FOLDER, SETTINGS_FOLDER, BIN_FOLDER, METAINF_FOLDER]
 	
 	public static val REPL_FILE = "wollokREPL.wlk"
-	public static val REPL_PROMPT = ">>> " 
+	public static val REPL_PROMPT = ">>> "
 	public static val SYNTHETIC_FILE = "__synthetic"
 	
 	public static val PATH_SEPARATOR = "/"


### PR DESCRIPTION
Bueno @PalumboN , con esto pienso cerrar el milestone, el fix al #1769 tiene todos los chiches que nos gustarían:

![PR_REPL_1769](https://user-images.githubusercontent.com/4549002/90847184-5adbfc80-e340-11ea-8bad-1f635cf0f38b.gif)

- cuando guardás el archivo te avisa con los caracteres en rojo en la consola (en Mac queda sin formatear, por el momento, por el error que teníamos con High Sierra)
- tenés el botón de restartear
- o bien restartear tratando de reconstruir el estado
- no nos hacemos cargo de lo que pase al correr el script, en el ejemplo borro un método y eso afecta al estado. Pero al menos una consecuencia mejor que lo que nos pasaba con Smalltalk es que tenés el objeto con el nuevo estado en base al código que tenés ahora (con Smalltalk tenías un mix de estados con código viejo y nuevo)
- ahora no guardamos el comando en el historial si tiene espacios (hay un trim)
- y también el prompt se pasó a un archivo de constantes

Una vez que mergeemos esta historia, largo el deploy de la 2.0.1 si te parece bien...