### PR TITLE
Fix assertion exception in wollok test result

### DIFF
--- a/org.uqbar.project.wollok.lib/src/wollok/lib/AssertionException.xtend
+++ b/org.uqbar.project.wollok.lib/src/wollok/lib/AssertionException.xtend
@@ -18,7 +18,7 @@ class AssertionException extends Exception {
 	int lineNumber
 	
 	new(String message, WollokProgramExceptionWrapper exceptionWrapper) {
-		this.message = message
+		this.message = message.replace("<", "|").replace(">", "|")
 		this.wollokException = exceptionWrapper.wollokException
 		this.URI = exceptionWrapper.URI
 		this.lineNumber = exceptionWrapper.lineNumber

--- a/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/nativeobj/WollokJavaConversions.xtend
+++ b/org.uqbar.project.wollok/src/org/uqbar/project/wollok/interpreter/nativeobj/WollokJavaConversions.xtend
@@ -152,7 +152,7 @@ class WollokJavaConversions {
 			throw throwInvalidOperation(NLS.bind(Messages.WollokConversion_INVALID_CONVERSION, o.call(TO_STRING_PRINTABLE), "Number"))
 		}
 		result
-	} 
+	}
 	
 	def static dispatch int coerceToInteger(BigDecimal value) {
 		coercingStrategy.coerceToInteger(value)


### PR DESCRIPTION
Resuelve el problema de cómo se muestra en Wollok los resultados cuando hay un assertion exception.

![image](https://user-images.githubusercontent.com/4549002/124410007-e3c51200-dd1f-11eb-9191-bb15a62b89d2.png)


En la consola se sigue viendo con `<` y `>`:

![image](https://user-images.githubusercontent.com/4549002/124409973-d3ad3280-dd1f-11eb-8589-167b575a2934.png)

y la idea es conservar el cambio así para no afectar wollok-language. Después ver cómo afecta eso a wollok-ts.