### PR TITLE
Fix #1938 - tirar un warning para métodos que tienen sintaxis rara

### DIFF
--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/MethodReturningBlockQuickFixTest.xtend
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/quickfix/MethodReturningBlockQuickFixTest.xtend
@@ -1,0 +1,24 @@
+package org.uqbar.project.wollok.tests.quickfix
+
+import org.junit.Test
+import org.uqbar.project.wollok.ui.Messages
+
+class MethodReturningBlockQuickFixTest extends AbstractWollokQuickFixTestCase {
+
+	@Test
+	def removeEqualsInMethodReturningBlock(){
+		val initial = #['''
+			object myObj {
+				method someMethod() = { return 4 }
+			}
+		''']
+
+		val result = #['''
+			object myObj {
+				method someMethod() { return 4 }
+			}
+		''']
+		assertQuickfix(initial, result, Messages.WollokDslQuickFixProvider_remove_equals_before_method_name)		
+	}
+
+}

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/EffectlessExpressionsInSequence.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/EffectlessExpressionsInSequence.wlk.xt
@@ -18,8 +18,10 @@ object testObject {
 		return v
 	}
 	
-	// XPECT warnings --> "This expression does not make sense in a sequence, as it does not produce any effects." at "helper" 
+	/* XPECT warnings ---
+		"This expression does not make sense in a sequence, as it does not produce any effects." at "helper"
+		"This method is returning a block, consider removing the '=' before curly braces." at "invalidBlock"
+	--- */ 
 	method invalidBlock() = { helper(100) }
 
-	method validBlock() = { const a = helper; [a] }
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/EffectlessExpressionsInSequence.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/EffectlessExpressionsInSequence.wlk.xt
@@ -24,4 +24,7 @@ object testObject {
 	--- */ 
 	method invalidBlock() = { helper(100) }
 
+	method validBlock() { 
+		return { const a = helper; [a] }
+	}
 }

--- a/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MethodsReturningBlock.wlk.xt
+++ b/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/xpect/MethodsReturningBlock.wlk.xt
@@ -1,0 +1,18 @@
+/* XPECT_SETUP org.uqbar.project.wollok.tests.xpect.WollokXPectTest END_SETUP */
+
+class A {
+	var property a = 1
+	var property b = 2
+	
+	// XPECT warnings --> "This method is returning a block, consider removing the '=' before curly braces." at "method1"
+	method method1() = { return 4 }
+
+	// XPECT warnings --> "This method is returning a block, consider removing the '=' before curly braces." at "method2"
+	method method2() = { 
+		return a + b
+	}
+
+	method method3() = { c => 
+		return a + b + c
+	}
+}

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/Messages.java
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/Messages.java
@@ -175,6 +175,8 @@ public class Messages extends NLS {
 	public static String WollokDslQuickFixProvider_create_new_external_wko_description;
 	public static String WollokDslQuickFixProvider_replace_assignment_with_comparison_name;
 	public static String WollokDslQuickFixProvider_replace_assignment_with_comparison_description;
+	public static String WollokDslQuickFixProvider_remove_equals_before_method_name;
+	public static String WollokDslQuickFixProvider_remove_equals_before_method_description;
 	
 	public static String AddNewElementQuickFix_Title;
 	public static String AddNewWKOQuickFix_Title;

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages.properties
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages.properties
@@ -283,6 +283,9 @@ WollokDslQuickFixProvider_remove_property_definition_description = Remove proper
 WollokDslQuickFixProvider_replace_assignment_with_comparison_name = Replace assignment with comparison
 WollokDslQuickFixProvider_replace_assignment_with_comparison_description = Replace assignment (=) with equality comparison (==)
 
+WollokDslQuickFixProvider_remove_equals_before_method_name = Remove '='
+WollokDslQuickFixProvider_remove_equals_before_method_description = Remove '=' before the method definition
+
 # Quick Fix - Add new element
 AddNewElementQuickFix_Title = Add new element
 AddNewWKOQuickFix_Title = Add new object

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages_es.properties
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/messages_es.properties
@@ -280,6 +280,10 @@ WollokTemplateProposalProvider_WClosure_description = Agregar un bloque
 WollokTemplateProposalProvider_WTry_name = Bloque try-catch
 WollokTemplateProposalProvider_WTry_description = Definir un bloque try-catch
 
+WollokDslQuickFixProvider_remove_equals_before_method_name = Eliminar '='
+WollokDslQuickFixProvider_remove_equals_before_method_description = Eliminar '=' antes de la definici\u00F3n del m\u00E9todo
+
+
 #
 # Refactoring
 #

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/QuickFixUtils.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/QuickFixUtils.xtend
@@ -106,7 +106,7 @@ class QuickFixUtils {
 	def static nextSiblingCode(EObject element) {
 		element.node?.nextSibling?.text?.trim	
 	}
-	
+
 	def static previousSiblingCode(EObject element) {
 		element.node?.previousSibling?.text?.trim	
 	}

--- a/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
+++ b/org.uqbar.project.wollok.ui/src/org/uqbar/project/wollok/ui/quickfix/WollokDslQuickfixProvider.xtend
@@ -136,6 +136,16 @@ class WollokDslQuickfixProvider extends DefaultQuickfixProvider {
 		]
 	}
 
+	@Fix(WollokDslValidator.METHOD_RETURNING_BLOCK)
+	def methodReturningBlock(Issue issue, IssueResolutionAcceptor acceptor) {
+		acceptor.accept(issue, Messages.WollokDslQuickFixProvider_remove_equals_before_method_name,
+			Messages.WollokDslQuickFixProvider_remove_equals_before_method_description, null) [ e, it |
+			val expressionBlock = (e as WMethodDeclaration).expression
+			val position = expressionBlock.node?.previousSibling.offset
+			xtextDocument.replace(position, expressionBlock.before - position, "")
+		]
+	}
+
 	@Fix(WollokDslValidator.MISSING_ASSIGNMENTS_IN_NAMED_PARAMETER_CONSTRUCTOR_CALL)
 	def addMissingAttributesInConstructorCall(Issue issue, IssueResolutionAcceptor acceptor) {
 		acceptor.accept(issue, Messages.WollokDslQuickFixProvider_add_missing_initializations_name,

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/Messages.java
@@ -51,6 +51,7 @@ public class Messages extends NLS {
 	public static String WollokDslValidator_OVERRIDING_METHOD_MUST_NOT_RETURN_VALUE;
 	public static String WollokDslValidator_OVERRIDING_METHOD_MUST_HAVE_A_BODY;
 	public static String WollokDslValidator_METHOD_OVERRIDING_BASE_CLASS;
+	public static String WollokDslValidator_METHOD_IS_RETURNING_BLOCK;
 
 	public static String WollokDslValidator_GETTER_METHOD_SHOULD_RETURN_VALUE;
 	public static String WollokDslValidator_CANNOT_MODIFY_VAL;

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages.properties
@@ -82,6 +82,7 @@ WollokDslValidator_MISSING_ASSIGNMENTS_IN_CONSTRUCTOR_CALL = You must provide in
 WollokDslValidator_METHOD_MUST_HAVE_OVERRIDE_KEYWORD = Method should be marked as override, since it overrides a superclass method
 WollokDslValidator_METHOD_NOT_OVERRIDING = Method does not override anything
 WollokDslValidator_METHOD_OVERRIDING_BASE_CLASS = You can't use override here: method doesn't exist in superclass and you can't change superclass definition
+WollokDslValidator_METHOD_IS_RETURNING_BLOCK = This method is returning a block, consider removing the '=' before curly braces.
 
 WollokDslValidator_OVERRIDING_METHOD_MUST_RETURN_VALUE = Must return a value since overridden method returns a value
 WollokDslValidator_GETTER_METHOD_SHOULD_RETURN_VALUE = Getter should return a value

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/messages_es.properties
@@ -84,6 +84,7 @@ WollokDslValidator_METHOD_NOT_OVERRIDING = Este m\u00E9todo no sobrescribe ning\
 WollokDslValidator_OVERRIDING_METHOD_MUST_RETURN_VALUE = Debe retornar un valor ya que el m\u00E9todo sobrescrito retorna un valor
 WollokDslValidator_OVERRIDING_METHOD_MUST_HAVE_A_BODY = Si sobrescribe debe especificar el cuerpo del m\u00E9todo
 WollokDslValidator_METHOD_OVERRIDING_BASE_CLASS = No se puede marcar con 'override' este m\u00E9todo ya que Object no lo define 
+WollokDslValidator_METHOD_IS_RETURNING_BLOCK = Este m\u00E9todo devuelve un bloque, si no es la intenci\u00F3n elimine el '=' antes de las llaves.
 
 WollokDslValidator_GETTER_METHOD_SHOULD_RETURN_VALUE = Getter debe retornar un valor
 

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -854,6 +854,6 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 
 	def static isInitializer(WMethodDeclaration m) { m.name.equals(INITIALIZE_METHOD) }
 
-	def static dispatch boolean returnExpressionInMethodIsBlock(WExpression e) { false	}
-	def static dispatch boolean returnExpressionInMethodIsBlock(WClosure block) { block.parameters.isEmpty } 
+	def static dispatch boolean isClosureWithoutParams(WExpression e) { false }
+	def static dispatch boolean isClosureWithoutParams(WClosure block) { block.parameters.isEmpty } 
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/model/WMethodContainerExtensions.xtend
@@ -853,4 +853,7 @@ class WMethodContainerExtensions extends WollokModelExtensions {
 	def static dispatch shouldCheckInitialization(WMixin it) { false }
 
 	def static isInitializer(WMethodDeclaration m) { m.name.equals(INITIALIZE_METHOD) }
+
+	def static dispatch boolean returnExpressionInMethodIsBlock(WExpression e) { false	}
+	def static dispatch boolean returnExpressionInMethodIsBlock(WClosure block) { block.parameters.isEmpty } 
 }

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -462,7 +462,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	@DefaultSeverity(WARN)
 	@NotConfigurable
 	def possiblyReturningBlock(WMethodDeclaration m) {
-		if (m.expressionReturns && m.expression.returnExpressionInMethodIsBlock) {
+		if (m.expressionReturns && m.expression.isClosureWithoutParams) {
 			m.report(WollokDslValidator_METHOD_IS_RETURNING_BLOCK, METHOD_RETURNING_BLOCK)
 		}
 	}

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/validation/WollokDslValidator.xtend
@@ -149,6 +149,7 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 	public static val WARNING_UNUSED_PARAMETER = "WARNING_UNUSED_PARAMETER"
 	public static val WARNING_VARIABLE_SHOULD_BE_CONST = "WARNING_VARIABLE_SHOULD_BE_CONST"
 	public static val GLOBAL_VARIABLE_NOT_ALLOWED = "GLOBAL_VARIABLE_NOT_ALLOWED"
+	public static val METHOD_RETURNING_BLOCK = "METHOD_RETURNING_BLOCK"
 
 	def validatorExtensions() {
 		if (wollokValidatorExtensions !== null)
@@ -457,6 +458,15 @@ class WollokDslValidator extends AbstractConfigurableDslValidator {
 		}
 	}
 
+	@Check
+	@DefaultSeverity(WARN)
+	@NotConfigurable
+	def possiblyReturningBlock(WMethodDeclaration m) {
+		if (m.expressionReturns && m.expression.returnExpressionInMethodIsBlock) {
+			m.report(WollokDslValidator_METHOD_IS_RETURNING_BLOCK, METHOD_RETURNING_BLOCK)
+		}
+	}
+	
 	@Check
 	@DefaultSeverity(WARN)
 	@CheckGroup(WollokCheckGroup.EXPLICIT_INTENTION)


### PR DESCRIPTION
Bueno @PalumboN , mientras esperamos cambios en el lenguaje, me dio cosita no arreglar esto:

1) Se agregó la validación de los métodos que tienen definición con `=` y una expresión y validamos que la expresión no sea un bloque que no tenga parámetros.

2) De paso agregué un quick fix para que elimine el `=`

![fix1938](https://user-images.githubusercontent.com/4549002/113074119-d9373180-91a0-11eb-88a5-3db1fb8eb10a.gif)
 